### PR TITLE
feat: trilha Pentest com Método ensina o ofício sem virar receita de ataque

### DIFF
--- a/backend/scripts/seed-categorias-trilhas.ts
+++ b/backend/scripts/seed-categorias-trilhas.ts
@@ -41,6 +41,7 @@ const MAPA: Record<string, string[]> = {
     "Fundamentos de Cibersegurança": ["Cibersegurança"],
     "Ameaças e Ataques na Prática": ["Cibersegurança"],
     "Defesa e o SOC": ["Cibersegurança"],
+    "Pentest com Método": ["Cibersegurança"],
     "Segurança de Aplicações Web": ["Cibersegurança", "Front-end"],
     "ISC2 Certified in Cybersecurity (CC)": ["Cibersegurança"],
     "Fundamentos de QA": ["QA"],

--- a/backend/scripts/seed-detalhes-trilhas.ts
+++ b/backend/scripts/seed-detalhes-trilhas.ts
@@ -536,6 +536,18 @@ const DETALHES: Record<string, { whatYouLearn: string[]; prerequisites: string[]
             "C++ Moderno para os padrões de projeto",
         ],
     },
+    "Pentest com Método": {
+        whatYouLearn: [
+            "Escopo, autorização e a lei: o que separa profissão de crime",
+            "Reconhecimento, enumeração e análise de vulnerabilidade com critério",
+            "O raciocínio por trás da exploração, incluindo lógica de negócio",
+            "Impacto traduzido para o negócio e o relatório que o cliente lê",
+        ],
+        prerequisites: [
+            "Defesa e o SOC, ou experiência equivalente em segurança",
+            "Redes, Linux e Segurança de Aplicações Web",
+        ],
+    },
     "Defesa e o SOC": {
         whatYouLearn: [
             "Como um centro de operações funciona por dentro, sem romantismo",

--- a/backend/scripts/seed-trilha-pentest-com-metodo.ts
+++ b/backend/scripts/seed-trilha-pentest-com-metodo.ts
@@ -1,0 +1,4856 @@
+// Seed da trilha Pentest com Método, estagio 7 do roadmap de Seguranca
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-pentest-com-metodo.ts
+import { pathToFileURL } from "node:url";
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+export const NOME = "Pentest com Método";
+const CARGA_HORARIA = 20;
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "avancado";
+const DESCRICAO =
+    "Teste de intrusão como profissão e não como receita: autorização, escopo, ética e a lei que separa o trabalho do crime. Você percorre o método completo, do reconhecimento à análise de vulnerabilidade, ao raciocínio de exploração e à pós-exploração que demonstra impacto. Fecha no que o cliente realmente compra, o relatório, e na carreira que se sustenta em confiança.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - O que é um teste de intrusão",
+    aulas: [
+        {
+            titulo: "Teste, varredura e hacking não são a mesma coisa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Três palavras que o mercado embaralha\n\nMuita gente chega em segurança ofensiva imaginando que teste de intrusão é hacking com nota fiscal. Não é bem isso. Hacking descreve uma habilidade: entender um sistema fundo o bastante para fazê-lo agir fora do previsto. Teste de intrusão é um serviço profissional, com escopo definido, prazo, autorização assinada e um entregável. A habilidade técnica é a mesma nos dois casos; o que muda é absolutamente tudo em volta dela.\n\nA confusão mais cara, porém, é outra: a que troca teste de intrusão por varredura de vulnerabilidade. O cliente pede um teste, recebe um relatório de quatrocentas páginas cuspido por uma ferramenta e paga achando que foi testado. Varredura é um programa comparando o que encontrou com uma lista de falhas conhecidas. Teste é uma pessoa decidindo o que aquilo significa naquele ambiente específico.\n\nUm exemplo concreto deixa a diferença nítida. A ferramenta aponta biblioteca desatualizada com falha crítica no servidor de relatórios. Quem testa vai descobrir que esse servidor só é alcançável de dentro da rede administrativa, que a função vulnerável não é chamada em nenhum fluxo real, e que a mesma biblioteca vive num serviço de upload publicado na internet que a ferramenta nem enxergou. O resultado do trabalho humano acaba sendo quase o inverso do relatório automático.",
+                },
+                {
+                    type: "text",
+                    value: "## Perguntas diferentes, preços diferentes\n\nVarredura é ampla, barata, repetível e ótima de rodar toda semana. Ela responde uma pergunta de higiene: o que aqui está desatualizado ou mal configurado. Teste de intrusão é estreito, caro, pontual e responde outra coisa: o que um adversário conseguiria efetivamente fazer com o que existe aqui. As duas são úteis e nenhuma substitui a outra.\n\nExiste ainda um terceiro serviço que costuma ser vendido com o nome errado: a simulação de adversário, ou red team. Ali o objetivo não é achar o máximo de falhas, e sim testar se a organização percebe e reage a um ataque real. O escopo é mais largo, o tempo é maior e o sucesso se mede em detecção, não em quantidade de achados.\n\nSaber diferenciar isso não é preciosismo de vocabulário. É o que te permite dizer para um cliente, na reunião comercial, que aquilo que ele pediu não resolve o problema que ele descreveu. Vender teste para quem precisa de varredura periódica é queimar orçamento; vender varredura para quem precisa de teste é entregar uma falsa sensação de segurança, que é pior do que não entregar nada.",
+                },
+                {
+                    type: "table",
+                    value: '[["Serviço","Pergunta que responde","Quem executa","Cadência típica"],["Varredura de vulnerabilidade","O que está desatualizado ou exposto","Ferramenta com pouca supervisão","Semanal ou mensal"],["Teste de intrusão","O que um adversário faria com isso","Profissional com método","Uma a duas vezes ao ano"],["Simulação de adversário","A empresa percebe e reage a tempo","Equipe dedicada, prazo longo","Anual ou sob demanda"],["Revisão de código e arquitetura","Onde a falha nasce no projeto","Especialista lendo o sistema","A cada mudança relevante"]]',
+                },
+                {
+                    type: "quote",
+                    value: "Ferramenta encontra padrão conhecido. Profissional encontra consequência. O relatório que só lista o que a ferramenta viu poderia ter sido entregue sem você.",
+                },
+                {
+                    type: "text",
+                    value: "## O que sobra para o humano\n\nSe a ferramenta acha padrão conhecido, o valor que você agrega está exatamente onde ela não chega. Três lugares, principalmente. O primeiro é o contexto: a mesma falha vale nota diferente dependendo de onde está, de quem alcança e do que ela protege. O segundo é a lógica de negócio, porque nenhum programa sabe que um usuário não deveria conseguir aprovar o próprio pedido de reembolso.\n\nO terceiro é o encadeamento. Ferramenta lista falhas isoladas em linhas separadas de uma planilha; adversário junta três delas numa história. Uma informação vazada aqui, uma permissão frouxa ali, um serviço interno que confia demais no que vem da rede, e o que era uma lista de itens médios vira um caminho até o banco de dados de clientes.\n\nÉ por isso que este curso trata teste de intrusão como método, e não como coleção de comandos. Comando envelhece em seis meses e está documentado em qualquer manual. O raciocínio de decidir o que olhar, o que ignorar, quando parar e como explicar o impacto para quem paga a conta é o que sustenta uma carreira.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual é a diferença essencial entre teste de intrusão e varredura de vulnerabilidade?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "O teste interpreta o achado no contexto do ambiente",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A varredura confirma o que o teste apenas indica",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O teste percorre mais ativos do que a varredura",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A varredura exige autorização formal e o teste não",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O que distingue uma simulação de adversário de um teste de intrusão comum?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ela mede se a empresa percebe e reage ao ataque",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela busca o maior número possível de falhas técnicas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela dispensa autorização por simular um caso real",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela roda em ambiente de teste, nunca em produção",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um cliente quer saber toda semana se algum servidor ficou desatualizado. O que atende melhor?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Varredura recorrente, que é ampla, barata e repetível",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Teste de intrusão trimestral, com escopo bem reduzido",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Simulação de adversário com equipe dedicada ao alvo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Revisão de código feita a cada entrega de versão nova",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que a lógica de negócio é uma área em que a ferramenta automatizada falha?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ela não sabe qual regra da empresa está sendo burlada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela não consegue autenticar em aplicações modernas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela só analisa serviços que respondem em portas comuns",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela precisa do código-fonte para avaliar qualquer fluxo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um relatório de varredura lista dez achados médios isolados. Onde está o valor que o profissional acrescenta?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Em mostrar que três deles formam um caminho até o dado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Em reordenar os dez achados pela nota que cada um tem",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Em rodar uma segunda ferramenta e comparar as duas listas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Em confirmar que os dez achados de fato existem no alvo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Caixa preta, branca e cinza",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Quanta informação o testador recebe\n\nOs nomes caixa preta, caixa branca e caixa cinza descrevem uma única variável: quanto o cliente conta para você antes de começar. Na caixa preta você recebe pouco mais que um nome de domínio ou uma faixa de endereços. Na caixa branca você recebe código-fonte, diagramas, credenciais de todos os perfis e acesso a quem construiu o sistema. Cinza é o meio termo, e é o formato mais comum na prática.\n\nA escolha não é sobre dificuldade, é sobre o que o cliente quer aprender. Muita gente pede caixa preta por achar que é mais realista, sem perceber o que está comprando: horas do seu contrato gastas descobrindo coisas que o cliente já sabia e poderia ter dito na primeira reunião. Se o teste dura duas semanas e você gasta quatro dias mapeando o que um documento resolveria em vinte minutos, o cliente pagou por reconhecimento em vez de pagar por achados.\n\nExiste um caso legítimo para caixa preta, e vale nomear: quando a pergunta do cliente é justamente sobre o que está exposto sem que ele saiba. Empresa grande, com aquisições recentes e nenhum inventário confiável, tem uma dúvida real sobre a própria superfície. Aí o tempo de descoberta é o produto, não desperdício.",
+                },
+                {
+                    type: "table",
+                    value: '[["Formato","O que você recebe","Melhor para descobrir","Custo escondido"],["Caixa preta","Domínio ou faixa de rede","Superfície exposta desconhecida","Horas gastas redescobrindo o óbvio"],["Caixa cinza","Credenciais e visão geral","Falhas pós-autenticação e de permissão","Risco de assumir que o mapa está certo"],["Caixa branca","Código, diagramas e acessos","Falha de projeto e caminho raro","Volume de material que ninguém lê"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Cobertura contra realismo\n\nA troca fundamental é essa. Quanto mais informação, maior a cobertura no mesmo prazo, porque você passa direto para as partes interessantes. Quanto menos informação, mais parecido com o que um estranho enfrentaria, e menor a chance de você testar tudo o que deveria.\n\nRepare que caixa preta não é mais segura nem mais honesta; ela apenas simula um adversário sem informação privilegiada. Só que muitos adversários reais têm informação privilegiada: ex-funcionário, fornecedor, alguém que comprou credencial vazada. Nesses casos, a caixa cinza é o cenário realista, não o contrário.\n\nA recomendação profissional que vale levar para qualquer proposta é simples: comece perguntando qual ameaça o cliente teme, e deixe a resposta escolher o formato. Se ele teme o estranho na internet, caixa preta ou cinza limitada faz sentido. Se ele teme o funcionário mal-intencionado ou o parceiro comprometido, você precisa das credenciais desde o primeiro dia. E se ele teme uma falha de projeto que ninguém percebeu, nada substitui ler o código.",
+                },
+                {
+                    type: "quote",
+                    value: "Caixa preta não é mais realista, é apenas menos informada. Muitos adversários reais já entram sabendo bastante, e simular isso é escolha de método.",
+                },
+                {
+                    type: "text",
+                    value: "## Um erro que aparece em contrato\n\nO combinado sobre informação tem que estar escrito, com nomes e prazos. É comum o cliente prometer credenciais de três perfis e entregar uma só, na quarta-feira da segunda semana. Quando isso acontece, metade do escopo simplesmente não foi testada, e o relatório precisa dizer isso com todas as letras em vez de silenciar.\n\nOutro erro clássico é a caixa cinza mal definida, em que você recebe um usuário comum e ninguém combina se pode ou não tentar virar administrador. Esse é justamente o teste mais valioso, e é o que mais gera atrito quando não foi acordado antes. Deixe explícito na proposta que escalonar privilégio faz parte, e o que você fará se conseguir.\n\nPor fim, informação recebida também vira responsabilidade. Código-fonte e credenciais do cliente ficam sob sua guarda, e vazar isso encerra uma carreira mais rápido do que qualquer erro técnico. Combine desde o início onde esse material será guardado, por quanto tempo e como será destruído no fim.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que define os formatos de caixa preta, cinza e branca?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "A quantidade de informação entregue ao testador",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O grau de agressividade autorizado no ambiente",
+                            isCorrect: false,
+                        },
+                        { text: "A duração contratada da janela de execução", isCorrect: false },
+                        { text: "O tipo de ativo incluído dentro do escopo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o custo escondido mais comum de um teste em caixa preta?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Gastar horas do contrato redescobrindo o que o cliente sabe",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Depender de ferramenta paga para mapear a rede do cliente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Precisar de uma equipe maior para cobrir o mesmo escopo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Exigir aprovação adicional do jurídico antes de começar",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um cliente teme principalmente o funcionário mal-intencionado. Que formato serve melhor?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Caixa cinza, com credenciais de usuário desde o início",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Caixa preta, para reproduzir o desconhecimento inicial",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Caixa branca, com leitura completa do código do sistema",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Varredura autenticada recorrente em toda a rede interna",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O cliente prometeu credenciais de três perfis e só entregou uma, tarde. O que fazer?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Registrar no relatório o escopo que ficou sem cobertura",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Tentar obter os outros perfis por conta própria no alvo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Encerrar o trabalho e devolver o valor já pago pelo cliente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Assumir que os perfis são equivalentes e seguir o teste",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Em uma caixa branca, o testador recebe código-fonte e credenciais administrativas. Que responsabilidade nasce daí?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Guardar, limitar e destruir o material conforme o acordo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Revisar cada linha entregue antes de iniciar qualquer teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Compartilhar o material com todo o time para acelerar a análise",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Manter cópia arquivada para comprovar o trabalho no futuro",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Escopo, regras de engajamento e autorização",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O documento que te separa do problema\n\nAntes de qualquer pacote sair da sua máquina existe um documento, e ele é a coisa mais importante do trabalho inteiro. A autorização por escrito é o que transforma uma sequência de ações que seriam crime em serviço contratado. Sem ela você não é testador, você é invasor com boa intenção, e boa intenção não é defesa jurídica.\n\nEsse documento tem três partes que valem separar na cabeça. O escopo diz o que pode ser tocado: quais domínios, quais endereços, quais aplicações, quais contas. As regras de engajamento dizem como pode ser tocado: em que horários, com que intensidade, o que é proibido tentar, quem avisar e quando. A autorização diz quem, dentro do cliente, tem poder para assinar isso, e essa parte é a que mais gente erra.\n\nQuem assina precisa ser dono do ativo ou ter delegação formal para autorizar. O gerente de TI que contratou você pode não ter autoridade sobre o sistema hospedado no provedor de nuvem, sobre o subdomínio operado por uma agência de marketing ou sobre a integração de um parceiro. Cada um desses casos exige autorização própria, e descobrir isso no meio do teste é tarde demais.",
+                },
+                {
+                    type: "table",
+                    value: '[["Componente","O que responde","Exemplo de item"],["Escopo","O que pode ser tocado","Domínios, faixas de rede e aplicações listadas"],["Fora de escopo","O que não pode, mesmo se aparecer","Subdomínio de terceiro e sistema de folha"],["Regras de engajamento","Como pode ser tocado","Janela noturna, sem negação de serviço"],["Contatos","Quem avisar e em quanto tempo","Responsável técnico e telefone fora do horário"],["Autorização","Quem tem poder de permitir","Assinatura de quem responde pelo ativo"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Escopo é uma fronteira, não uma sugestão\n\nNa prática, o escopo escorrega sozinho. Você começa em um domínio autorizado, encontra um redirecionamento e três cliques depois está em um servidor que pertence a outra empresa. Isso acontece com frequência, e a única resposta profissional é parar, registrar o achado do redirecionamento e não continuar por ali sem nova autorização.\n\nO caso mais comum hoje envolve nuvem e serviços de terceiros. O sistema do cliente roda em infraestrutura de um provedor, o gateway de pagamento é de outra empresa e o chat de suporte é de uma terceira. Testar esses componentes atinge alvos que o seu contratante não controla, e o contrato dele com o fornecedor normalmente proíbe exatamente isso.\n\nA regra que evita quase todo problema é dupla. Primeiro: na dúvida, está fora. Segundo: qualquer ampliação de escopo vira mensagem escrita, com resposta escrita, antes de qualquer ação. Um e-mail de duas linhas registrando que o cliente autorizou o subdomínio novo às 14h vale mais do que qualquer memória de conversa por telefone.",
+                },
+                {
+                    type: "quote",
+                    value: "Na dúvida, está fora do escopo. Ampliação combinada por telefone e não registrada por escrito não protege ninguém, e o custo dela cai sempre do seu lado.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual é a função da autorização por escrito em um teste de intrusão?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Transformar em serviço o que seria crime sem ela",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Definir o preço final cobrado pelo trabalho técnico",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Garantir que nenhum sistema sofra indisponibilidade",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Provar a competência técnica de quem vai executar",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que as regras de engajamento definem, ao contrário do escopo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Como o alvo pode ser tocado, com horários e limites",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Quais domínios e faixas de rede entram no trabalho",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Quem dentro do cliente responde pelo ativo testado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Qual metodologia pública será seguida na execução",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Durante o teste, um redirecionamento leva a um servidor de outra empresa. O que fazer?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Parar ali, registrar o achado e pedir nova autorização",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Seguir com cautela, já que o caminho partiu do escopo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Testar apenas de forma passiva, sem enviar nenhum pacote",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ignorar o caso e não mencionar nada no relatório final",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que testar o gateway de pagamento usado pelo cliente costuma ser proibido?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O ativo é de terceiro, e o cliente não pode autorizá-lo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O tráfego cifrado impede qualquer análise significativa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A norma de cartões proíbe testes fora do ambiente local",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O volume de requisições derruba o serviço de pagamento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O gerente de TI assinou a autorização, mas o subdomínio testado é operado por uma agência externa. Qual é o problema?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Quem assinou não tem poder sobre aquele ativo específico",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A agência precisaria ser avisada apenas depois do teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O subdomínio deveria constar na seção de fora de escopo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A assinatura do gerente vale, mas exige aviso ao jurídico",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "A lei, o crime e a única diferença",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O que o art. 154-A diz, em português\n\nO Código Penal brasileiro trata invasão de dispositivo informático no artigo 154-A, introduzido pela Lei 12.737 de 2012 e endurecido pela Lei 14.155 de 2021. O núcleo do texto é curto: invadir dispositivo informático alheio, com o fim de obter, adulterar ou destruir dados, ou instalar vulnerabilidade para obter vantagem ilícita. A pena base hoje é de reclusão, e aumenta em várias situações, entre elas quando há obtenção de conteúdo de comunicações privadas ou controle remoto do dispositivo.\n\nLeia de novo a expressão que decide tudo: dispositivo alheio, sem autorização expressa ou tácita do titular. É exatamente isso que separa o seu trabalho do crime descrito ali. Não é a técnica, não é a intenção declarada, não é o fato de você ter parado antes de causar dano. É a autorização de quem é dono.\n\nVale saber também que o assunto não termina no 154-A. Interromper serviço de utilidade pública, fraudar sistema para obter vantagem, violar sigilo e tratar dado pessoal fora das hipóteses legais são condutas com previsão própria. A Lei Geral de Proteção de Dados entra nessa conta na hora em que o teste toca base de clientes, o que acontece com frequência.",
+                },
+                {
+                    type: "table",
+                    value: '[["Situação","Autorizado por escrito","Como a lei tende a ver"],["Varrer a rede do cliente contratante","Sim","Serviço prestado dentro do contrato"],["Varrer a rede do vizinho do cliente","Não","Conduta sem autorização do titular"],["Testar sem contrato e avisar depois","Não","Invasão, ainda que sem dano ou lucro"],["Baixar base de clientes como prova","Além do acordado","Risco de sigilo e de dado pessoal"],["Publicar falha antes do prazo combinado","Não","Quebra de contrato e possível dano"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O testador bem-intencionado que vira réu\n\nO caso mais comum de encrenca não envolve maldade. É a pessoa que encontra uma falha em um site qualquer navegando, resolve confirmar com mais alguns testes, manda um e-mail educado para a empresa e recebe de volta uma notificação jurídica. Do ponto de vista da lei, boa fé pode importar na dosagem, mas não apaga a ausência de autorização.\n\nProgramas de recompensa por falhas mudam esse quadro, porque a política publicada funciona como autorização com limites definidos. Só que ela vale nas condições dela: alvos listados, técnicas permitidas, proibição de acessar dado de terceiros e prazo de divulgação. Sair dessas condições é sair do guarda-chuva, mesmo que o programa exista.\n\nA leitura profissional disso é uma disciplina simples e chata: nada de teste espontâneo em sistema que não te contratou nem publicou política que te convide. Curiosidade é o motor certo da carreira, e o lugar dela é laboratório próprio, ambiente proposital de treino e programa com regra escrita. Fora disso, você está apostando a sua ficha limpa contra um achado que ninguém pediu.",
+                },
+                {
+                    type: "quote",
+                    value: "A técnica é idêntica dos dois lados. O que separa profissão de crime é a assinatura de quem é dono do sistema, e não a sua intenção ao apertar a tecla.",
+                },
+                {
+                    type: "text",
+                    value: "## Ética além do que a lei exige\n\nA lei é o piso, não o teto. Existem coisas legalmente defensáveis que um profissional sério não faz. Ler o e-mail de um funcionário porque a credencial caiu na sua mão durante o teste é uma delas: você provou o acesso no momento em que autenticou, e o conteúdo não acrescenta nada ao relatório além de constrangimento.\n\nO mesmo vale para o volume de dado coletado. Se você achou uma falha que expõe a base de clientes, uma captura mostrando três registros parciais prova o ponto tão bem quanto um despejo completo, e não transforma você em custodiante involuntário de dado sensível de milhares de pessoas. Minimizar a coleta protege o cliente, protege os titulares e protege você.\n\nPor fim, confidencialidade não expira com o contrato. O que você viu no ambiente de um cliente não vira história de palestra, exemplo em treinamento nem post anônimo. Reputação é o ativo real dessa profissão, e ela se constrói em anos e se perde em uma frase mal colocada.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Segundo o art. 154-A, o que caracteriza a invasão de dispositivo informático?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Invadir dispositivo alheio sem autorização do titular",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Causar prejuízo financeiro ao dono do sistema atacado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Utilizar ferramenta ofensiva não licenciada no Brasil",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Divulgar publicamente a falha encontrada no dispositivo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Alguém encontra uma falha navegando, confirma com testes e avisa a empresa. Como a lei tende a ver?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Conduta sem autorização, mesmo com boa fé demonstrada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Conduta permitida, porque houve aviso e nenhum prejuízo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Conduta permitida, já que o site estava aberto ao público",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Conduta irrelevante, pois não houve acesso a dado nenhum",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que um programa de recompensa por falhas oferece ao pesquisador?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Autorização com limites definidos na política publicada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Imunidade ampla para testar qualquer ativo da empresa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Contrato formal de prestação de serviço por escopo fixo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Garantia de pagamento por qualquer falha que for aceita",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Durante o teste você obtém a senha de um funcionário. Qual é a conduta correta quanto ao e-mail dele?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Não abrir: autenticar já provou o acesso que interessava",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Abrir e registrar prints como evidência forte do impacto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Abrir apenas os assuntos, sem ler o corpo das mensagens",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Abrir e avisar o funcionário depois, por transparência",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Ao demonstrar exposição de uma base de clientes, qual coleta de evidência é adequada?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Poucos registros parciais, o suficiente para provar o ponto",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Uma cópia integral da base, guardada em local cifrado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Uma amostra grande, para estimar o tamanho real do vazamento",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Nenhum registro, apenas a descrição textual do que ocorreu",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "As metodologias públicas e o que cada uma dá",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Por que seguir método, e não talento\n\nDois testadores igualmente bons entregando resultados completamente diferentes no mesmo alvo é sinal de que não existe método. Metodologia pública resolve três problemas de uma vez: dá cobertura previsível, permite que outra pessoa repita o trabalho e transforma o relatório em algo comparável entre um ano e outro. Quando o cliente pergunta o que exatamente foi testado, a resposta honesta vem de um método, não da memória.\n\nExiste um efeito colateral que ninguém comenta o suficiente: método também protege você. Se o teste seguiu um guia público e um achado passou despercebido, existe uma defesa razoável sobre o que estava dentro da diligência esperada. Se o teste foi feito por instinto, essa conversa fica bem mais difícil.\n\nO erro do outro extremo é tratar guia como lista de tarefas a marcar. Nenhum documento sabe que o sistema do seu cliente tem uma tela de aprovação de crédito com uma regra bizarra. Método garante o piso da cobertura; o julgamento profissional é o que acrescenta o resto.",
+                },
+                {
+                    type: "table",
+                    value: '[["Referência","Foco principal","Melhor uso no seu trabalho"],["PTES","Processo de ponta a ponta","Estruturar as fases e a conversa inicial"],["NIST SP 800-115","Avaliação técnica de segurança","Vocabulário aceito por auditoria e governo"],["OWASP WSTG","Teste de aplicação web","Checklist de cobertura por categoria"],["OWASP ASVS","Requisitos verificáveis de aplicação","Definir o nível de rigor combinado"],["OSSTMM","Medição de segurança operacional","Métrica de superfície e controles"],["CIS Benchmarks","Configuração segura por produto","Comparar o encontrado com a base esperada"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O que cada uma resolve de verdade\n\nO PTES é o que mais se parece com o desenho do serviço: interação inicial, coleta de informação, modelagem de ameaça, análise de vulnerabilidade, exploração, pós-exploração e relatório. É excelente para organizar a proposta e para explicar ao cliente por que a primeira semana não tem achado nenhum.\n\nO NIST SP 800-115 é mais curto e mais técnico, e tem uma vantagem específica no Brasil: é referência reconhecida quando o interlocutor é auditoria, órgão público ou compliance. Já o WSTG da OWASP é o guia mais útil no dia a dia de quem testa web, porque é organizado por categoria de falha e serve como controle de cobertura enquanto você trabalha.\n\nO ASVS entra em outro momento, o de combinar rigor. Ele lista requisitos verificáveis em três níveis, e definir com o cliente que o teste vai cobrir o nível 2 é uma forma honesta de dizer o que entra e o que não entra. O OSSTMM tem uma proposta diferente, mais de medição e de disciplina operacional, e os Benchmarks do CIS servem de régua concreta para dizer se uma configuração está fora do esperado.",
+                },
+                {
+                    type: "quote",
+                    value: "Metodologia garante o piso da cobertura e a possibilidade de repetir o trabalho. O teto continua sendo o julgamento de quem está olhando para aquele sistema.",
+                },
+                {
+                    type: "text",
+                    value: "## Montando o seu processo\n\nNa prática ninguém segue um guia único do começo ao fim. O arranjo mais comum é usar o PTES como esqueleto do serviço, o WSTG como cobertura dentro da fase de análise quando o alvo é web, o CIS como referência de configuração esperada e o NIST como vocabulário no relatório. Isso não é ecletismo preguiçoso, é usar cada documento para o que ele foi feito.\n\nO que fecha o processo é o registro. Para cada item do guia que você percorreu, fique com a anotação do que foi testado, quando, com que resultado. Esse material vira o apêndice de cobertura do relatório e responde antecipadamente à pergunta mais desconfortável que um cliente faz: e isso aqui, vocês olharam?\n\nUm alerta de mercado para fechar. Guia público é de graça e está a um clique. Se alguém tenta te vender método fechado como se fosse segredo, desconfie: o valor da profissão nunca esteve na lista de itens, e sim em quem sabe interpretar o que aparece quando você percorre a lista.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é o principal benefício de seguir uma metodologia pública?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Cobertura previsível e trabalho que outra pessoa repete",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Garantia de que nenhuma falha relevante vai escapar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Redução direta do tempo total gasto na execução",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Dispensa da autorização formal exigida pelo cliente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve melhor o PTES dentro de um projeto?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Estruturar as fases do serviço e a conversa inicial",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Listar categorias de falha de aplicação web em detalhe",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Definir a configuração esperada de cada produto usado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Calcular a nota de severidade de cada achado do teste",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quando o OWASP WSTG é a referência mais útil?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ao controlar cobertura por categoria em alvo web",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ao negociar o nível de rigor com o cliente final",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ao comparar configuração de sistema operacional",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ao redigir o sumário executivo para a diretoria",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O cliente quer combinar previamente o nível de rigor da verificação da aplicação. Qual referência ajuda mais?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O ASVS, que organiza requisitos em três níveis", isCorrect: true },
+                        { text: "O OSSTMM, que mede a segurança operacional", isCorrect: false },
+                        { text: "O CIS, que descreve configuração por produto", isCorrect: false },
+                        { text: "O PTES, que descreve as fases do serviço", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que registrar item a item o que foi percorrido do guia muda a conversa com o cliente?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Responde de forma objetiva o que foi e não foi testado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Substitui a necessidade de descrever cada achado no texto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Permite cobrar por item percorrido em vez de por hora",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Garante que o reteste encontre exatamente o mesmo cenário",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Antes de tocar em qualquer coisa",
+    aulas: [
+        {
+            titulo: "O que o cliente pediu e o que ele precisa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O pedido raramente é o problema\n\nA primeira reunião de um projeto costuma vir com um pedido pronto: queremos um pentest externo de dois domínios, para a semana que vem. Aceitar isso como especificação é o erro mais caro do serviço inteiro, porque o pedido é a solução que o cliente imaginou, não o problema que ele tem. Sua primeira tarefa é descobrir o problema.\n\nA pergunta que abre tudo é curta: o que fez você procurar isso agora. As respostas se agrupam em poucas famílias. Ou tem um cliente grande exigindo um laudo, ou vem uma auditoria, ou aconteceu um susto recente, ou o time interno desconfia de um sistema específico, ou alguém leu uma notícia e ficou preocupado. Cada uma dessas origens leva a um trabalho diferente, mesmo que o pedido inicial tenha sido idêntico.\n\nUm caso real desse padrão: cliente pede teste externo de dois domínios, e a conversa revela que o medo verdadeiro é um funcionário do time de suporte conseguir ver dados de todos os clientes. Teste externo não responde isso de jeito nenhum. O trabalho certo era um teste autenticado com perfil de suporte, focado em autorização. O pedido estava errado, e concordar com ele teria produzido um relatório inútil e um cliente insatisfeito sem saber por quê.",
+                },
+                {
+                    type: "table",
+                    value: '[["Motivação real","O que o cliente costuma pedir","O que costuma resolver"],["Exigência de cliente grande","Um laudo qualquer, rápido","Escopo alinhado ao que o contrato cobra"],["Auditoria ou norma","Pentest anual genérico","Teste com referência citável no relatório"],["Incidente recente","Teste do sistema afetado","Revisão da causa e do que mais compartilha o risco"],["Desconfiança interna","Teste amplo em tudo","Foco no sistema e no perfil que preocupam"],["Notícia ou medo difuso","O pacote mais completo","Conversa de risco antes de vender execução"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Perguntas que mudam o desenho do trabalho\n\nAlgumas perguntas rendem mais que outras. Qual sistema, se ficasse indisponível por um dia, mais dói. Que dado, se vazasse, viraria manchete ou multa. Quem hoje tem acesso demais e todo mundo sabe. Já aconteceu algo que não virou incidente formal. Essas perguntas fazem o cliente falar de risco, e risco é o idioma em que o escopo deve ser escrito.\n\nOutra pergunta subestimada é sobre o depois. O que vocês vão fazer com o relatório. Se a resposta for arquivar para mostrar ao auditor, o trabalho de fato entregue tem outro formato do que se a resposta for corrigir tudo em noventa dias. Nos dois casos você entrega um serviço honesto, mas fingir que não sabe a diferença atrapalha o resultado.\n\nExiste também a hora de dizer não. Se o cliente nunca fez varredura, não tem inventário e não aplica correção há dois anos, um teste de intrusão vai produzir uma lista previsível e cara de coisas óbvias. O serviço certo ali é higiene básica primeiro. Recusar um projeto porque ele não vai ajudar o cliente é raro, é desconfortável e é exatamente o que constrói reputação.",
+                },
+                {
+                    type: "quote",
+                    value: "O cliente descreve a solução que imaginou. Descobrir qual problema ele estava tentando resolver com aquilo é metade do valor que você entrega no projeto.",
+                },
+                {
+                    type: "text",
+                    value: "## Traduzir a conversa em um documento\n\nO fim dessa etapa não é uma boa impressão, é um texto curto que devolve ao cliente o que você entendeu. Duas ou três frases sobre o problema, os objetivos numerados, o que fica de fora e como será medido o sucesso. Mandar isso por escrito e pedir confirmação elimina quase todo o desalinhamento que apareceria na entrega.\n\nEsse documento também é o que te salva quando alguém do lado do cliente troca de ideia no meio do caminho. Com objetivo escrito, uma mudança vira uma conversa sobre prioridade e prazo. Sem ele, vira você tentando lembrar o que foi combinado numa call de quarenta minutos, três semanas atrás.\n\nRepare que nada disso é burocracia comercial: é engenharia de requisitos aplicada a segurança. Um teste sem objetivo declarado sempre parece ter dado certo, porque não existe critério para dizer o contrário. Um teste com objetivo declarado pode ser avaliado, e é essa possibilidade que torna o trabalho profissional.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Por que o pedido inicial do cliente não deve ser tratado como especificação?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Ele é a solução imaginada, e não o problema real",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele costuma ter escopo maior do que o orçamento",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele raramente inclui a autorização já assinada",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não segue o vocabulário técnico da área", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O cliente teme que alguém do suporte veja dados de todos os clientes, mas pediu teste externo. O que serve melhor?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Teste autenticado com perfil de suporte, focado em autorização",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Teste externo dos dois domínios, ampliado para mais subdomínios",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Varredura autenticada de rede interna com relatório comparativo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Revisão de configuração dos servidores que hospedam o sistema",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual pergunta faz o cliente falar em termos de risco?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Que dado, se vazasse, viraria multa ou manchete",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Quantos servidores existem no ambiente de rede",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Qual ferramenta de segurança já foi contratada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Quem responde pelo time de tecnologia na empresa",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um cliente sem inventário e sem correção há dois anos pede um teste de intrusão. Qual é a recomendação profissional?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Propor higiene básica antes, porque o teste renderia o óbvio",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Aceitar o teste e destacar no relatório todos os itens básicos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Reduzir o escopo a um sistema só e executar o teste mesmo assim",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Fazer o teste em caixa branca, para compensar a falta de mapa",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que deve fechar a etapa de entendimento com o cliente?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Um texto curto com objetivos e exclusões, confirmado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Uma proposta comercial com preço fechado e prazo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Uma reunião com todos os responsáveis técnicos",
+                            isCorrect: false,
+                        },
+                        { text: "Um cronograma detalhado por dia de execução", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Definir escopo sem buraco e sem invasão",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Dois erros opostos, o mesmo prejuízo\n\nEscopo mal feito falha de duas maneiras. Ou fica curto demais, e o teste passa ao lado do caminho que um adversário usaria, ou fica largo demais e inclui coisas que o cliente não pode autorizar. O primeiro erro entrega um relatório que não protege ninguém. O segundo entrega um problema jurídico. Nenhum dos dois se resolve durante a execução.\n\nO buraco mais frequente tem nome: o ativo que o cliente esqueceu que tinha. Ambiente de homologação publicado na internet com dado real de produção. Subdomínio de uma campanha de marketing de dois anos atrás. Servidor antigo respondendo depois da migração. Interface de administração de um equipamento de rede. Nenhum desses aparece na lista que o cliente manda, e todos aparecem no reconhecimento.\n\nO excesso costuma vir de infraestrutura de terceiros. O sistema roda em nuvem, autentica por um provedor de identidade externo, cobra por um gateway de pagamento, atende por um chat de fornecedor e entrega arquivos por uma rede de distribuição. Testar qualquer um desses atinge alvo que o seu contratante não controla, e a autorização dele não vale ali.",
+                },
+                {
+                    type: "table",
+                    value: '[["Item","Entra no escopo","Motivo"],["Domínio principal do cliente","Sim, com autorização","Ativo próprio e sob controle dele"],["Homologação exposta com dado real","Sim, se autorizado","Risco real, mesmo sendo ambiente de teste"],["Provedor de identidade externo","Não","Ativo de terceiro, fora do poder do cliente"],["Gateway de pagamento","Não","Contrato do fornecedor costuma proibir"],["Servidor legado ainda respondendo","Sim, se identificado","Superfície viva que ninguém está vigiando"],["Aplicativo publicado em loja","Depende","Análise local pode valer, backend precisa constar"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Como escrever a lista\n\nEscopo bom se escreve de forma que outra pessoa consiga aplicar sem te perguntar nada. Isso significa endereço de rede em notação exata, domínio com ou sem os subdomínios explicitamente dito, aplicação com a URL de entrada e o ambiente identificado, e usuário de teste com o perfil nomeado. Escrever apenas o nome da empresa é convite para interpretação.\n\nA parte que mais gente esquece é a lista do que fica de fora, e ela deve ser tão explícita quanto a de dentro. Não basta omitir: o documento precisa dizer que o provedor de e-mail, o gateway de pagamento e o domínio da holding estão fora, mesmo que apareçam durante o trabalho. Essa frase evita discussão e evita ação errada por conta própria.\n\nHá ainda um item que quase sempre falta: o procedimento para incluir alguma coisa depois. Você vai encontrar ativos não listados, é praticamente certo. Ter combinado antes que descobertas vão para uma lista, que o cliente responde por escrito e que só então elas entram economiza dias e evita a tentação de decidir sozinho no meio da noite.",
+                },
+                {
+                    type: "quote",
+                    value: "A lista do que fica de fora vale tanto quanto a do que fica dentro. O que não foi escrito como excluído vira decisão sua no pior momento possível.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais são os dois modos opostos de errar o escopo?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Curto demais para proteger, largo demais para autorizar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Técnico demais para o cliente, vago demais para o time",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Caro demais para o projeto, longo demais para o prazo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Rígido demais na execução, frouxo demais no relatório",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um ambiente de homologação está exposto na internet com dado real de produção. Como tratar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Incluir se autorizado, porque o risco ali é real",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Excluir sempre, já que não é ambiente produtivo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Testar sem autorização, pois pertence ao cliente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Apenas reportar a existência, sem tocar no ativo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que o provedor de identidade externo costuma ficar fora do escopo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "É ativo de terceiro, que o cliente não pode autorizar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "É protegido por criptografia que impede qualquer teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "É irrelevante para o risco da aplicação do contratante",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "É coberto por norma que dispensa a avaliação periódica",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza um escopo bem escrito?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Outra pessoa consegue aplicá-lo sem precisar perguntar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele cobre todos os ativos que a empresa possui hoje",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele é curto o bastante para caber em uma única página",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele usa apenas nomes de domínio, sem faixas de rede",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Durante o reconhecimento aparecem quatro ativos não listados que parecem do cliente. Qual é o procedimento certo?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Listar as descobertas e aguardar resposta escrita do cliente",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Testar de forma leve e informar o cliente no relatório final",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Incluir no escopo, pois pertencem ao mesmo domínio autorizado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Descartar do trabalho, já que não constavam na lista inicial",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Janela, comunicação e plano de contingência",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Quando testar é uma decisão de risco\n\nA janela de execução parece detalhe administrativo e não é. Testar em horário comercial em cima de um sistema de vendas significa que qualquer lentidão que você causar acontece com clientes reais dentro. Testar de madrugada significa que ninguém do lado do cliente estará acordado se algo travar. As duas opções têm custo, e a escolha precisa ser consciente e escrita.\n\nA regra prática que funciona: teste passivo e reconhecimento podem correr a qualquer hora, porque o impacto é próximo de zero. Atividades com potencial de carga, como enumeração intensa ou tentativas repetidas de autenticação, ficam melhor em janela combinada, com alguém de plantão do lado do cliente. Ação que pode alterar estado do sistema exige alguém acordado, sempre.\n\nExiste também o calendário do negócio, que quase ninguém pergunta. Fechamento contábil, Black Friday, período de matrícula, virada de folha, campanha de marketing com investimento pesado. Rodar teste em cima dessas datas é criar risco desnecessário para o cliente e desgaste garantido para você quando qualquer coisa der errado, mesmo que a culpa não seja sua.",
+                },
+                {
+                    type: "table",
+                    value: '[["Atividade","Impacto possível","Janela recomendada"],["Coleta em fontes abertas","Nenhum no ambiente do cliente","Qualquer horário"],["Varredura leve de serviços","Ruído em log e alerta","Horário combinado, com aviso"],["Enumeração intensa","Carga e possível lentidão","Fora de pico, com plantão"],["Tentativa de autenticação","Bloqueio de contas legítimas","Janela curta, com limite acordado"],["Ação que altera estado","Falha funcional e perda de dado","Somente com equipe presente"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O canal de comunicação que existe antes de precisar\n\nAntes do primeiro pacote você precisa de nomes, telefones e um canal fora do ambiente testado. Isso último não é paranoia: se o teste derrubar o serviço de mensagens interno ou o e-mail corporativo, o canal combinado sumiu junto. Um grupo em aplicativo de mensagens com os três nomes certos resolve, desde que combinado antes.\n\nO conjunto mínimo de contatos tem três papéis. Quem responde tecnicamente pelo ambiente, para acionar quando algo travar. Quem responde pela decisão, para autorizar mudança de escopo ou parada. E quem responde pela resposta a incidentes, para o caso mais delicado de todos, que é você encontrar sinal de invasão que não é sua.\n\nDo seu lado, combine dois rituais. Um aviso curto de início e fim de cada dia de teste, com o que será feito, para que o time do cliente saiba distinguir você de um ataque real. E um relatório imediato para achado crítico, que não espera o documento final. Falha crítica descoberta na terça não pode ser noticiada no relatório da sexta.",
+                },
+                {
+                    type: "quote",
+                    value: "O canal de comunicação precisa existir fora do ambiente testado. Se o seu único caminho até o cliente é o sistema que você acabou de derrubar, não havia plano.",
+                },
+                {
+                    type: "text",
+                    value: "## Contingência é combinar o que dá errado\n\nTeste de intrusão quebra coisas de vez em quando, mesmo com cuidado. Aplicação antiga cai com requisição malformada, serviço com pouca memória trava com concorrência maior do que o normal, conta de serviço bloqueia depois de tentativas repetidas. Assumir isso antecipadamente e combinar o procedimento é o que separa um incidente administrado de uma crise.\n\nO plano precisa dizer três coisas. Quem eu aviso e em quanto tempo quando percebo que causei impacto. O que eu paro imediatamente enquanto o cliente avalia. E quem decide se o teste continua depois. Definir isso leva dez minutos na reunião inicial e evita horas de confusão no dia em que acontecer.\n\nA outra metade da contingência é o backup do lado do cliente, e essa conversa é dele com ele mesmo, mas você deve levantá-la. Perguntar se existe cópia recente e testada dos sistemas em escopo, antes de começar, é cuidado profissional. Se a resposta for insegura, isso já é um achado de risco, anotado antes de qualquer teste ter começado.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Por que a janela de execução é uma decisão de risco, e não administrativa?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "O horário define quem sofre e quem responde ao impacto",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O horário determina qual metodologia deve ser adotada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O horário influencia o custo por hora cobrado do cliente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O horário altera quais ferramentas conseguem ser usadas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Que tipo de atividade exige alguém da equipe do cliente presente?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Qualquer ação capaz de alterar o estado do sistema",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Toda coleta de informação feita em fontes abertas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A varredura leve de serviços expostos na internet",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A leitura de documentação técnica cedida no início",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que o canal de comunicação deve ficar fora do ambiente testado?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Se o teste derrubar o ambiente, o canal cai junto",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O tráfego interno pode ser lido por quem monitora",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A empresa exige registro externo por conformidade",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O canal interno costuma ter limite de anexo baixo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que fazer ao encontrar uma falha crítica na terça-feira?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Comunicar de imediato, sem esperar o relatório final",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Explorar até o fim antes de comunicar qualquer coisa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Registrar e incluir na entrega prevista para a sexta",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Avisar somente se a exploração for bem-sucedida",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Antes de começar, o cliente não sabe dizer se tem backup recente e testado. Como tratar isso?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Registrar como achado de risco antes mesmo de testar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Suspender o projeto até que o backup seja comprovado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Seguir normalmente, pois backup não é tema do escopo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Reduzir a intensidade e não mencionar no documento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Critérios de parada e comprometimento prévio",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Saber quando parar é técnica\n\nExiste uma fantasia romântica de que o bom testador vai até o fim. Na vida profissional, saber parar vale mais. Critério de parada é uma lista curta, combinada antes, de situações em que você interrompe a atividade e liga para o cliente, independentemente de estar perto de algo interessante.\n\nA lista básica cabe em cinco linhas. Você percebeu que causou indisponibilidade ou degradação. Você alcançou um sistema fora do escopo. Você acessou dado pessoal sensível em volume que não era necessário. Você encontrou sinal de que outra pessoa já esteve ali. E o cliente pediu parada, sem precisar explicar o motivo. Qualquer uma dessas encerra a atividade em curso na hora.\n\nO ponto que causa desconforto é o terceiro. Muita gente, ao encontrar o caminho para uma base de dados, sente o impulso de confirmar tudo, contar registros e explorar o conteúdo. Aquele impulso é justamente o que precisa ser controlado. A prova de que você chegou é o acesso demonstrado com a menor amostra possível, e o resto é curiosidade cobrando um preço que o cliente vai pagar.",
+                },
+                {
+                    type: "table",
+                    value: '[["Gatilho de parada","O que fazer na hora","Quem decide o retorno"],["Indisponibilidade percebida","Parar a atividade e avisar o contato técnico","Responsável técnico do cliente"],["Alvo fora do escopo alcançado","Interromper e registrar o caminho","Quem assina a autorização"],["Dado sensível em volume","Parar a coleta e preservar o mínimo","Responsável pela decisão"],["Sinal de invasor anterior","Congelar a ação e acionar contato de incidente","Resposta a incidentes do cliente"],["Pedido do cliente","Parar imediatamente, sem discutir","O próprio cliente"]]',
+                },
+                {
+                    type: "text",
+                    value: "# Encontrar alguém que chegou antes\n\nAcontece mais do que se imagina: no meio do teste você encontra uma conta administrativa criada há oito meses com nome esquisito, uma tarefa agendada que ninguém reconhece, um arquivo estranho em diretório público. A leitura correta é assumir que pode ser comprometimento real até que se prove o contrário, e mudar completamente de modo de operação.\n\nA sequência aqui é diferente do resto do trabalho. Primeiro, pare de mexer: cada ação sua a partir desse ponto contamina evidência e atrapalha uma investigação futura. Segundo, preserve o que já registrou, com data e hora. Terceiro, acione o contato de resposta a incidentes combinado, por um canal fora do ambiente, porque se houver invasor ativo ele pode estar lendo o e-mail interno. Quarto, escreva o que você fez, minuto a minuto, para separar o seu rastro do dele.\n\nEssa última parte é a que protege você. Sem um registro detalhado das suas ações, a investigação vai encontrar atividade anômala no período do teste e vai levar tempo até distinguir o que foi você do que foi o outro. Testador que documenta mal vira suspeito por acidente, e isso já custou contratos e reputações.",
+                },
+                {
+                    type: "quote",
+                    value: "Ao encontrar sinal de invasor anterior, a sua prioridade deixa de ser o teste. Você vira testemunha, e testemunha preserva a cena em vez de continuar andando nela.",
+                },
+                {
+                    type: "text",
+                    value: "## Continuar ou encerrar\n\nDepois do aviso, a decisão de continuar não é sua. O cliente pode preferir suspender o teste e tratar o incidente com prioridade, e essa costuma ser a escolha certa. Pode também pedir que você continue em uma parte não relacionada do escopo, o que é aceitável desde que registrado por escrito e desde que não interfira na investigação.\n\nO que não é aceitável, em nenhuma hipótese, é você investigar o comprometimento por conta própria por curiosidade ou para engrossar o relatório. Isso não estava contratado, exige competência de outra disciplina e destrói evidência. Ajudar na resposta pode virar um segundo trabalho, com escopo e autorização próprios, e é assim que se faz.\n\nHá ainda uma consequência contratual que vale antecipar na reunião inicial: quem paga pelo tempo perdido se o teste for suspenso por um incidente prévio. Combinar isso antes é conversa madura, e evita que a descoberta correta seja atrasada por medo de prejuízo comercial. Ninguém deveria hesitar em avisar o cliente por causa de uma cláusula que não existe.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é um critério de parada em um teste de intrusão?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Situação combinada antes que interrompe a atividade",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Limite de horas contratadas para cada fase do teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Marco técnico que indica o fim de uma etapa do método",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Regra que define quando o relatório pode ser fechado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Ao encontrar o caminho para uma base de dados de clientes, qual é a conduta correta?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Provar o acesso com a menor amostra possível e parar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Contar os registros para dimensionar bem o impacto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Copiar a estrutura completa das tabelas encontradas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Explorar o conteúdo até identificar o dado mais crítico",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Você encontra uma conta administrativa criada há meses que ninguém reconhece. Qual é o primeiro passo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Parar de mexer, para não contaminar a evidência",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Testar a senha da conta para confirmar o acesso",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Remover a conta e comunicar o cliente em seguida",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Seguir o teste e anotar o caso no relatório final",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que avisar o cliente sobre suspeita de invasão por um canal fora do ambiente?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Um invasor ativo pode estar lendo a comunicação interna",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O canal interno não registra data e hora das mensagens",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A comunicação externa é exigida pela legislação vigente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O time interno demora mais para responder no e-mail",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que registrar minuto a minuto as próprias ações protege o testador nesse cenário?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Separa o rastro dele do rastro do invasor anterior",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Comprova ao cliente o total de horas de fato usadas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Permite refazer o mesmo caminho durante o reteste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Substitui a necessidade de acionar resposta a incidente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Documentar desde o primeiro minuto",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O relatório começa no primeiro dia\n\nQuem deixa para escrever no fim entrega pior e sofre mais. A memória do teste dura pouco: na sexta-feira você não lembra o parâmetro exato que causou o comportamento estranho na terça, nem a sequência de cliques que levou até aquela tela. Anotar durante é a diferença entre um achado reproduzível e uma frase vaga que o cliente não consegue confirmar.\n\nO registro mínimo por ação tem cinco campos: horário com fuso, alvo exato, o que foi feito, o que respondeu e o que você concluiu. Parece excessivo até o dia em que o cliente pergunta se foi você quem gerou aquele pico de erro às 15h42, e você consegue responder com precisão em vez de com jeito.\n\nO segundo motivo é reprodutibilidade. Um achado que o cliente não consegue reproduzir é um achado que não será corrigido, porque o desenvolvedor precisa ver a falha acontecer para ter certeza de que a correção funcionou. Escrever o passo a passo enquanto a coisa está fresca é o que garante isso, e escrever depois quase sempre produz uma versão incompleta.",
+                },
+                {
+                    type: "table",
+                    value: '[["Campo do registro","Exemplo do que anotar","Serve para"],["Horário com fuso","2026-03-11 15:42 BRT","Correlacionar com o log do cliente"],["Alvo exato","Aplicação e caminho acessado","Evitar ambiguidade sobre onde ocorreu"],["Ação executada","Requisição alterada em um parâmetro","Reproduzir o cenário depois"],["Resposta observada","Código de retorno e trecho relevante","Sustentar a conclusão com evidência"],["Conclusão preliminar","Suspeita de falha de autorização","Guiar a validação posterior"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Onde essas anotações vivem\n\nAnotação de teste contém dado do cliente, então o lugar dela não é um bloco de notas na nuvem pessoal. O padrão profissional é um repositório do projeto, cifrado, com acesso restrito à equipe, e com prazo de retenção combinado em contrato. Depois desse prazo, o material é destruído e essa destruição também é registrada.\n\nCapturas de tela merecem cuidado próprio, porque é nelas que dado pessoal entra sem você perceber. Nome completo, CPF, endereço, e-mail de cliente real aparecem no canto da imagem e vão parar no relatório, que será encaminhado internamente para várias pessoas. Ocultar o que não é necessário para o entendimento é parte do trabalho, não etapa opcional de embelezamento.\n\nUm hábito que rende muito é separar dois cadernos: o diário bruto, com tudo o que você fez em ordem cronológica, e a lista de achados, que nasce vazia e vai recebendo entradas conforme a validação confirma. O diário serve à defesa e à correlação; a lista de achados vira o relatório. Misturar os dois é o que produz aquele documento confuso em que ninguém acha o que importa.",
+                },
+                {
+                    type: "quote",
+                    value: "Achado que o cliente não consegue reproduzir não é corrigido. O caminho escrito enquanto a coisa está fresca é o que transforma observação em conserto.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que documentar durante o teste, e não no fim?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "A memória do detalhe some e o achado perde precisão",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O contrato exige entrega parcial ao final de cada dia",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A ferramenta usada apaga o histórico ao ser encerrada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O cliente acompanha as anotações em tempo real sempre",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve registrar horário com fuso em cada ação?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Correlacionar a sua ação com o log do cliente", isCorrect: true },
+                        {
+                            text: "Calcular as horas faturáveis do projeto com exatidão",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ordenar os achados por gravidade no documento final",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Provar que a janela combinada foi de fato respeitada",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde as anotações de um teste devem ficar guardadas?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Em repositório do projeto, cifrado e com acesso restrito",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Em serviço pessoal de notas, desde que com senha forte",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "No ambiente do cliente, para facilitar a consulta dele",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Em arquivo local sem cópia, apagado ao fim de cada dia",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual cuidado específico as capturas de tela exigem?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ocultar dado pessoal que não é necessário ao entendimento",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Salvar sempre em resolução máxima para não perder detalhe",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Incluir a tela inteira, para provar que não houve montagem",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Nomear os arquivos com o nome do cliente e a data exata",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que separar o diário cronológico da lista de achados durante o trabalho?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Um serve de defesa e correlação, o outro vira o relatório",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Um fica com o cliente e o outro permanece com a equipe",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Um exige cifra no repositório e o outro pode ficar aberto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Um é escrito pelo testador e o outro pelo líder do projeto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Reconhecimento",
+    aulas: [
+        {
+            titulo: "Reconhecimento passivo e fontes abertas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Descobrir sem encostar\n\nReconhecimento passivo é tudo que você aprende sobre o alvo sem enviar um único pacote para a infraestrutura dele. Você consulta registros públicos, bases de terceiros, mecanismos de busca, redes sociais e material que a própria empresa publicou. O alvo não vê nada, porque nada saiu na direção dele.\n\nA quantidade de informação disponível surpreende quem nunca fez. Registros de domínio revelam quem administra e desde quando. Certificados emitidos publicamente revelam nomes de subdomínio que ninguém pretendia divulgar, incluindo ambientes internos que acabaram recebendo certificado. Anúncios de vaga descrevem em detalhe a pilha tecnológica: a vaga que pede experiência em uma versão específica de servidor de aplicação acabou de contar o que roda ali dentro.\n\nUm exemplo que se repete em quase todo projeto: o repositório público de um desenvolvedor da empresa, com um arquivo de configuração de exemplo esquecido no histórico de commits. O arquivo não tem senha real, mas tem o nome do servidor interno, o padrão de nomenclatura das contas e a estrutura da API. Nada disso é secreto isoladamente; junto, é um mapa.",
+                },
+                {
+                    type: "table",
+                    value: '[["Fonte aberta","O que costuma entregar","Como isso ajuda o teste"],["Registro de domínio","Responsável, datas e servidores de nome","Confirmar propriedade e achar infraestrutura"],["Transparência de certificados","Subdomínios que receberam certificado","Revelar ambientes não divulgados"],["Anúncios de vaga","Tecnologias e versões em uso","Direcionar hipóteses sobre a pilha"],["Redes profissionais","Nomes, cargos e padrão de e-mail","Modelar o fator humano quando autorizado"],["Repositórios públicos","Configuração de exemplo e histórico","Encontrar nomes internos e estrutura"],["Vazamentos já divulgados","Credenciais antigas de funcionários","Avaliar risco de reuso de senha"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O que passivo não significa\n\nPassivo quer dizer invisível para o alvo, não quer dizer sem limite. Duas confusões aparecem sempre. A primeira é achar que qualquer consulta a serviço de terceiro é passiva: se a base que você consulta faz uma varredura ao vivo no alvo quando você pergunta, você acabou de tocar no cliente por interposta pessoa, e o log dele registra isso.\n\nA segunda é confundir dado público com dado livre de responsabilidade. Credencial de funcionário aparecendo em base de vazamentos antigos é informação pública, e testar essa credencial no ambiente do cliente é ação ativa que precisa estar autorizada. Coletar é uma coisa, usar é outra, e a fronteira entre as duas é o contrato.\n\nDado pessoal merece a mesma disciplina. Você vai encontrar nomes, e-mails, telefones e às vezes coisas constrangedoras sobre gente que não assinou nada. Colete o que serve ao objetivo do teste, guarde no repositório do projeto, não espalhe e destrua ao final. O fato de estar acessível não torna a coleta ilimitada legítima.",
+                },
+                {
+                    type: "quote",
+                    value: "Nada do que você acha em fonte aberta é secreto sozinho. O valor está na montagem: nome, padrão de conta, versão e subdomínio esquecido viram um caminho.",
+                },
+                {
+                    type: "text",
+                    value: "## Organizar antes de avançar\n\nReconhecimento passivo produz volume, e volume sem organização vira ruído. O hábito que funciona é manter três listas desde o início: ativos candidatos, com a origem de cada um; tecnologias suspeitadas, com a evidência que sustenta a suspeita; e pessoas, se e somente se o fator humano estiver no escopo.\n\nCada item precisa carregar a origem, porque você vai precisar dela duas vezes. Uma na hora de pedir confirmação de escopo ao cliente, quando ele perguntar de onde saiu aquele subdomínio que ele jurava não existir. Outra no relatório, na seção de exposição em fontes abertas, que costuma ser das mais valiosas para o cliente justamente por ser a que ele nunca olhou.\n\nO fechamento dessa etapa é uma hipótese, não uma conclusão. Você sai dela com um mapa provável do alvo e uma lista ordenada de coisas a confirmar. Confirmar é o trabalho da fase ativa, e é ali que o rastro começa a existir, com todas as consequências que a próxima aula descreve.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que caracteriza o reconhecimento passivo?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Aprender sobre o alvo sem enviar pacote a ele", isCorrect: true },
+                        {
+                            text: "Consultar apenas serviços gratuitos e públicos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Coletar dados sem precisar de autorização prévia",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Usar somente ferramentas que não deixam registro",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que a transparência de certificados costuma revelar em um alvo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Subdomínios que a empresa não pretendia divulgar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Versões exatas das bibliotecas usadas no servidor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Contas administrativas criadas para o ambiente web",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Endereços internos das estações usadas pelo time",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que um anúncio de vaga é uma fonte relevante no reconhecimento?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ele descreve as tecnologias e versões usadas na empresa",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele revela as senhas padrão adotadas pelo time interno",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele lista os endereços de rede publicados pela empresa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele expõe os contratos de segurança já firmados por ela",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Você consulta um serviço de terceiro que faz varredura ao vivo no alvo. Isso ainda é passivo?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Não, porque o alvo recebe tráfego por interposta pessoa",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Sim, porque a consulta partiu de um serviço de terceiro",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sim, desde que o serviço consultado seja público e pago",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Não, porque toda consulta externa exige autorização escrita",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Credenciais antigas de funcionários aparecem em uma base pública de vazamentos. O que muda quanto ao uso?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Coletar é passivo, mas testá-las exige autorização",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Coletar e testar são livres, pois o dado já é público",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Nem coletar é permitido, porque envolve dado pessoal",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Testar é livre desde que a senha já tenha sido trocada",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Reconhecimento ativo e o rastro que ele deixa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A partir daqui, o cliente enxerga você\n\nReconhecimento ativo é o momento em que você começa a enviar tráfego para a infraestrutura do alvo para confirmar o que a fase passiva sugeriu. Descobrir quais endereços respondem, quais portas estão abertas, que serviço atende cada uma, se aquele subdomínio realmente existe. Tudo isso gera registro do lado de lá.\n\nEsse rastro é uma parte legítima e útil do serviço. Uma varredura de portas contra um ambiente monitorado deveria gerar alerta, e se não gerar, isso é um achado por si só: o cliente comprou monitoramento e não está enxergando o que deveria. Muitos relatórios trazem uma seção justamente sobre o que foi detectado e em quanto tempo, comparando com o que o cliente acreditava ter.\n\nExiste uma decisão de método aqui que precisa estar combinada. Teste anunciado significa que o time de defesa sabe da janela e não vai tratar como incidente real. Teste não anunciado significa que a reação também está sendo avaliada. Os dois são válidos, e o desastre é o meio termo acidental, em que ninguém combinou nada e o time de resposta passa a madrugada tratando você como invasor.",
+                },
+                {
+                    type: "table",
+                    value: '[["Atividade ativa","Rastro típico no cliente","Leitura defensiva esperada"],["Descoberta de hosts","Sequência de conexões curtas em faixa","Alerta de varredura de rede"],["Varredura de portas","Muitas portas tocadas por uma origem","Alerta com origem única identificada"],["Consulta de versão de serviço","Conexão que abre e encerra rápido","Registro no log do próprio serviço"],["Descoberta de conteúdo web","Volume alto de respostas de erro","Alerta no servidor web ou no filtro"],["Teste de autenticação","Tentativas seguidas na mesma conta","Bloqueio de conta e alerta de acesso"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Intensidade é escolha profissional\n\nA velocidade com que você faz reconhecimento ativo não é detalhe de configuração, é decisão com consequência. Ir rápido termina antes e ajuda no prazo, mas gera carga, pode derrubar serviço frágil e enche o log do cliente de milhares de linhas. Ir devagar é gentil com o ambiente e custa tempo de contrato.\n\nA regra que orienta bem: a intensidade deve ser proporcional à fragilidade do que está do outro lado. Servidor web moderno atrás de balanceador aguenta bem mais do que um equipamento industrial antigo ou um sistema legado com pouca memória. Quando você não sabe o que tem do outro lado, comece devagar e aumente conforme entende, nunca o contrário.\n\nUm cuidado específico merece destaque porque causa incidente com frequência: tentativas repetidas de autenticação bloqueiam contas legítimas. Uma sequência de tentativas contra uma lista de usuários reais pode travar dezenas de pessoas no início do expediente. Isso precisa estar combinado, com limite acordado, e em muitos contratos simplesmente não é autorizado.",
+                },
+                {
+                    type: "quote",
+                    value: "Se a sua varredura passou sem gerar nenhum alerta, você achou algo antes de achar qualquer vulnerabilidade: o monitoramento do cliente não está olhando ali.",
+                },
+                {
+                    type: "text",
+                    value: "## O que registrar enquanto você faz barulho\n\nComo essa fase gera evento do lado do cliente, o seu registro precisa ser bom o bastante para responder por ele. Origem usada, horário de início e fim de cada varredura, faixa alvo e intensidade escolhida. Com isso, quando o time de segurança perguntar sobre uma atividade às 3h12, a resposta é imediata e verificável.\n\nEsse mesmo registro serve para uma conversa que rende muito no fechamento: comparar a sua linha do tempo com a do cliente. Você varreu às 22h, o alerta apareceu às 22h04, o analista abriu às 9h da manhã seguinte e ninguém ligou para o contato de emergência. Essa comparação vale mais para o cliente do que a lista de portas abertas que você encontrou.\n\nPor fim, mantenha a origem do seu tráfego estável e informada ao cliente. Trocar de endereço no meio, usar caminhos diferentes ou mascarar a procedência transforma o trabalho em algo indistinguível de um ataque e mistura o seu rastro com o de terceiros. Testador profissional é identificável dentro do próprio teste.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que marca a passagem para o reconhecimento ativo?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Passar a enviar tráfego para a infraestrutura do alvo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Começar a usar ferramentas automatizadas no projeto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Obter a autorização assinada por quem responde pelo ativo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Confirmar a lista de subdomínios em fontes abertas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Sua varredura não gerou nenhum alerta no ambiente monitorado do cliente. Como ler isso?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Como um achado: o monitoramento não cobre aquele ponto",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Como sinal de que a varredura foi discreta o bastante",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Como confirmação de que a rede está bem segmentada ali",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Como indício de que as portas testadas estavam fechadas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual é o risco do meio termo entre teste anunciado e não anunciado?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O time de resposta trata você como incidente real",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O relatório perde a seção sobre tempo de detecção",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A varredura fica lenta demais para o prazo previsto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O cliente deixa de registrar os eventos gerados ali",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como escolher a intensidade do reconhecimento ativo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Proporcional à fragilidade do que está do outro lado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Sempre no máximo, para caber no prazo contratado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sempre no mínimo, para nunca aparecer nos registros",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Conforme a quantidade de alvos listados no escopo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que manter a origem do tráfego estável e informada ao cliente?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Para separar o seu rastro do de qualquer outro tráfego",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Para reduzir a chance de bloqueio pelo filtro de borda",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Para acelerar a varredura ao evitar novas conexões",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Para cumprir exigência das metodologias públicas usadas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Enumeração de serviços e o valor da versão",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Porta aberta é pergunta, não resposta\n\nSaber que a porta 8080 responde é quase nada. Enumeração é o trabalho de transformar isso em informação útil: que serviço atende ali, que produto o implementa, que versão está rodando, como ele está configurado e para que ele serve dentro do negócio do cliente. Cada uma dessas camadas muda o que vem depois.\n\nA versão é a peça que mais gente valoriza e a que mais engana. Ela vale porque conecta o serviço com falhas conhecidas e publicadas, e permite priorizar. Ela engana porque o que o serviço diz sobre si mesmo não é necessariamente verdade: a distribuição pode aplicar correções sem mudar o número exibido, o administrador pode ter alterado o texto de apresentação e um intermediário pode reescrever tudo.\n\nO exemplo que mais aparece na prática vem justamente das distribuições que aplicam correções de segurança mantendo o número original. O serviço se apresenta com uma versão listada como vulnerável, a ferramenta acusa uma falha crítica, e a correção já estava aplicada há meses. Reportar isso sem validar é o jeito mais rápido de perder credibilidade com o time técnico do cliente.",
+                },
+                {
+                    type: "table",
+                    value: '[["Camada da enumeração","Pergunta que responde","Por que importa"],["Porta responde","Existe algo escutando ali","Confirma superfície viva"],["Protocolo e serviço","Que tipo de serviço atende","Define o que faz sentido testar"],["Produto e versão","Qual implementação e qual release","Liga o serviço a falhas conhecidas"],["Configuração","Como o serviço está ajustado","Revela exposição sem falha de código"],["Função no negócio","Para que aquilo serve na empresa","Define a severidade real do achado"]]',
+                },
+                {
+                    type: "text",
+                    value: "## A camada que rende mais: configuração\n\nQuem está começando persegue versão vulnerável. Quem já rodou alguns projetos sabe que a maior parte dos achados relevantes vem de configuração, não de falha de software. Serviço administrativo publicado onde não devia, credencial padrão nunca trocada, permissão excessiva em compartilhamento, listagem de diretório ligada, mensagem de erro detalhada mostrando caminho interno.\n\nEssas coisas não têm identificador em catálogo, não aparecem com nota pronta e frequentemente passam batido em varredura automatizada, porque exigem entender que aquilo não deveria estar assim naquele contexto. É exatamente onde o julgamento profissional aparece, e é por isso que os Benchmarks do CIS são uma referência útil: eles descrevem a configuração esperada de produtos comuns e viram régua de comparação.\n\nA última camada da tabela é a que separa relatório bom de relatório burocrático. Duas instâncias do mesmo serviço, com a mesma versão e a mesma configuração, podem ter severidades completamente diferentes: uma serve à ferramenta interna de reserva de sala, a outra intermedia o faturamento. Descobrir para que serve exige perguntar ao cliente, e essa pergunta é parte do método.",
+                },
+                {
+                    type: "quote",
+                    value: "O serviço diz a versão que quiser. Achado baseado só no que o banner declara é palpite documentado, e o time técnico do cliente vai perceber isso na primeira leitura.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a enumeração acrescenta a uma porta aberta encontrada?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Serviço, produto, versão, configuração e função",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Nota de severidade calculada de forma automática",
+                            isCorrect: false,
+                        },
+                        { text: "Autorização formal para testar aquele serviço", isCorrect: false },
+                        {
+                            text: "Confirmação de que existe uma falha conhecida ali",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que a versão exibida por um serviço pode enganar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Distribuições corrigem falhas sem mudar o número",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O serviço só exibe versão quando está desatualizado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A versão muda a cada reinicialização do processo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ferramentas de varredura ignoram esse campo do banner",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "De onde vem a maior parte dos achados relevantes na prática?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "De configuração inadequada, e não de falha de software",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "De versões antigas com falhas críticas já publicadas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "De protocolos obsoletos ainda habilitados no servidor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "De portas incomuns abertas sem necessidade aparente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que servem os Benchmarks do CIS nessa etapa?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Comparar a configuração encontrada com a esperada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Atribuir nota de severidade a cada achado do teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Listar as falhas conhecidas de cada versão de produto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Definir a ordem das fases dentro da metodologia usada",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Dois serviços idênticos, mesma versão e configuração, recebem severidades diferentes. O que justifica?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A função que cada um cumpre dentro do negócio", isCorrect: true },
+                        {
+                            text: "A quantidade de usuários conectados em cada um",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O tempo desde a última atualização aplicada neles",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A ferramenta que encontrou cada um dos serviços",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Mapeamento de superfície web",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma aplicação é maior do que a tela mostra\n\nMapear uma aplicação web é responder o que existe ali dentro antes de decidir o que testar. Isso vai muito além de navegar pelo menu. Existem rotas que não aparecem em link nenhum, endpoints de API usados só pelo aplicativo móvel, painéis administrativos em caminhos previsíveis, versões antigas de arquivos deixadas para trás e funcionalidades acessíveis apenas por perfis específicos.\n\nO caminho profissional começa pelo que a aplicação entrega de graça. O código que roda no navegador contém a lista de rotas do sistema, os nomes dos campos que a API espera e às vezes verificações de permissão que só existem ali. Documentação de API publicada, arquivos de configuração de rota e mapas de origem esquecidos em produção contam a estrutura inteira sem nenhuma adivinhação.\n\nDepois vem a diferença entre a superfície anônima e a autenticada. Uma aplicação típica mostra três telas para quem não entrou e cento e vinte para quem entrou. Se o contrato deu credenciais, a maior parte do trabalho está do lado autenticado, e testar cada perfil separadamente é o que revela as falhas de autorização que o módulo cinco vai tratar em detalhe.",
+                },
+                {
+                    type: "table",
+                    value: '[["O que mapear","Onde costuma estar","O que revela"],["Rotas do front-end","Código carregado no navegador","Telas que o menu não mostra"],["Endpoints de API","Documentação publicada e chamadas do app","Superfície maior que a interface web"],["Painéis administrativos","Caminhos previsíveis por produto","Acesso privilegiado exposto"],["Arquivos residuais","Cópias antigas e backups deixados","Código, credencial ou dado antigo"],["Superfície por perfil","Cada credencial recebida","Diferença de permissão entre papéis"],["Fluxos de estado","Cadastro, compra, aprovação","Onde a lógica de negócio pode falhar"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Mapear é anotar, não é atacar\n\nO erro que mais atrasa iniciante é começar a testar cada coisa assim que encontra. Você acha um formulário, para tudo, gasta quarenta minutos ali, e no fim da semana descobre que existiam trinta telas mais interessantes que nunca foram vistas. Mapeamento é uma fase de inventário: registre, classifique e siga em frente.\n\nUma classificação simples resolve bem. Para cada ponto encontrado, anote se ele recebe entrada do usuário, se exige autenticação, se lida com dinheiro ou dado pessoal e se parece feito sob medida ou vem de biblioteca conhecida. Com essas quatro marcas você consegue ordenar por onde começar quando a fase de análise chegar, e essa ordem é o que faz o tempo do contrato render.\n\nVale também mapear o que está na frente da aplicação. Filtro de aplicação, balanceador, rede de distribuição, gateway de API. Isso muda como o alvo responde e explica comportamento estranho: um bloqueio pode ser do filtro e não da aplicação, e concluir errado sobre isso leva a achado incorreto no relatório. Saber quem responde é parte de mapear.",
+                },
+                {
+                    type: "quote",
+                    value: "Mapear é fazer inventário, não é atacar. Quem começa a testar o primeiro formulário que encontra termina a semana sem ter visto metade da aplicação.",
+                },
+                {
+                    type: "text",
+                    value: "## O sinal de que o mapa está bom\n\nVocê sabe que mapeou bem quando consegue desenhar a aplicação em uma página: os grandes blocos de função, quais exigem qual perfil, por onde entra dado do usuário e onde estão os fluxos que envolvem valor. Se você não consegue explicar isso em voz alta, ainda está navegando, não mapeando.\n\nEsse desenho tem um segundo uso, que aparece no fim do projeto: ele vira a seção de cobertura do relatório. Poder dizer que a aplicação tem seis áreas funcionais, que quatro foram testadas em profundidade e duas ficaram limitadas por falta de credencial é uma informação honesta e rara. Cliente acostumado a relatório genérico percebe a diferença imediatamente.\n\nPor fim, mapa envelhece. Aplicação em desenvolvimento ativo muda durante o próprio teste, e não é incomum uma implantação nova aparecer no meio da semana. Anotar a data de cada observação e conferir os pontos críticos perto do fim evita reportar como existente algo que já foi removido, ou deixar de ver o que entrou depois.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Por que o código que roda no navegador é uma fonte valiosa no mapeamento?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Ele costuma listar rotas e campos que a API espera",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele contém as senhas usadas na integração com a API",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele indica a versão exata do servidor de aplicação",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele guarda os registros de acesso dos outros usuários",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual erro mais atrasa quem está mapeando uma aplicação?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Começar a testar o primeiro formulário que encontra",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Registrar pontos demais e classificar cada um deles",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Usar as credenciais recebidas antes de mapear tudo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Consultar a documentação de API publicada pelo cliente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Que marcas ajudam a ordenar os pontos encontrados para a fase seguinte?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Recebe entrada, exige login, envolve valor, é sob medida",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Tempo de resposta, tamanho da página, idioma e formato",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Data de criação, autor do código, ambiente e servidor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Frequência de uso, número de campos e tipo de método",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que importa saber o que está na frente da aplicação?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Um bloqueio pode vir do filtro e não da aplicação",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O balanceador define a severidade final dos achados",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A rede de distribuição impede qualquer teste válido",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O gateway de API costuma expor o código-fonte real",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma implantação nova ocorre no meio da semana de teste. Qual é o cuidado necessário?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Datar cada observação e reconferir os pontos críticos",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Reiniciar o mapeamento completo da aplicação do zero",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Interromper o teste até o ambiente ficar congelado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Manter o mapa antigo, que representa a versão testada",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O fator humano, se estiver no escopo",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A regra vem antes da técnica\n\nEngenharia social é a parte mais delicada do ofício, e por isso a regra vem primeiro: só se faz se estiver explicitamente autorizado, com escopo próprio, e nunca porque pareceu conveniente no meio do teste. Simular um golpe contra um funcionário que não sabe de nada tem consequência humana e trabalhista, e isso não é detalhe.\n\nA autorização para o fator humano precisa responder perguntas que a autorização técnica não responde. Quem pode ser abordado e quem está fora, sem exceção. Que pretextos são aceitáveis e quais são proibidos, porque usar demissão, doença ou emergência familiar como isca é eficaz e é inaceitável. O que acontece com quem cair: o combinado profissional é que resultado individual não é usado para punir ninguém.\n\nExiste ainda a questão de para que serve o exercício. Se o objetivo é medir a taxa de clique, o desenho é um. Se o objetivo é testar se o processo de resposta funciona quando alguém denuncia, o desenho é outro, e o número de cliques até importa menos que o tempo até a primeira denúncia. Definir isso antes é o que impede que o resultado vire estatística sem uso.",
+                },
+                {
+                    type: "table",
+                    value: '[["Item do acordo","Pergunta que responde","Risco de deixar em aberto"],["Lista de alvos","Quem pode ser abordado","Atingir quem tinha razão para ficar fora"],["Pretextos proibidos","Que temas não podem ser usados","Dano emocional e crise interna"],["Uso do resultado","Como o dado individual será tratado","Funcionário punido por um teste"],["Objetivo do exercício","O que se quer medir de fato","Número sem leitura nem melhoria"],["Encerramento","Como e quando informar as pessoas","Desconfiança prolongada no time"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Por que funciona, e o que isso ensina\n\nEngenharia social não explora burrice, explora funcionamento normal do ser humano. Autoridade percebida, urgência criada, reciprocidade, medo de errar diante do chefe e a simples vontade de ser útil. O funcionário que abre o anexo urgente do diretor financeiro está fazendo o que a empresa espera dele o dia inteiro: responder rápido a quem manda.\n\nEssa leitura muda a recomendação que vai no relatório. Se o problema fosse falta de atenção, treinar mais resolveria. Como o problema é um processo que depende da atenção de uma pessoa cansada às 17h de sexta, a recomendação certa é reduzir a dependência: exigir confirmação por outro canal para pagamento, tirar do e-mail a capacidade de disparar transferência, adotar segundo fator resistente a phishing.\n\nO indicador que mais importa também muda com isso. Taxa de clique é fácil de medir e diz pouco, porque em qualquer amostra grande alguém clica. Quantas pessoas denunciaram, em quanto tempo a primeira denúncia chegou e o que a empresa fez depois dela dizem muito mais sobre a saúde do processo. Uma empresa em que dez por cento clica e a primeira denúncia chega em três minutos está em situação melhor do que outra em que só dois por cento clica e ninguém avisa ninguém.",
+                },
+                {
+                    type: "quote",
+                    value: "Taxa de clique mede pouco. Quanto tempo até a primeira denúncia e o que a empresa fez com ela dizem se existe processo ou apenas treinamento anual.",
+                },
+                {
+                    type: "text",
+                    value: "## Escrever isso no relatório sem expor ninguém\n\nA seção de fator humano precisa ser escrita com cuidado especial. Nada de nome de funcionário, nada de captura de tela com a pessoa identificada, nada de ranking de setores. O dado individual serve para a operação do exercício e morre ali; o que vai para o documento é agregado, com foco no processo que falhou.\n\nA recomendação também muda de endereço. Em vez de sugerir que o time seja mais cuidadoso, aponte o controle que teria evitado o dano mesmo com a pessoa tendo caído. Segundo fator resistente a phishing, aprovação de pagamento com dupla verificação, restrição de execução de anexo, canal fácil e rápido de denúncia. Controle não depende de humor, treinamento depende.\n\nE existe a etapa que muita gente pula: contar às pessoas depois. Fazer isso com tom de aprendizado, sem constrangimento e explicando o que a empresa vai mudar transforma o exercício em algo que fortalece a relação com segurança. Fazer isso mal, ou não fazer, deixa um time desconfiado que passa a esconder erro, o que é bem pior do que o clique original.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é a regra básica para incluir engenharia social em um teste?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Só executar se houver autorização explícita e escopo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Executar sempre que houver acesso ao e-mail corporativo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Executar apenas depois de esgotados os testes técnicos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Executar com aviso prévio a todos os alvos escolhidos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que certos pretextos devem ser proibidos por acordo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Temas como demissão e doença causam dano real", isCorrect: true },
+                        {
+                            text: "Eles reduzem a taxa de clique obtida no exercício",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Eles dificultam a medição do tempo de denúncia",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Eles exigem infraestrutura mais cara para simular",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que engenharia social funciona mesmo com gente atenta?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ela explora comportamentos que a empresa incentiva",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela usa falhas técnicas do cliente de e-mail usado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela depende de listas de senhas vazadas previamente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela atinge apenas quem nunca recebeu treinamento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual indicador diz mais sobre a saúde do processo do que a taxa de clique?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O tempo até a primeira denúncia e o que veio depois",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O percentual de mensagens bloqueadas pelo filtro",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A quantidade de setores atingidos pelo exercício",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O número de pessoas que abriram sem clicar no link",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Como escrever a seção de fator humano no relatório sem expor pessoas?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Dados agregados e foco no processo que deixou passar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Lista de setores com o desempenho relativo de cada um",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Capturas com identificação, mantidas em anexo restrito",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Resultado individual entregue apenas ao gestor direto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Análise de vulnerabilidade",
+    aulas: [
+        {
+            titulo: "O que a varredura pega e o que ela inventa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma ferramenta muito boa em uma coisa só\n\nUm scanner de vulnerabilidade faz três coisas bem: percorre muito mais alvos do que você conseguiria manualmente, compara o que encontra com uma base enorme de falhas publicadas e nunca se distrai. Em um ambiente com oitocentos servidores, ele encontra em duas horas o que uma pessoa levaria semanas para catalogar. Isso é valor real e não deve ser desprezado por esnobismo.\n\nO problema é que ele responde por semelhança, e semelhança não é confirmação. A maior parte dos scanners identifica falha pela versão declarada, por um padrão na resposta ou por um comportamento parecido com o de um sistema vulnerável. Nenhuma dessas evidências prova que a falha existe naquele alvo, e é daí que nasce o falso positivo.\n\nO caso clássico já apareceu no módulo anterior e vale fechar aqui. Distribuições estáveis aplicam correções mantendo o número de versão original. O scanner vê o número, consulta a base, encontra uma falha crítica de dois anos atrás e reporta com nota alta. O time do cliente checa em cinco minutos, descobre que a correção está aplicada desde então, e a partir daí passa a ler o seu relatório inteiro com desconfiança.",
+                },
+                {
+                    type: "table",
+                    value: '[["O scanner é bom em","O scanner é ruim em","Consequência prática"],["Cobrir muitos alvos rápido","Entender o contexto do ativo","Nota alta em sistema irrelevante"],["Reconhecer falha publicada","Achar falha de lógica de negócio","Cliente acha que está coberto e não está"],["Comparar configuração conhecida","Perceber correção sem troca de versão","Falso positivo por número declarado"],["Repetir sem cansar","Encadear achados numa história","Lista longa sem caminho de ataque"],["Registrar tudo que viu","Decidir o que importa","Relatório que ninguém consegue priorizar"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Falso positivo e falso negativo\n\nOs dois erros existem e machucam de formas diferentes. Falso positivo é a ferramenta apontando algo que não é: custa tempo do cliente, gera retrabalho e corrói a sua credibilidade. Falso negativo é a ferramenta não apontando algo que é: custa segurança de verdade, e o pior é que ninguém percebe que aconteceu.\n\nQuem está começando teme o falso positivo e ignora o falso negativo, porque o primeiro é visível e o segundo é invisível. Profissionalmente, o segundo é mais grave. Um relatório limpo produzido só por ferramenta gera uma sensação de segurança que não corresponde a nada: falha de autorização, falha de lógica e encadeamento simplesmente não estão na base de comparação que o scanner usa.\n\nExiste ainda uma categoria que confunde e merece nome próprio: o achado verdadeiro e irrelevante. A ferramenta está tecnicamente certa, aquela cifra antiga está habilitada mesmo, e ninguém no mundo real conseguiria explorar isso naquele contexto. Reportar isso com nota média enche o relatório de ruído e afoga os três achados que de fato mereciam a atenção do cliente.",
+                },
+                {
+                    type: "quote",
+                    value: "Scanner responde por semelhança, e semelhança não é confirmação. O que ele entrega é uma lista de hipóteses, e a validação delas é o trabalho pelo qual você é pago.",
+                },
+                {
+                    type: "text",
+                    value: "## Usando a ferramenta como profissional\n\nO uso maduro é tratar a saída do scanner como fila de trabalho, nunca como resultado. Você recebe uma lista de hipóteses ordenada por prioridade aparente, e o seu trabalho é confirmar, descartar ou reclassificar cada uma delas antes que qualquer coisa entre no relatório.\n\nDuas decisões de configuração valem antecipar. A primeira é varredura autenticada contra não autenticada: com credencial, a ferramenta consulta versões de dentro e erra muito menos, mas exige combinar acesso com o cliente. A segunda é a intensidade, que já apareceu no reconhecimento e vale de novo: perfil agressivo em ambiente frágil derruba serviço, e a decisão precisa ser consciente.\n\nPor fim, o relatório nunca deve reproduzir a saída bruta com outro logotipo. Se o cliente pode rodar a mesma ferramenta sozinho e obter o mesmo texto, ele não precisava de você. O que ele compra é a lista curta do que foi confirmado, com o contexto dele aplicado e com o que aquilo permite fazer na prática.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Como um scanner normalmente identifica uma vulnerabilidade?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Por semelhança com padrões e versões conhecidas",
+                            isCorrect: true,
+                        },
+                        { text: "Por exploração controlada da falha encontrada", isCorrect: false },
+                        { text: "Por leitura do código-fonte da aplicação alvo", isCorrect: false },
+                        {
+                            text: "Por comparação com o inventário do próprio cliente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que o falso negativo é considerado mais grave que o falso positivo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ele passa despercebido e deixa risco real sem tratamento",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele gera retrabalho maior para o time técnico do cliente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele aparece com nota alta e distorce a priorização feita",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele impede que a ferramenta conclua a varredura iniciada",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que é um achado verdadeiro e irrelevante?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "A ferramenta acertou, mas ninguém exploraria aquilo ali",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A ferramenta errou, mas o item parece plausível no alvo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A falha existe, mas já foi corrigida durante o teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A falha existe apenas no ambiente de homologação",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual é a vantagem de uma varredura autenticada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Consultar versões de dentro e errar bem menos", isCorrect: true },
+                        { text: "Reduzir a carga aplicada sobre o alvo testado", isCorrect: false },
+                        {
+                            text: "Dispensar a validação manual dos achados gerados",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Encontrar falhas de lógica que escapam de fora",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um relatório reproduz a saída bruta do scanner com outro logotipo. Qual é o problema central?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O cliente obteria o mesmo resultado sem contratar ninguém",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A ferramenta usada pode ter licença que proíbe a revenda",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O formato de saída dificulta a leitura pela área técnica",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "As notas atribuídas não seguem o padrão de mercado usado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Validação manual: achado real ou ruído",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Confirmar é responder três perguntas\n\nValidar um achado não é repetir a varredura com outra ferramenta. É responder, com evidência, três perguntas em ordem. A condição descrita existe mesmo neste alvo. Ela é alcançável por quem o modelo de ameaça considera. E alguém consegue tirar proveito dela no estado em que o sistema está. Um não em qualquer uma dessas encerra o achado ou muda a classificação dele.\n\nA primeira pergunta é técnica e costuma ser rápida. A segunda é onde metade dos achados de scanner morre: a condição existe, mas o serviço só responde na rede administrativa, atrás de autenticação, ou depende de um perfil que ninguém tem. A terceira é a que distingue vulnerabilidade de curiosidade, e é onde entra o raciocínio de exploração que o próximo módulo trata.\n\nUm exemplo concreto para amarrar. O scanner reporta divulgação de informação em um endpoint de saúde da aplicação, que devolve nome do servidor, versão da estrutura e tempo de atividade. Existe: sim. Alcançável de fora: sim, sem autenticação. Alguém tira proveito: aqui a resposta honesta é que isso ajuda um atacante a escolher o que tentar, mas sozinho não abre nada. O achado é real, é de severidade baixa e a descrição precisa dizer exatamente isso.",
+                },
+                {
+                    type: "table",
+                    value: '[["Pergunta da validação","Como responder","Resultado do não"],["A condição existe aqui","Observar o comportamento direto no alvo","Falso positivo, descartar com nota"],["É alcançável pelo ator","Verificar rede, autenticação e perfil","Severidade cai muito ou vira informativo"],["Alguém tira proveito","Raciocinar o caminho até um impacto","Vira observação e não achado explorável"],["Reproduz de novo","Repetir o passo a passo do zero","Precisa de mais detalhe antes de reportar"],["Afeta o negócio","Perguntar para que serve o sistema","Ajusta a severidade final do achado"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Reproduzir é parte de validar\n\nUm achado só está validado quando você consegue chegar nele de novo, do começo, seguindo o próprio registro. Isso parece óbvio e é violado o tempo todo: a pessoa viu o comportamento estranho uma vez, anotou pela metade e não consegue mais reproduzir. Reportar assim cria um problema garantido no reteste, quando o cliente pedir a confirmação de que corrigiu.\n\nHá um detalhe que sempre atrapalha e vale ficar atento: estado. Muitas aplicações se comportam de forma diferente conforme a sessão, o cache, o registro criado antes ou a ordem dos passos. Aquele comportamento que só acontece com um usuário criado naquele minuto é reprodutível, mas exige que você registre a condição inicial, não apenas a requisição final.\n\nQuando algo não reproduz, a conduta profissional não é omitir nem inflar. Registre como observação, descreva o que foi visto e o que já foi tentado, e deixe explícito que não houve reprodução. Cliente maduro respeita isso, e às vezes o time interno consegue reproduzir com o conhecimento que só ele tem do sistema.",
+                },
+                {
+                    type: "quote",
+                    value: "Achado que você não consegue refazer não é achado, é lembrança. Ou vira observação declarada como não reproduzida, ou não entra na lista de jeito nenhum.",
+                },
+                {
+                    type: "text",
+                    value: "## O custo de errar para os dois lados\n\nInflar achado é a tentação comercial mais comum da área. Relatório com trinta itens parece mais trabalho do que relatório com seis. Só que o cliente que corrige tudo gasta semanas de equipe em coisas que não mudavam o risco dele, e o cliente que percebe o exagero nunca mais te chama. Volume não é qualidade e o mercado técnico enxerga isso rápido.\n\nO erro oposto também existe e é mais sutil: descartar cedo demais porque a exploração pareceu difícil naquele momento. Difícil para você numa tarde não significa impossível para quem tem uma semana e um objetivo. Quando a exploração não sai, o registro correto descreve a condição encontrada, explica por que não foi possível confirmar e deixa a avaliação de risco explícita, em vez de fingir que não existe.\n\nO equilíbrio vem de uma pergunta que você deve fazer para cada item antes de escrever: se eu fosse o gerente de tecnologia deste cliente, o que eu faria com esta linha na segunda-feira. Se a resposta for nada, aquele item provavelmente não merece nota nem espaço, e o lugar dele é um apêndice informativo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais são as três perguntas centrais da validação de um achado?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Existe aqui, é alcançável e alguém tira proveito",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "É conhecida, tem correção e afeta muitos sistemas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Foi detectada, tem nota alta e consta no catálogo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "É recente, é pública e já foi vista em incidentes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um serviço vulnerável só responde na rede administrativa interna. O que isso muda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A alcançabilidade cai e a severidade acompanha", isCorrect: true },
+                        {
+                            text: "O achado vira falso positivo e deve ser removido",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A severidade se mantém, pois a falha existe mesmo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O item sai do escopo por estar na rede interna",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quando um achado é considerado validado?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Quando você chega nele de novo pelo próprio registro",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Quando uma segunda ferramenta aponta o mesmo item",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Quando o cliente confirma que o sistema é antigo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Quando existe uma falha publicada com aquele nome",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Você viu um comportamento suspeito uma vez e não consegue reproduzir. Qual é a conduta?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Registrar como observação e declarar a não reprodução",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Reportar como achado normal, com a nota que merecia",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Descartar por completo e não mencionar no relatório",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Reportar como crítico, já que o efeito era relevante",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Que pergunta ajuda a decidir se um item merece espaço no relatório?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O que o gerente de tecnologia faria com isso na segunda",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Quantas ferramentas diferentes apontaram o mesmo achado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Se o item aparece com nota alta na base pública usada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Se a falha foi publicada nos últimos doze meses ou não",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Severidade com contexto, não a nota do scanner",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A nota vem sem conhecer o cliente\n\nA nota que acompanha uma falha publicada é calculada sobre características da falha em si: como ela é alcançada, que privilégio exige, se depende de interação e o que ela afeta em confidencialidade, integridade e disponibilidade. Essa é a pontuação base, e ela é útil justamente por ser independente de ambiente. O problema é usá-la como se fosse a resposta final.\n\nA mesma falha, com a mesma nota base, significa coisas completamente diferentes em dois lugares. Execução remota de código com nota 9.8 num servidor exposto que atende clientes é uma emergência. A mesma falha numa máquina de laboratório desligada da rede é um item de manutenção. Aceitar 9.8 nos dois casos é entregar uma priorização que o cliente vai ter que refazer sozinho, e refazer sem os dados que você tinha.\n\nOs padrões de pontuação preveem isso. Existem métricas ambientais e temporais justamente para ajustar a base ao contexto e à maturidade da exploração. Quase ninguém usa, porque dá trabalho e porque a nota base já vem pronta na tela. Usar é uma das formas mais visíveis de mostrar que existe profissional por trás do relatório.",
+                },
+                {
+                    type: "table",
+                    value: '[["Fator de contexto","Pergunta que ele responde","Efeito típico na nota"],["Exposição","Quem alcança o sistema, e de onde","Sobe se público, cai se restrito"],["Valor do dado","O que aquilo guarda ou movimenta","Sobe muito com dado pessoal ou dinheiro"],["Compensações","Que controle já limita o abuso","Cai quando há barreira real no caminho"],["Facilidade real","Quanto esforço a exploração exige aqui","Cai se depende de condição improvável"],["Efeito em cadeia","O que mais cai junto se isso cair","Sobe quando é ponto de passagem"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Severidade não é a mesma coisa que prioridade\n\nVale separar dois conceitos que quase todo relatório mistura. Severidade descreve o quanto aquilo é ruim se acontecer. Prioridade descreve a ordem em que o cliente deve tratar, e ela mistura severidade com esforço de correção, dependência entre itens e risco da própria mudança.\n\nUm exemplo que aparece sempre: dois achados altos, um resolvido mudando uma linha de configuração em dez minutos e outro que exige trocar a versão de um componente central, com janela de indisponibilidade e regressão para testar. Mesmo com severidade igual, a ordem óbvia começa pelo de dez minutos, e dizer isso no relatório é serviço, não opinião gratuita.\n\nA armadilha aqui é o cliente que só olha a cor. Relatório com dezoito itens vermelhos leva o time a corrigir por cor, de cima para baixo, e a gastar o primeiro mês no que é caro e difícil. Uma seção curta de plano recomendado, com o que fazer nesta semana, neste mês e neste trimestre, muda completamente o aproveitamento do trabalho.",
+                },
+                {
+                    type: "quote",
+                    value: "A nota base descreve a falha; ela nunca conheceu o seu cliente. Entregar a nota do catálogo sem ajuste é terceirizar para o cliente a parte mais difícil do trabalho.",
+                },
+                {
+                    type: "text",
+                    value: "## Como sustentar uma reclassificação\n\nSubir ou descer a nota de um achado exige justificativa escrita, e é isso que separa avaliação de arbitrariedade. O padrão que funciona é uma frase curta com três partes: a nota base, o fator de contexto que mudou e a nota final. Por exemplo, base alta, sistema alcançável apenas por rede administrativa com acesso restrito, severidade final média.\n\nEsse formato tem três vantagens. O cliente entende por que a sua tabela não bate com a do catálogo. O time técnico consegue discordar de forma produtiva, apontando um fator que você não conhecia. E o auditor que ler o documento daqui a um ano entende o raciocínio sem ter que confiar na sua reputação.\n\nDescer nota exige mais cuidado do que subir, porque reduzir severidade tem efeito prático de tirar o item da fila. Se a redução se apoia numa compensação que existe hoje, diga isso: a nota é média enquanto o acesso continuar restrito, e volta a ser alta se a exposição mudar. Essa condicional é honesta e evita que uma decisão de arquitetura futura reabra o risco sem ninguém perceber.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a pontuação base de uma falha publicada descreve?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Características da falha, sem considerar o ambiente",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O risco real que ela representa naquele cliente",
+                            isCorrect: false,
+                        },
+                        { text: "A ordem em que a correção deve ser executada", isCorrect: false },
+                        {
+                            text: "A probabilidade de a falha ser explorada no ano",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "A mesma falha crítica está num servidor público e numa máquina isolada de laboratório. O que fazer?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ajustar a severidade de cada uma pelo contexto do ativo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Manter a nota do catálogo nos dois, por consistência",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Reportar apenas a do servidor público, que é o que importa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Somar as duas ocorrências e reportar como um item único",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual é a diferença entre severidade e prioridade?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Severidade é o quanto dói, prioridade é a ordem de tratar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Severidade é dada pelo scanner, prioridade vem do cliente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Severidade vale para técnicos, prioridade vale para gestão",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Severidade é fixa no catálogo, prioridade muda a cada ano",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Dois achados altos: um corrigido em dez minutos, outro exige troca de componente central. O que recomendar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Começar pelo de dez minutos e explicar isso no plano",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Começar pelo mais complexo, que traz o risco maior",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Tratar os dois em paralelo, já que a nota é a mesma",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Deixar a ordem a critério do time técnico do cliente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como sustentar por escrito a redução da severidade de um achado?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Nota base, fator de contexto que mudou e nota final",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Referência ao catálogo público e à versão do produto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Opinião do time técnico do cliente registrada em ata",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Comparação com a nota obtida no teste do ano passado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Encadeamento: duas médias viram uma crítica",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Adversário não pensa em lista\n\nFerramenta entrega achados como linhas independentes de uma planilha. Adversário lê a mesma planilha procurando uma história: começo, meio e fim. Encadeamento é justamente isso, usar o resultado de uma falha como pré-requisito da próxima até chegar a um impacto que nenhuma delas produzia sozinha.\n\nUm exemplo montado a partir de peças que aparecem em quase todo projeto. Achado um: uma página de erro devolve o caminho completo de instalação e o nome do usuário do serviço, severidade baixa. Achado dois: um endpoint aceita um identificador de outro usuário sem verificar permissão, severidade média por expor dados. Achado três: existe um painel administrativo acessível na internet, protegido só por senha, severidade média.\n\nSeparados, esses três itens rendem uma tarde de correção e nenhuma emoção. Juntos, contam outra coisa: o primeiro entrega o padrão de nome das contas, o segundo permite enumerar quem é administrador e coletar dados de perfil, e o terceiro é a porta onde essa informação vira acesso privilegiado. O impacto final não é médio; é acesso administrativo ao sistema.",
+                },
+                {
+                    type: "table",
+                    value: '[["Elo","O que ele entrega sozinho","O que ele habilita no encadeamento"],["Divulgação de informação","Detalhe técnico aparentemente inofensivo","Padrão de nomes e alvo do próximo passo"],["Falha de autorização","Acesso a dado de outro usuário","Identificação de contas privilegiadas"],["Painel exposto","Superfície administrativa alcançável","Ponto onde o dado obtido vira acesso"],["Credencial reaproveitada","Entrada em um sistema secundário","Passagem para o ambiente principal"],["Excesso de permissão","Acesso amplo depois de autenticado","Alcance total a partir de um acesso pequeno"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Como procurar cadeia de propósito\n\nEncadeamento não aparece sozinho; ele é procurado. O hábito que funciona é, ao terminar a validação, olhar a lista inteira de uma vez e fazer três perguntas. Que achado me dá informação que outro achado precisava. Que achado me dá acesso que outro achado exigia. E que dois achados, juntos, atravessam uma fronteira que separadamente nenhum atravessa.\n\nEssa terceira pergunta é a mais valiosa, porque fronteira é o que o cliente acredita ter. Fronteira entre anônimo e autenticado, entre usuário comum e administrador, entre um cliente e outro no mesmo sistema, entre a rede de escritório e a de produção. Um relatório que mostra uma fronteira atravessada muda a conversa dentro da empresa de um jeito que nenhuma lista de itens médios muda.\n\nO cuidado é não inventar cadeia teórica para inflar severidade. A regra honesta: cadeia demonstrada, com evidência de cada elo, vira um achado de alta severidade com o caminho descrito. Cadeia possível mas não demonstrada é escrita como cenário, com essa palavra, e sustenta uma recomendação sem fingir que foi executada.",
+                },
+                {
+                    type: "quote",
+                    value: "Fronteira atravessada é o que muda a conversa dentro da empresa. Três itens médios numa lista viram um pedido de orçamento quando alguém desenha o caminho entre eles.",
+                },
+                {
+                    type: "text",
+                    value: "## Como reportar uma cadeia\n\nCadeia bem escrita tem estrutura própria no relatório: um achado principal, com o impacto final e o caminho completo, e os elos referenciados como itens individuais com as respectivas correções. Isso resolve um problema prático, porque quem corrige normalmente não é uma pessoa só: o elo um é do time de infraestrutura, o dois é do time da aplicação e o três é de quem cuida de acesso.\n\nUm detalhe que faz diferença na correção: diga qual elo, se quebrado, derruba a cadeia mais barato. Nem sempre é o mais grave. Às vezes fechar o painel administrativo para a internet custa uma regra de firewall e elimina o impacto final naquele mesmo dia, enquanto a correção da falha de autorização exige mudança de código e uma sprint inteira.\n\nE deixe explícito que os elos continuam sendo problemas depois que a cadeia for quebrada. É comum o cliente corrigir o item mais fácil, ver a cadeia interrompida e arquivar o resto. Escrever que cada elo permanece explorável em outra combinação evita esse encerramento prematuro, que é uma das formas mais comuns de o risco voltar meses depois.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é encadeamento na análise de vulnerabilidade?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Usar o resultado de uma falha como entrada da seguinte",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Agrupar achados semelhantes em um único item do texto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Rodar ferramentas em sequência sobre o mesmo alvo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Somar as notas de falhas encontradas no mesmo servidor",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual pergunta ajuda mais a encontrar uma cadeia dentro da lista de achados?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Que dois achados juntos atravessam uma fronteira",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Que achado tem a maior nota atribuída no catálogo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Que achado apareceu em mais de um alvo testado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Que achado exige o menor esforço para ser corrigido",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Você imagina uma cadeia plausível, mas não conseguiu demonstrar todos os elos. Como reportar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Como cenário declarado, sem apresentar como executado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Como achado crítico, já que o impacto final é grave",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Como observação genérica, sem descrever o caminho",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sem citar, para não sugerir algo que não foi provado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que indicar qual elo é mais barato de quebrar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Permite eliminar o impacto final sem esperar meses",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Reduz o número de achados listados no documento",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Evita que o cliente precise reter a equipe atual",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Garante que a cadeia não volte a existir no futuro",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O cliente quebra a cadeia corrigindo o elo mais fácil e arquiva os demais. Qual é o risco?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Os elos restantes seguem exploráveis em outra combinação",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A correção aplicada tende a ser revertida na atualização",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O reteste não conseguirá confirmar a correção realizada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A severidade original do achado principal deixa de valer",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O que deliberadamente não se testa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Restrição não é covardia\n\nTodo teste sério tem uma lista de coisas que não serão feitas, e essa lista é resultado de julgamento, não de falta de habilidade. O critério que orienta é simples de enunciar e difícil de aplicar: o teste não pode causar ao cliente um dano maior do que o conhecimento que ele produz.\n\nA restrição mais universal é negação de serviço. Derrubar um sistema prova pouco, porque quase todo sistema cai sob carga suficiente, e custa muito, porque o prejuízo é imediato e real. O que faz sentido é apontar as condições que tornariam o alvo vulnerável, como ausência de limite de requisição, operação custosa exposta sem controle ou dependência única sem redundância, e recomendar um teste de carga controlado com o time de infraestrutura, que é outro serviço.\n\nA segunda restrição comum é produção sensível. Sistema de saúde em uso, sistema industrial controlando equipamento físico, plataforma financeira em horário de liquidação. Nesses casos o certo é testar em ambiente equivalente, e se ele não existir ou não for fiel, isso vira um achado por si só, porque significa que o cliente não tem onde validar mudança nenhuma antes de aplicar.",
+                },
+                {
+                    type: "table",
+                    value: '[["Não se testa","Por quê","O que fazer em vez disso"],["Negação de serviço","Dano imediato e prova pouca coisa","Apontar condições e propor teste de carga"],["Sistema em uso crítico","Risco a pessoas e a operação real","Testar em ambiente equivalente e informar"],["Dado de produção em volume","Exposição desnecessária de terceiros","Amostra mínima suficiente para provar"],["Ação destrutiva em base","Perda irreversível para o cliente","Demonstrar acesso de escrita sem destruir"],["Alvo de terceiro","Falta autorização de quem é dono","Registrar a dependência como risco"],["Técnica de evasão","Foge do objetivo do teste contratado","Medir detecção com o time avisado"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O limite dentro da própria exploração\n\nMesmo dentro do que é permitido existe um limite de intensidade que o profissional respeita. Demonstrar que você consegue escrever em uma base não exige apagar nada: criar um registro identificável e removível prova o mesmo ponto e é reversível. Demonstrar acesso a arquivos não exige baixar tudo. Demonstrar controle de uma conta não exige usar essa conta para agir no lugar da pessoa.\n\nA pergunta que resolve quase todos os casos duvidosos é qual é a menor ação que prova o ponto. Ela é útil porque força a separar a prova do impulso. E ela tem um efeito colateral bom: prova mínima costuma ser mais fácil de descrever no relatório, mais fácil de reproduzir no reteste e mais fácil de defender se alguém questionar depois.\n\nQuando a dúvida persiste, o caminho é perguntar. Uma mensagem descrevendo o que você pretende fazer, qual o risco e o que espera obter, com resposta escrita do cliente, resolve o caso e vira registro. Testadores experientes perguntam mais do que iniciantes imaginam, e isso não é insegurança técnica; é gestão de risco de quem já viu o que acontece quando ninguém perguntou.",
+                },
+                {
+                    type: "quote",
+                    value: "A pergunta que resolve o caso duvidoso é qual a menor ação que prova o ponto. Ela separa a demonstração necessária do impulso de ver até onde dá para ir.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual critério orienta a lista do que não será testado?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "O dano possível não pode superar o que se aprende",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A dificuldade técnica de executar aquele tipo de teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O tempo disponível dentro da janela combinada antes",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A existência de ferramenta adequada para aquele alvo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que negação de serviço fica fora da maioria dos testes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Causa prejuízo imediato e prova muito pouco", isCorrect: true },
+                        {
+                            text: "Exige ferramentas que poucos profissionais têm",
+                            isCorrect: false,
+                        },
+                        { text: "Só funciona contra sistemas antigos e frágeis", isCorrect: false },
+                        { text: "É proibida por lei em qualquer circunstância", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O sistema é crítico e não existe ambiente equivalente para testar. Como tratar isso?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Registrar a ausência do ambiente como achado de risco",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Testar em produção com intensidade bastante reduzida",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Excluir o sistema do escopo e não citar no relatório",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Adiar o teste até que o cliente construa o ambiente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como demonstrar acesso de escrita em uma base sem causar dano?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Criar um registro identificável e depois removê-lo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Alterar um campo pouco usado e restaurar o valor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Apagar um registro de teste criado pelo próprio time",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Exportar a estrutura das tabelas como comprovação",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Diante de uma ação de risco não prevista nas regras de engajamento, qual é a conduta madura?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Descrever a ação ao cliente e agir após resposta escrita",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Executar com cuidado e relatar o ocorrido logo em seguida",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Evitar a ação e não registrar o caso no documento final",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Consultar apenas o contato técnico por telefone e seguir",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - Raciocínio de exploração",
+    aulas: [
+        {
+            titulo: "O que significa explorar uma falha",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Toda exploração é uma suposição quebrada\n\nExplorar não é digitar um comando mágico. É encontrar uma suposição que quem construiu o sistema fez sem perceber e demonstrar que ela não se sustenta. O desenvolvedor supôs que o identificador viria do próprio usuário. Supôs que o arquivo enviado seria uma imagem porque o nome termina em jpg. Supôs que só a tela dele chamaria aquele endpoint. Exploração é o ato de mostrar que a realidade não obedece a essas suposições.\n\nEsse enquadramento muda o que você procura. Em vez de correr atrás de uma lista de truques, você lê o sistema perguntando: o que este código precisa acreditar para funcionar. A resposta aponta direto para os lugares frágeis, mesmo em tecnologias que você nunca viu antes, e é por isso que profissionais experientes se adaptam rápido a pilhas desconhecidas.\n\nUm exemplo simples deixa isso concreto. Uma tela de exportação de relatório recebe o intervalo de datas e o identificador da empresa, e o sistema monta o arquivo. A suposição embutida é que o identificador enviado é sempre o da empresa do usuário logado, porque a tela só oferece essa opção. A pergunta profissional não é qual ferramenta usar, e sim: se esse número for outro, quem verifica.",
+                },
+                {
+                    type: "table",
+                    value: '[["Suposição do desenvolvedor","Onde ela costuma aparecer","O que a quebra revela"],["O valor vem da minha tela","Campos e parâmetros do formulário","Falha de autorização direta"],["O tipo do arquivo é o da extensão","Envio de anexo e importação","Aceitação de conteúdo inesperado"],["Só quem tem link vai chegar aqui","Rotas administrativas escondidas","Controle de acesso ausente"],["A ordem dos passos será respeitada","Fluxos de compra e aprovação","Falha de lógica de negócio"],["O dado que salvei já foi validado","Confiança em conteúdo do banco","Reintrodução de entrada não tratada"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Por que entender vale mais que executar\n\nExiste uma diferença enorme entre a pessoa que roda um módulo pronto e a que entende o que está acontecendo. A primeira funciona enquanto o alvo é padrão e trava no primeiro ambiente diferente. A segunda consegue explicar por que não funcionou, o que precisaria ser verdade para funcionar, e transformar até a tentativa frustrada em informação útil para o relatório.\n\nO teste que não deu certo também informa. Se a injeção não passou, saber se foi por causa de uma consulta parametrizada, de um filtro na frente da aplicação ou de uma validação de tipo muda completamente a recomendação. No primeiro caso o sistema está bem construído naquele ponto. No segundo, existe uma proteção externa cobrindo um código que continua frágil, e isso merece um parágrafo no relatório.\n\nEste curso trata exploração nesse nível de propósito. Você vai sair sabendo raciocinar sobre classes de falha, reconhecer o que cada uma significa e explicar impacto. Comando pronto envelhece em meses, muda a cada versão e está documentado em qualquer manual de ferramenta; o modelo mental que decide onde olhar é o que continua valendo daqui a dez anos.",
+                },
+                {
+                    type: "quote",
+                    value: "Explorar é mostrar que uma suposição do desenvolvedor não se sustenta. Quem procura truque fica preso ao alvo padrão; quem procura suposição se adapta a qualquer pilha.",
+                },
+                {
+                    type: "text",
+                    value: "## Do achado ao impacto\n\nA pergunta que fecha qualquer exploração é o que isso permite fazer. Não o nome da classe de falha, não a nota do catálogo: o que uma pessoa mal-intencionada consegue, concretamente, a partir daqui. Ler dado de outro cliente. Aprovar o próprio pedido. Assumir a conta de um administrador. Sair da aplicação e chegar ao servidor.\n\nEssa tradução é o que o cliente compra, e ela precisa ser feita por você, porque ninguém do lado de lá tem os elementos para fazer. O desenvolvedor entende o código, o gestor entende o negócio, e só quem testou viu a ponte entre os dois. Um relatório que para no nome técnico da falha deixa essa ponte para o leitor construir, e ele não vai construir.\n\nExiste um limite honesto nessa tradução, e ele também deve aparecer. Se você demonstrou leitura de dado de outro cliente em ambiente de homologação com dado sintético, diga isso, e diga que o mesmo caminho existe em produção com dado real. Precisão sobre o que foi demonstrado e o que foi inferido é o que mantém a confiança do time técnico ao longo do documento.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que significa explorar uma falha, no sentido conceitual?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Mostrar que uma suposição do sistema não se sustenta",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Executar um módulo pronto contra o serviço vulnerável",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Confirmar que a versão instalada consta em um catálogo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Obter acesso administrativo ao servidor que hospeda",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma tela de exportação envia o identificador da empresa junto ao pedido. Qual é a pergunta profissional?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Se esse número mudar, quem verifica do lado do servidor",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Se o campo aceita valores maiores do que os previstos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Se a exportação gera carga suficiente para derrubar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Se o formato do arquivo revela informação do sistema",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que uma tentativa de exploração frustrada ainda informa?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O motivo da falha muda qual recomendação é correta",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela comprova que o sistema não tem aquela categoria",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela permite calcular a nota base do achado no catálogo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela reduz o tempo necessário para o reteste posterior",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "A injeção não passou por causa de um filtro na frente, e não do código. O que reportar?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Que existe proteção externa sobre um código ainda frágil",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Que a aplicação está corretamente protegida naquele ponto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Que nada deve ser reportado, pois o teste não teve êxito",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Que o filtro deve ser removido para permitir novo teste",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual pergunta fecha a análise de qualquer exploração?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O que isso permite fazer, de forma concreta", isCorrect: true },
+                        { text: "Qual é o nome técnico daquela classe de falha", isCorrect: false },
+                        { text: "Qual nota o catálogo público atribui ao caso", isCorrect: false },
+                        { text: "Quantos sistemas do cliente têm o mesmo item", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Autenticação e sessão",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Provar quem é, e continuar sendo\n\nAutenticação responde uma pergunta única: você é mesmo quem diz ser. Sessão responde outra, que vem logo depois e é esquecida com frequência: por quanto tempo o sistema continua acreditando nisso, e o que acontece quando essa crença deveria acabar. As falhas mais graves dessa área costumam estar na segunda pergunta, não na primeira.\n\nDo lado da autenticação, os problemas se agrupam em poucas famílias. Ausência de proteção contra tentativa repetida, o que permite testar senhas em volume. Mensagens que revelam se o usuário existe, transformando a tela de login num verificador de contas válidas. Recuperação de senha frágil, que costuma ser a porta mais fraca do sistema inteiro porque recebe menos atenção que o login. Segundo fator implementado de forma que dá para pular, por exemplo quando o passo é validado apenas na interface.\n\nDo lado da sessão, a pergunta central é o que representa o identificador que o navegador guarda. Se ele é previsível, alguém adivinha. Se não muda depois do login, um valor obtido antes continua valendo depois. Se não expira nem no encerramento, o encerramento é decorativo. Se viaja por canal sem cifra, quem está no caminho copia. Cada um desses é um problema independente, e sistemas reais costumam ter mais de um.",
+                },
+                {
+                    type: "table",
+                    value: '[["Ponto de falha","Pergunta que revela","Impacto quando falha"],["Tentativa repetida","O sistema limita e detecta o volume","Teste de senhas em massa nas contas"],["Mensagem de erro","O login diz se o usuário existe","Lista de contas válidas para o próximo passo"],["Recuperação de senha","O caminho de reset é tão forte quanto o login","Tomada de conta sem saber a senha"],["Segundo fator","O passo é validado no servidor","Etapa adicional que dá para contornar"],["Identificador de sessão","Ele muda ao autenticar e ao sair","Sessão reutilizada por outra pessoa"],["Transporte","O identificador viaja sempre cifrado","Cópia da sessão por quem está no caminho"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Onde mora o achado mais valioso\n\nNa prática, o achado que mais impressiona nessa área quase nunca é a senha fraca. É a inconsistência entre caminhos. O sistema exige segundo fator na tela web, mas a API móvel autentica só com usuário e senha. O login corporativo passa por provedor central, mas existe uma tela antiga de acesso local que ninguém desativou. A conta bloqueia depois de tentativas na interface, e não bloqueia no endpoint que o aplicativo usa.\n\nEsse padrão aparece porque autenticação costuma ser implementada mais de uma vez ao longo dos anos, por times diferentes, e a proteção é adicionada onde alguém lembrou. Procurar por caminhos alternativos de autenticação é uma das buscas com melhor retorno em qualquer teste de aplicação.\n\nO segundo lugar em valor é a recuperação de senha. Ela existe para funcionar quando o usuário não sabe a senha, o que significa que ela é um mecanismo de acesso construído para contornar o mecanismo de acesso principal. Perguntas cujas respostas estão em rede social, código de verificação curto sem limite de tentativa, link que não expira, token previsível: cada um desses transforma o processo de ajuda numa entrada.",
+                },
+                {
+                    type: "quote",
+                    value: "A recuperação de senha é um caminho oficial para entrar sem saber a senha. Ela merece o mesmo rigor do login, e quase nunca recebe metade dessa atenção.",
+                },
+                {
+                    type: "text",
+                    value: "## Escrever esse achado com precisão\n\nRelatar falha de autenticação exige cuidado extra com o que foi demonstrado. Dizer que a aplicação permite ataque de senha em massa sem mostrar que a proteção está de fato ausente naquele caminho específico é o tipo de afirmação que o time técnico derruba na primeira reunião, porque quase sempre existe alguma proteção em algum lugar.\n\nDescreva o caminho exato, o comportamento observado e o limite do teste. Por exemplo: no endpoint usado pelo aplicativo móvel, tentativas seguidas com a mesma conta não resultaram em bloqueio nem em atraso, verificado com uma conta de teste fornecida pelo cliente e interrompido após um número pequeno de tentativas. Essa frase é verificável, é reproduzível e não expõe usuário real.\n\nE nunca teste em massa contra contas reais. Além do risco de bloquear pessoas no meio do expediente, isso cria um evento de segurança verdadeiro no ambiente do cliente e mistura o seu rastro com qualquer atividade maliciosa que estivesse acontecendo em paralelo. Conta de teste, volume pequeno, limite acordado.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual pergunta a gestão de sessão responde, ao contrário da autenticação?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Por quanto tempo o sistema continua acreditando em você",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Se as credenciais informadas conferem com o cadastro",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Quais permissões o usuário tem dentro da aplicação",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "De onde o acesso partiu e em que dispositivo ocorreu",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que uma mensagem de erro que diferencia usuário inexistente é um problema?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Transforma o login em verificador de contas válidas",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Permite deduzir a política de senha adotada no sistema",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Expõe a versão da estrutura usada para autenticar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Elimina o bloqueio automático por tentativas seguidas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "A web exige segundo fator e a API móvel aceita só usuário e senha. Como classificar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Inconsistência entre caminhos de autenticação", isCorrect: true },
+                        { text: "Falha na gestão do identificador de sessão", isCorrect: false },
+                        { text: "Ausência de limite de tentativas no servidor", isCorrect: false },
+                        { text: "Problema no transporte cifrado da credencial", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a recuperação de senha merece rigor igual ao do login?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ela é um caminho oficial para entrar sem saber a senha",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela costuma usar a mesma base de credenciais do login",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela é a funcionalidade mais usada pelos clientes finais",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela armazena o histórico de senhas antigas do usuário",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Como testar ausência de proteção contra tentativas repetidas sem causar dano?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Conta de teste do cliente, volume pequeno e limite acordado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Lista curta de contas reais, com poucas tentativas em cada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Volume alto em janela noturna, quando ninguém está logado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Tentativas distribuídas ao longo do dia para evitar alerta",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Autorização e lógica de negócio",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A pergunta que vem depois de quem é você\n\nAutenticação diz quem você é. Autorização diz o que você pode fazer, e é onde estão os achados mais valiosos de um teste de aplicação. O motivo é estrutural: autenticação é resolvida uma vez, num lugar do código. Autorização precisa ser verificada em cada ação, em cada tela, em cada endpoint, por gente diferente ao longo de anos. Basta esquecer uma vez.\n\nO padrão mais comum é a referência direta a objeto sem verificação. O usuário acessa um documento pelo identificador, o sistema busca pelo identificador e devolve, sem perguntar se aquele documento pertence a quem pediu. A tela nunca ofereceria o número do documento de outra pessoa, e o desenvolvedor confiou nisso, o que nos leva de volta à suposição da primeira aula.\n\nO segundo padrão é a verificação feita só na interface. O botão de excluir não aparece para o usuário comum, e por isso ninguém verificou no servidor se ele pode excluir. Esconder o botão é experiência de uso; controlar quem pode agir é segurança. Confundir os dois produz sistemas em que a permissão existe apenas visualmente, e essa confusão é responsável por uma fatia grande dos achados críticos de aplicação.",
+                },
+                {
+                    type: "table",
+                    value: '[["Padrão de falha","Como se manifesta","Por que o scanner não pega"],["Referência direta sem checagem","Trocar o identificador alcança outro dono","Ele não sabe de quem é cada registro"],["Controle apenas na interface","A ação existe sem o botão na tela","Ele não conhece o papel esperado ali"],["Escalonamento horizontal","Mesmo nível, dados de outro cliente","Sem duas contas, não há comparação"],["Escalonamento vertical","Perfil comum executa ação de gestor","A resposta parece normal e válida"],["Fluxo fora de ordem","Pular etapa e concluir mesmo assim","Ele não conhece as regras do processo"],["Regra de valor","Desconto, limite ou preço manipulado","Ele não sabe o que a empresa permite"]]',
+                },
+                {
+                    type: "text",
+                    value: "# Lógica de negócio é onde a máquina não chega\n\nFalha de lógica de negócio não é um erro de código, é um descompasso entre o que o sistema permite e o que a empresa pretendia permitir. Um funcionário aprovando o próprio reembolso porque o fluxo não impede. Um pedido concluído com o estoque conferido no início e não no fim. Um desconto aplicado duas vezes porque o cupom é validado em uma etapa e consumido em outra. Nenhum desses casos é anomalia técnica: cada requisição é válida, o servidor responde corretamente e o resultado é um prejuízo real.\n\nÉ por isso que nenhuma ferramenta encontra essas falhas. Para reconhecê-las é preciso saber para que serve o sistema, quem são os papéis envolvidos, qual sequência de passos a empresa espera e onde está o dinheiro. Esse conhecimento vem de ler a documentação do processo, de usar a aplicação como usuário real e de perguntar ao cliente, e não de rodar mais uma ferramenta.\n\nO método que funciona é desenhar cada fluxo com valor e atacar as junções. Onde o estado muda, onde uma decisão é tomada, onde a validação de um passo é usada por outro. E então perguntar coisas simples: e se eu repetir esta etapa. E se eu pular. E se eu enviar duas ao mesmo tempo. E se eu voltar para um passo anterior depois de concluir. E se eu enviar um valor negativo onde só se esperava positivo.",
+                },
+                {
+                    type: "quote",
+                    value: "Esconder o botão é experiência de uso. Verificar quem pode agir é segurança. Sistemas que confundem os dois têm permissão apenas visual, e ela cai na primeira requisição.",
+                },
+                {
+                    type: "text",
+                    value: "## Testar isso exige duas contas e paciência\n\nO pedido mais importante que você faz ao cliente na fase de escopo aparece aqui: contas de perfis diferentes, e mais de uma do mesmo perfil. Sem duas contas de mesmo nível não dá para demonstrar acesso horizontal a dados de outro cliente. Sem contas de níveis diferentes não dá para demonstrar escalonamento. É por isso que a caixa cinza rende tanto em aplicação.\n\nO trabalho é comparativo e trabalhoso: registrar o que cada perfil vê e faz legitimamente, e depois tentar cada ação a partir do perfil errado. A parte que separa o profissional é a atenção ao resultado: uma resposta de sucesso com dado vazio pode significar que a permissão foi verificada, mas também pode significar que o registro pedido não existia. Confundir os dois gera achado errado.\n\nUm cuidado ético fecha a aula. Ao demonstrar acesso indevido, você está lendo dado que pertence a alguém, muitas vezes um cliente real do seu cliente. Use contas de teste sempre que possível, e quando só houver dado real, capture o mínimo, oculte o que não é necessário e registre apenas o suficiente para provar que a fronteira foi atravessada.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que falhas de autorização são tão comuns em aplicações?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Elas precisam ser verificadas em cada ação do sistema",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Elas dependem de bibliotecas externas mal mantidas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Elas surgem quando a senha do usuário é reutilizada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Elas só aparecem em sistemas com muitos integrantes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O botão de excluir não aparece para o perfil comum e nada é checado no servidor. Como classificar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Controle de acesso implementado apenas na interface",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Referência direta a objeto sem verificação de dono",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Falha de lógica de negócio no fluxo de exclusão",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sessão que não expira após o encerramento do uso",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que ferramentas automatizadas não encontram falha de lógica de negócio?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Elas não sabem o que a empresa pretendia permitir",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Elas não conseguem autenticar em fluxos com etapas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Elas ignoram requisições que retornam sucesso normal",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Elas dependem de catálogo público para cada aplicação",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Que perguntas guiam a busca por falha de lógica em um fluxo com valor?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "E se eu repetir, pular, voltar ou enviar em paralelo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "E se o campo aceitar texto maior que o limite previsto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "E se a versão do componente tiver falha já publicada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "E se o servidor responder devagar sob carga elevada",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma tentativa de acesso a outro registro devolve sucesso com dado vazio. Como interpretar?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Pode ser permissão checada ou registro inexistente",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "É confirmação de que a autorização está funcionando",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "É indício de falha, pois o acesso não foi negado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "É resultado inconclusivo que deve ser descartado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Injeção: quando dado vira instrução",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Um modelo mental que serve para todas\n\nInjeção parece uma família enorme de falhas com nomes diferentes, mas todas repetem a mesma história. Existe um lugar onde um texto é interpretado por alguém: um banco de dados, um interpretador de comandos, um navegador, um serviço de diretório, um mecanismo de modelo de página. O programa monta esse texto juntando partes fixas com dado do usuário. Se o dado do usuário consegue sair do lugar de valor e virar parte da instrução, existe injeção.\n\nA imagem que ajuda é a de uma frase com lacunas. O programa escreveu a frase e deixou um espaço para o nome. Se quem preenche o espaço escreve algo que faz o leitor entender uma frase diferente da pretendida, a fronteira entre o que era estrutura e o que era conteúdo desapareceu. Todas as injeções são variações desse mesmo acidente, em interpretadores diferentes.\n\nÉ por isso que a defesa correta é sempre a mesma ideia, adaptada ao contexto: nunca montar a instrução por concatenação de texto. Consultas parametrizadas mantêm dado como dado no banco. Chamadas que recebem argumentos em lista, em vez de uma linha de comando, evitam que um valor vire outro comando. Codificação correta na saída faz o navegador tratar texto como texto. Em todos os casos, o princípio é separar estrutura de conteúdo em vez de tentar adivinhar caracteres perigosos.",
+                },
+                {
+                    type: "table",
+                    value: '[["Interpretador","O que ele lê","Consequência quando o dado vira instrução"],["Banco de dados","Consulta montada pela aplicação","Leitura ou alteração de dados fora do previsto"],["Interpretador de comandos","Linha executada no sistema","Execução de instrução no servidor"],["Navegador do usuário","Página devolvida pela aplicação","Ação executada no contexto de outra pessoa"],["Serviço de diretório","Filtro de busca de usuários","Consulta ampliada além do permitido"],["Mecanismo de modelo","Modelo de página processado","Avaliação de expressão no lado do servidor"],["Analisador de documento","Arquivo estruturado recebido","Acesso a recurso interno pelo próprio analisador"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Filtro de lista negra é remendo, não solução\n\nA tentação de quem está corrigindo é bloquear caracteres suspeitos. Isso falha por um motivo estrutural: a lista de coisas ruins é infinita e a criatividade dos interpretadores é maior do que a de quem escreve o filtro. Codificação alternativa, variação de maiúsculas, comentários, representações equivalentes e recursos que ninguém lembrou existir contornam filtro de lista negra com regularidade.\n\nQuando o filtro é a única defesa, a recomendação do relatório precisa dizer isso com clareza, mesmo que a sua tentativa não tenha passado. O achado não é que você conseguiu injetar; é que a aplicação depende de reconhecer o ataque em vez de tornar o ataque impossível. Essa distinção é uma das que mais elevam a qualidade percebida de um relatório.\n\nExiste um caso que merece atenção especial: a entrada que vem de dentro. Muitos sistemas validam o que o usuário digita e confiam cegamente no que já está no banco, no que veio de outro serviço interno ou no que foi importado de um arquivo. Um valor malicioso gravado hoje, exibido amanhã em outra tela, produz o mesmo efeito. A validação certa acontece no momento do uso, e não apenas na porta de entrada.",
+                },
+                {
+                    type: "quote",
+                    value: "Não existe caractere perigoso, existe contexto que interpreta. Defesa que tenta listar o que é ruim perde para quem só precisa achar uma variação que ninguém previu.",
+                },
+                {
+                    type: "text",
+                    value: "## Demonstrar sem quebrar\n\nInjeção é a classe em que a demonstração mais facilmente causa dano, e por isso ela exige o cuidado mais explícito. A prova de que existe interpretação indevida quase nunca precisa de uma ação destrutiva. Uma resposta que muda de forma inequívoca quando o valor enviado deveria ser tratado como texto já demonstra o ponto.\n\nA escala do que se faz depois deve ser combinada, não escolhida no impulso. Confirmar a existência é uma coisa; caminhar até extrair dados é outra decisão, com risco e com impacto sobre dado de terceiros; e qualquer ação de escrita, alteração ou remoção fica fora, salvo autorização específica e ambiente adequado. Sistemas com falha de injeção costumam ser exatamente os mais frágeis, e uma consulta mal calibrada trava o serviço.\n\nA parte de relatório também muda de tom aqui. Além de descrever o caminho, vale escrever o que aquilo alcança no pior caso realista, mesmo sem ter executado. Dizer que a falha permite leitura da base inteira, com base no privilégio observado da conexão, e que a demonstração foi limitada a uma consulta inofensiva por decisão de escopo, é honesto e comunica o risco sem tê-lo materializado.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é o modelo mental comum a todas as falhas de injeção?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Dado do usuário sai do lugar de valor e vira instrução",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O sistema aceita caracteres especiais em campos de texto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A aplicação não valida o tamanho da entrada recebida",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O servidor executa código enviado por um usuário anônimo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual é o princípio comum às defesas corretas contra injeção?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Separar estrutura de conteúdo em vez de filtrar sinais",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Bloquear caracteres reconhecidos como perigosos na entrada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Validar o tamanho e o tipo de todo campo do formulário",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Registrar as requisições suspeitas para análise posterior",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que filtro de lista negra é considerado remendo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A lista do que é ruim nunca fica completa", isCorrect: true },
+                        { text: "Ele impõe custo alto de processamento", isCorrect: false },
+                        { text: "Ele impede o uso normal da aplicação", isCorrect: false },
+                        { text: "Ele depende de atualização do fornecedor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "A aplicação valida o que o usuário digita, mas confia no que já está no banco. Qual é o risco?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Valor gravado antes é interpretado depois em outra tela",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O banco de dados perde a consistência entre as tabelas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A validação de entrada deixa de funcionar com o tempo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O desempenho cai porque a checagem ocorre duas vezes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual é a forma responsável de demonstrar uma injeção encontrada em produção?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Confirmar a interpretação indevida sem ação destrutiva",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Extrair uma amostra grande da base para medir o alcance",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Alterar um registro de teste e restaurar o valor original",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Repetir a consulta várias vezes para medir a estabilidade",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Prova de conceito mínima e reversível",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A prova existe para convencer, não para vencer\n\nProva de conceito é a evidência de que o problema é real. O objetivo dela é fazer uma pessoa cética do lado do cliente olhar e concordar que aquilo acontece. Não é medir até onde você conseguiria ir, nem mostrar habilidade. Essa mudança de objetivo reorganiza todas as decisões que vêm depois.\n\nTrês critérios definem uma boa prova. Mínima: usa a menor ação capaz de demonstrar o ponto. Reversível: não deixa o ambiente diferente de como estava, ou deixa algo que pode ser removido e é removido. Verificável: outra pessoa consegue repetir seguindo o que você escreveu, sem precisar te perguntar nada.\n\nUm exemplo de calibragem. Você encontrou acesso indevido a documentos de outros clientes. A prova mínima é uma captura mostrando um documento que não pertence à sua conta de teste, com o identificador visível e o dado pessoal ocultado. A prova exagerada é uma lista de trezentos documentos baixados. As duas demonstram a mesma coisa; só a segunda transforma você em detentor de dado que não deveria ter.",
+                },
+                {
+                    type: "table",
+                    value: '[["Critério","Pergunta que ele responde","Erro típico quando ignorado"],["Mínima","Qual a menor ação que prova isso","Coleta de volume desnecessário de dado"],["Reversível","O ambiente volta ao estado anterior","Registro ou conta deixados para trás"],["Verificável","Outra pessoa repete pelo que escrevi","Achado que não sobrevive ao reteste"],["Segura","Existe risco de indisponibilidade aqui","Serviço frágil derrubado na demonstração"],["Respeitosa","Estou expondo dado de quem não é parte","Dado pessoal de terceiro no relatório"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Marcar, registrar e desfazer\n\nQuando a demonstração precisa criar alguma coisa, três regras evitam problema. Primeira: torne o artefato identificável, com nome que deixe claro que é do teste e a data. Segunda: registre no seu diário o que foi criado, onde e quando, no momento em que criou, e não depois. Terceira: remova ao final e confirme a remoção, ou entregue a lista ao cliente quando a remoção depender de acesso que você não tem.\n\nO esquecimento aqui é mais comum do que se admite e tem consequência real. Conta de teste deixada ativa, registro de demonstração numa tabela de produção, arquivo enviado que continua acessível na internet. Cada um desses é uma exposição criada por você, no ambiente do cliente, e a responsabilidade é sua mesmo que ninguém perceba.\n\nExiste um caso em que a remoção não é possível: quando desfazer exigiria mais privilégio do que você tem, ou quando a remoção em si traz risco de quebrar alguma coisa. Aí a conduta é informar imediatamente, com localização exata do artefato, e registrar isso no relatório como item de acompanhamento, que será conferido no reteste.",
+                },
+                {
+                    type: "quote",
+                    value: "A prova serve para convencer alguém cético, não para medir até onde daria para ir. A menor demonstração que faz o cliente concordar é sempre a melhor demonstração.",
+                },
+                {
+                    type: "text",
+                    value: "## O que entra na evidência\n\nEvidência boa combina três elementos: o que foi enviado, o que voltou e o carimbo de tempo. Captura de tela ajuda a comunicar, mas sozinha é fraca, porque não mostra o caminho. Registro da requisição e da resposta é mais forte, e o horário é o que permite ao cliente cruzar com o log dele e confirmar do lado de dentro.\n\nO cuidado com dado de terceiro vale aqui de novo, e vale mais do que em qualquer outra parte do trabalho. Nome, documento, endereço, e-mail e telefone de pessoas reais devem ser ocultados na evidência, mantendo apenas o suficiente para provar que o dado era real e de outra pessoa. Um identificador parcial e um campo visível costumam bastar.\n\nPor fim, evidência tem prazo de vida. Ela vive no repositório cifrado do projeto, é entregue com o relatório pelo canal combinado e é destruída no prazo do contrato. Guardar material de cliente antigo por comodidade, ou para portfólio, é uma das piores decisões possíveis nessa carreira, e o dia em que der errado não vai ter defesa técnica que segure.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual é o objetivo de uma prova de conceito em um teste de intrusão?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Convencer alguém cético de que o problema é real",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Medir até onde o acesso obtido conseguiria chegar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Demonstrar o nível técnico da equipe contratada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Reproduzir o comportamento esperado de um invasor",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quais critérios definem uma boa prova de conceito?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Mínima, reversível e verificável por outra pessoa",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Completa, documentada e assinada pelo responsável",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Automatizada, rápida e aplicável a vários alvos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Detalhada, ilustrada e revisada por um segundo par",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Você acessou documentos de outros clientes. Qual evidência é adequada?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Um documento alheio, com o dado pessoal ocultado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Uma lista com centenas de documentos identificados",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Um resumo textual, sem nenhuma captura anexada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Uma cópia dos arquivos guardada até o fim do prazo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "A demonstração exigiu criar um registro em produção e você não consegue removê-lo. O que fazer?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Informar de imediato com a localização exata do artefato",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Registrar apenas no relatório final, na seção de evidência",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Tentar a remoção com outra conta obtida durante o teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Deixar como está, pois o artefato não causa risco nenhum",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que a captura de tela sozinha é uma evidência fraca?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Ela não mostra o caminho nem permite cruzar com o log",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela pode ser alterada com facilidade por qualquer editor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela ocupa espaço demais no repositório cifrado do projeto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ela expõe dado pessoal que deveria ficar fora do relatório",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - Pós-exploração e o que ela demonstra",
+    aulas: [
+        {
+            titulo: "Para que serve a pós-exploração",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Entrar não é o fim, é o começo da pergunta\n\nQuando o acesso acontece, existe uma tentação forte de comemorar e seguir para o próximo alvo. Só que o cliente não contratou uma coleção de acessos: ele contratou uma resposta sobre o que aquilo custa para ele. Pós-exploração é a fase em que você responde a pergunta que importa, que é o que esse acesso permite fazer com o negócio.\n\nA diferença entre um relatório mediano e um bom relatório costuma estar exatamente aqui. O mediano diz que foi obtido acesso ao servidor de aplicação. O bom diz que a partir daquele acesso era possível ler a configuração com a credencial do banco, e que essa credencial dava leitura em todas as tabelas de clientes, incluindo as de contratos ativos. A primeira frase é um fato técnico; a segunda é uma decisão de orçamento esperando para acontecer.\n\nExiste também um valor defensivo nessa fase que quase ninguém menciona. Pós-exploração mostra o que a empresa não vê. Se você passou uma tarde inteira dentro de um servidor, consultando informação, abrindo caminho para outros sistemas, e nenhum alerta subiu, o relatório ganhou uma seção que vale mais para o cliente do que metade dos achados técnicos.",
+                },
+                {
+                    type: "table",
+                    value: '[["Pergunta da pós-exploração","O que ela produz","Por que o cliente se importa"],["O que este acesso alcança","Lista de dados e sistemas ao alcance","Define o tamanho real do prejuízo"],["De onde vem esse poder","Privilégio, credencial ou confiança herdada","Aponta onde corrigir de fato"],["Quanto tempo isso duraria","Estabilidade do acesso obtido","Mostra se seria um susto ou uma campanha"],["Quem enxergaria isso","Alertas gerados e reação observada","Mede a defesa, não apenas a falha"],["O que muda se corrigirmos","Efeito de fechar um ponto do caminho","Orienta a prioridade da correção"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Duas armadilhas comuns\n\nA primeira é colecionar. A pessoa entra em uma máquina, encontra caminho para a segunda, depois para a terceira, e no fim da semana tem doze acessos e nenhuma história contada. Doze acessos que provam a mesma coisa valem menos do que um acesso que demonstra alcance a um dado sensível, porque o cliente precisa decidir o que fazer, não admirar o percurso.\n\nA segunda é a curiosidade sem propósito. Uma vez dentro, tudo parece interessante: mensagens, documentos, histórico de comandos, arquivos pessoais de alguém. Boa parte disso não acrescenta nada ao relatório e adiciona exposição desnecessária. A pergunta que disciplina é direta: o que eu quero demonstrar com isso, e existe forma menor de demonstrar a mesma coisa.\n\nUm terceiro cuidado, mais sutil, é o tempo. Pós-exploração pode consumir dias, e o contrato tem prazo. Aprofundar um caminho é excelente quando ele leva a um impacto novo; é desperdício quando leva ao mesmo impacto já demonstrado por outro caminho. Saber quando parar de aprofundar e voltar a ampliar cobertura é decisão de método, e ela aparece em qualquer projeto real.",
+                },
+                {
+                    type: "quote",
+                    value: "O cliente não comprou uma coleção de acessos. Ele comprou a resposta sobre o que um acesso custa para ele, e essa resposta só nasce depois que você entra.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é o objetivo da fase de pós-exploração?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Demonstrar o que o acesso obtido permite no negócio",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Obter o maior número possível de acessos no ambiente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Garantir que o acesso continue disponível depois",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Confirmar que a falha explorada é de fato real",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual frase caracteriza um bom relato de pós-exploração?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O acesso alcançava a base de clientes por credencial lida",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Foi obtido acesso administrativo ao servidor de aplicação",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A falha explorada consta no catálogo público com nota alta",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O acesso foi obtido em menos de duas horas de tentativa",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Você passou horas dentro do ambiente e nenhum alerta foi gerado. Como usar isso?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Como seção do relatório sobre a defesa que não enxergou",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Como sinal de que a atuação foi discreta o suficiente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Como confirmação de que o acesso obtido era legítimo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Como justificativa para ampliar o escopo já autorizado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual pergunta disciplina a curiosidade durante a pós-exploração?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O que quero demonstrar, e há forma menor de demonstrar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Quanto tempo ainda resta dentro da janela combinada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Qual sistema tem a maior nota atribuída no inventário",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Quantos acessos já foram obtidos até este momento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um novo caminho leva ao mesmo impacto já demonstrado por outro. O que fazer?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Registrar o caminho e voltar a ampliar a cobertura",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Aprofundar, pois caminhos distintos exigem correções",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Descartar sem registro, já que nada novo foi provado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Reportar como achado independente com a mesma nota",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Escalonamento e movimento dentro dos limites",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Subir e andar, com a régua na mão\n\nEscalonamento é ganhar mais poder do que o acesso inicial dava. Movimento lateral é usar o acesso que você tem para alcançar outro sistema. Os dois existem no teste por um motivo só: demonstrar que a fronteira que o cliente acredita ter não está de pé. E os dois precisam acontecer dentro de um limite escrito, porque são exatamente as ações com maior potencial de sair do escopo sem que ninguém perceba.\n\nO raciocínio de escalonamento é sempre o mesmo, independente da tecnologia. Você procura algo que rode com mais privilégio do que você tem e que aceite influência sua. Um processo privilegiado que lê um arquivo que você pode escrever. Uma tarefa automática que executa um script em local aberto demais. Uma credencial guardada em texto claro num arquivo de configuração legível. Um serviço que confia em quem está na mesma máquina. Em todos os casos, a falha é uma confiança mal colocada, e não um truque específico.\n\nO raciocínio de movimento lateral também tem um padrão único: procurar por confiança herdada. Onde esta máquina é confiável para outra. Que credencial guardada aqui abre algo lá. Que serviço interno aceita conexão de qualquer origem da rede porque assume que a rede é confiável. Encontrar isso é encontrar a arquitetura de confiança da empresa, que costuma ser bem mais permissiva do que qualquer diagrama sugere.",
+                },
+                {
+                    type: "table",
+                    value: '[["Padrão observado","Confiança mal colocada","O que ele demonstra ao cliente"],["Credencial em arquivo de configuração","Segredo guardado onde muita gente lê","Um acesso pequeno abre um acesso grande"],["Tarefa automática privilegiada","Execução de conteúdo alterável","Privilégio herdado sem ninguém autorizar"],["Permissão ampla em compartilhamento","Todos leem o que é de poucos","Dado sensível alcançável sem invasão"],["Serviço que confia na rede","Estar dentro é ser autorizado","Segmentação existe só no diagrama"],["Conta reutilizada em vários sistemas","Um segredo protege muitas portas","Comprometer um lugar derruba todos"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O limite que precisa estar escrito\n\nEstas são as ações que mais provocam incidente contratual, então as regras de engajamento precisam ser específicas. Até onde o movimento pode ir: apenas dentro da faixa listada, ou pode alcançar qualquer sistema que o acesso permitir. Se contas de usuários reais podem ser usadas quando uma credencial aparecer, ou se apenas contas de teste são permitidas. Se sistemas de terceiros alcançáveis a partir de dentro estão excluídos, o que quase sempre estão.\n\nExiste um caso especialmente sensível e vale nomear: encontrar credencial de administrador de domínio, ou equivalente, no meio do caminho. Usar isso é o passo mais impactante possível de um teste e também o mais arriscado. A conduta profissional é parar, comunicar e obter confirmação escrita antes de usar. Muitos contratos preveem que a demonstração termina exatamente ali, com a prova de que a credencial foi obtida.\n\nO mesmo vale para sistemas que não estavam no escopo mas viraram alcançáveis. O fato de você conseguir chegar não autoriza chegar. Alcance técnico e autorização são coisas separadas, e confundir as duas é a forma mais comum de um teste bem-feito virar um problema jurídico na semana seguinte.",
+                },
+                {
+                    type: "quote",
+                    value: "Alcance técnico não é autorização. Conseguir chegar a um sistema e poder tocar nele são perguntas diferentes, e só a segunda está escrita no contrato.",
+                },
+                {
+                    type: "text",
+                    value: "## Persistência: por que ela quase sempre fica fora\n\nEm um ataque real, o invasor garante que consegue voltar amanhã. Em um teste, isso raramente é necessário e frequentemente é proibido. Implantar mecanismo de retorno significa criar, no ambiente do cliente, uma porta que você precisa lembrar de fechar, e que qualquer outra pessoa pode encontrar enquanto ela existir.\n\nQuando a persistência entra no escopo, normalmente é em simulação de adversário, com objetivo declarado de testar detecção, e com regras próprias: mecanismo identificável, inventariado, com prazo e com remoção verificada. Fora desse contexto, o padrão profissional é não persistir e reautenticar quando precisar voltar.\n\nEste curso não trata de técnicas para evitar detecção nem de infraestrutura para manter acesso remoto, e a razão é de propósito, não de omissão. O objetivo do teste de intrusão é medir risco e comunicar impacto. Investir em passar despercebido serve a um objetivo diferente, exige acordo específico e pertence a outra disciplina, com outras salvaguardas contratuais.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual é o padrão comum por trás de quase todo escalonamento de privilégio?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Algo com mais poder aceita influência de quem tem menos",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Uma versão desatualizada permanece instalada no sistema",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A senha do administrador é fraca e acaba sendo adivinhada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O sistema operacional não recebe correção há muitos meses",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que o testador procura ao avaliar movimento lateral?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Onde existe confiança herdada entre sistemas", isCorrect: true },
+                        { text: "Quais portas estão abertas em cada servidor", isCorrect: false },
+                        {
+                            text: "Que versões estão desatualizadas na rede interna",
+                            isCorrect: false,
+                        },
+                        { text: "Quantos usuários acessam cada máquina por dia", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Durante o teste aparece uma credencial de administrador de domínio. Qual é a conduta?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Parar, comunicar e aguardar confirmação por escrito",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Usar de imediato, pois demonstra o impacto máximo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Registrar e seguir testando outros alvos do escopo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Validar a credencial e depois avisar o cliente disso",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um sistema fora do escopo se tornou alcançável a partir do acesso obtido. O que isso autoriza?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Nada: alcance técnico não substitui autorização",
+                            isCorrect: true,
+                        },
+                        { text: "Teste leve, já que o caminho partiu do escopo", isCorrect: false },
+                        {
+                            text: "Acesso somente de leitura, sem qualquer alteração",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Enumeração passiva do serviço, mas nada além disso",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que persistência costuma ficar fora de um teste de intrusão?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Cria uma porta no cliente que outro pode encontrar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Exige ferramentas que a maioria das equipes não tem",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Gera alerta imediato e encerra o teste antes da hora",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Só funciona em ambientes sem monitoramento adequado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "De acesso técnico a risco de negócio",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A tradução que decide o orçamento\n\nO relatório será lido por gente que não vai reproduzir nada. Diretor financeiro, jurídico, alguém do conselho. Para essas pessoas, escrever que houve execução remota de código no servidor de aplicação é uma frase sem consequência. Escrever que o teste alcançou os dados cadastrais e os contratos de todos os clientes ativos, incluindo documentos de identificação, é uma frase que muda a reunião.\n\nA tradução tem um método. Primeiro você lista, concretamente, o que o acesso alcança: quais dados, quais sistemas, quais ações. Depois responde o que aconteceria se um adversário fizesse isso de verdade, em quatro eixos que a empresa entende. Vazamento de informação, interrupção de operação, fraude ou perda financeira direta, e obrigação legal ou regulatória decorrente.\n\nO quarto eixo é o mais subestimado por técnicos e o mais poderoso na conversa. Se a base alcançada contém dado pessoal, existe uma consequência que independe de o incidente dar prejuízo: obrigações de comunicação a titulares e a autoridade, exposição a sanção e dano de reputação. Um relatório que aponta isso com sobriedade, sem dramatizar, costuma ser o que destrava a correção.",
+                },
+                {
+                    type: "table",
+                    value: '[["Achado técnico","Tradução para o negócio","Quem decide com isso"],["Acesso ao servidor de aplicação","Leitura de contratos e dados de clientes","Diretoria e jurídico"],["Falha de autorização entre clientes","Um cliente enxerga dados de outro","Área de produto e comercial"],["Credencial de integração exposta","Movimentação indevida entre sistemas","Tecnologia e controles internos"],["Painel administrativo exposto","Alteração de preço, cadastro ou pedido","Operação e financeiro"],["Base de dados alcançável","Comunicação obrigatória em caso de vazamento","Jurídico e conformidade"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Concreto vence adjetivo\n\nO vício mais comum nessa tradução é o adjetivo. Impacto severo, risco elevado, consequências graves. Nada disso informa. O que informa é número, nome e escala: quantos registros, que tipo de dado, quanto tempo o serviço ficaria indisponível, quantos clientes afetados, qual processo pararia. Quando não dá para saber o número exato, uma faixa honesta com a fonte é melhor do que um adjetivo.\n\nUm cuidado que separa profissional de vendedor de medo: não invente cenário catastrófico para elevar a urgência. Se você demonstrou leitura da base, escreva leitura da base, e se o mesmo acesso permitiria alteração mas você não testou, escreva exatamente assim. A credibilidade construída ao longo do documento é o que faz a recomendação ser aceita, e ela quebra na primeira frase inflada que o time técnico identificar.\n\nHá também um erro na direção oposta: minimizar por modéstia técnica. Testador que acha um achado sem graça porque foi fácil de encontrar costuma subestimar o impacto real. Facilidade de exploração aumenta o risco, não diminui: se foi fácil para você em duas horas, é fácil para qualquer um. Achado simples com impacto grande é o achado mais valioso do relatório, não o menos.",
+                },
+                {
+                    type: "quote",
+                    value: "Adjetivo não informa. Número, tipo de dado e processo afetado informam. Quem decide orçamento precisa da consequência descrita, e não da gravidade adjetivada.",
+                },
+                {
+                    type: "text",
+                    value: "## Perguntar ao cliente o que dói\n\nA melhor tradução não sai só da sua cabeça, porque você não conhece o negócio por dentro. A conversa que rende é feita antes, na fase de escopo, e retomada no fim: qual sistema, se parasse, causaria mais dano; que dado seria pior vazar; que processo tem regulação em cima. Com essas respostas, você escreve a tradução na linguagem que o cliente já usa internamente.\n\nEsse alinhamento evita um erro clássico, que é atribuir criticidade máxima ao sistema tecnicamente mais interessante. O servidor com a falha mais elegante pode servir a um processo secundário, enquanto o achado modesto está no sistema que sustenta o faturamento. Só o cliente sabe disso, e só perguntar revela.\n\nQuando o cliente não sabe responder, isso também é informação. Empresa que não consegue dizer qual sistema é mais crítico não tem classificação de ativos, e isso vale um item próprio no relatório, na seção de recomendações estruturais. Vários dos achados mais úteis de um teste não são falhas técnicas: são ausências de processo que aparecem justamente nessa conversa.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais eixos organizam a tradução de um achado para o negócio?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Vazamento, interrupção, fraude e obrigação legal",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Severidade, exposição, esforço e prazo de correção",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Confidencialidade, integridade e disponibilidade",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Probabilidade, impacto, detecção e recuperação",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que o eixo legal costuma destravar a correção?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "A obrigação existe mesmo sem prejuízo financeiro",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A multa prevista supera o custo de qualquer correção",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O jurídico assume a responsabilidade pelo tratamento",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A lei exige teste de intrusão anual nas empresas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que substitui adjetivos como grave e severo em um relatório?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Quantidade, tipo de dado e processo afetado", isCorrect: true },
+                        { text: "Nota do catálogo público e cor da severidade", isCorrect: false },
+                        { text: "Comparação com incidentes ocorridos no setor", isCorrect: false },
+                        { text: "Referência à metodologia adotada no trabalho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Um achado foi encontrado com facilidade em duas horas. Como isso afeta o risco?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Aumenta, porque qualquer um encontraria do mesmo jeito",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Diminui, porque a falha é superficial e de baixo impacto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Não muda, porque a nota depende apenas da consequência",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Diminui, porque o cliente corrigiria em pouco tempo também",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O cliente não consegue dizer qual sistema é o mais crítico dele. Como tratar isso?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Como achado de processo, por falta de classificação de ativos",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Como limitação do teste, registrada apenas na seção de escopo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Como caso em que o testador define a criticidade por conta",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Como motivo para adiar a entrega até que a lista exista",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Evidência: registrar, preservar e proteger",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Evidência é o que sobrevive à discussão\n\nTodo achado relevante vai ser questionado por alguém do lado do cliente, e isso é saudável. O time que construiu o sistema tem o dever de duvidar antes de mudar código em produção. Evidência é o que faz essa conversa terminar em correção em vez de terminar em impasse.\n\nUma evidência completa tem quatro partes. O contexto, que diz onde e com qual identidade a ação ocorreu. A ação, que descreve o que foi enviado. O resultado, que mostra o que voltou. E o carimbo de tempo, que permite ao cliente confirmar a mesma ação no log dele. Faltando o carimbo, o cliente não consegue cruzar; faltando a ação, ele não consegue reproduzir; faltando o contexto, ele não sabe se aquilo valia para qualquer usuário ou só para o seu.\n\nO formato importa menos do que a completude, mas alguns hábitos ajudam. Registro textual da requisição e da resposta é melhor do que imagem, porque é pesquisável e copiável. Imagem funciona bem para o que é visual, como uma tela mostrando dados de outro cliente. E numerar as evidências e referenciá-las no texto do achado evita o documento em que ninguém sabe qual anexo pertence a qual item.",
+                },
+                {
+                    type: "table",
+                    value: '[["Parte da evidência","O que ela responde","O que quebra sem ela"],["Contexto","Onde e com qual identidade ocorreu","Não se sabe se vale para outros usuários"],["Ação","O que exatamente foi enviado","O cliente não consegue reproduzir"],["Resultado","O que o sistema devolveu","A conclusão fica sem sustentação"],["Carimbo de tempo","Quando aconteceu, com fuso","Impossível cruzar com o log do cliente"],["Referência no texto","A qual achado aquilo pertence","Anexo solto que ninguém liga ao item"]]',
+                },
+                {
+                    type: "text",
+                    value: "# Dado do cliente na sua mão\n\nA partir do momento em que você guarda evidência, você é custodiante de informação de uma empresa e, muitas vezes, de dados pessoais de terceiros que nunca ouviram falar de você. Essa responsabilidade tem consequências práticas que precisam virar rotina, não boa intenção.\n\nA rotina mínima tem cinco itens. Coletar o mínimo necessário para provar o ponto. Ocultar dado pessoal que não é essencial ao entendimento, mantendo apenas o suficiente para mostrar que era real. Guardar tudo cifrado, em repositório do projeto com acesso restrito a quem trabalha nele. Transportar e entregar por canal combinado, nunca por anexo em e-mail pessoal ou serviço improvisado. Destruir no prazo do contrato e registrar a destruição.\n\nExiste um tipo de material que merece regra ainda mais dura: credencial obtida durante o teste, base de dados extraída, chave privada, cópia de arquivo de configuração com segredo. Isso não deveria sair do ambiente do cliente sempre que houver alternativa, e quando precisar ser guardado, o prazo é o mais curto possível. Se o seu repositório de projeto vazar, o estrago não é só seu.",
+                },
+                {
+                    type: "quote",
+                    value: "No momento em que você guarda evidência, vira custodiante de dado que não é seu. A rotina que protege isso precisa ser hábito, e não boa intenção declarada.",
+                },
+                {
+                    type: "text",
+                    value: "## Quando a evidência vira prova de outra coisa\n\nExiste um cenário em que as regras mudam completamente: quando o teste esbarra em indício de crime ou de incidente real, como aquele comprometimento prévio do módulo dois. Ali a sua evidência deixa de ser material de relatório e pode virar elemento de uma investigação, com exigências de preservação que você não controla.\n\nA conduta correta é congelar o que já existe, não produzir mais material por conta própria e transferir a condução para quem tem mandato para isso, que é a resposta a incidentes do cliente e eventualmente uma perícia contratada. Continuar coletando por iniciativa própria pode inutilizar a evidência, além de te colocar numa posição que ninguém contratou.\n\nHá também situações menos dramáticas em que a evidência ganha peso especial: achado que envolve conduta de um funcionário, como acesso indevido reiterado, ou material que sugere descumprimento de norma. Nesses casos, entregue os fatos observados, sem interpretação sobre intenção ou culpa, e deixe o encaminhamento com o cliente. Testador descreve o que viu; atribuir responsabilidade a pessoas é papel de outra área.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais são as quatro partes de uma evidência completa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Contexto, ação, resultado e carimbo de tempo", isCorrect: true },
+                        { text: "Descrição, severidade, correção e responsável", isCorrect: false },
+                        {
+                            text: "Alvo, ferramenta, saída bruta e conclusão final",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Data, autor, referência pública e nota atribuída",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que o carimbo de tempo é indispensável na evidência?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Permite ao cliente cruzar a ação com o log dele",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Comprova o total de horas trabalhadas no projeto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Define a ordem em que os achados serão corrigidos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Garante que a janela combinada foi de fato seguida",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual é a rotina correta para material sensível obtido no teste?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Mínimo coletado, cifrado, restrito e destruído no prazo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Cópia completa arquivada para consulta em testes futuros",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Envio ao cliente por e-mail assim que a coleta terminar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Guarda indefinida, desde que o repositório seja cifrado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O teste esbarra em indício de incidente real anterior. O que acontece com a evidência?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Congela o que existe e transfere a condução ao cliente",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Amplia a coleta para caracterizar melhor o ocorrido",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Anexa ao relatório final como um achado de alta nota",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Descarta, porque o caso está fora do escopo do teste",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Um achado envolve conduta aparentemente indevida de um funcionário. Como escrever?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Só os fatos observados, sem julgar intenção ou culpa",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Com a conclusão sobre a responsabilidade da pessoa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Em anexo separado, entregue apenas ao gestor dela",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sem registro, para evitar consequência trabalhista",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Limpeza e devolução do ambiente",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Sair sem deixar sujeira\n\nUm teste bem-feito termina com o ambiente do jeito que estava. Isso parece óbvio e é uma das partes mais negligenciadas do serviço, porque acontece no fim, quando o prazo aperta e a atenção está no relatório. O resultado aparece meses depois: conta de teste ainda ativa, arquivo enviado ainda acessível, registro estranho numa tabela de produção que ninguém sabe explicar.\n\nA limpeza começa antes de existir, no registro. Cada artefato criado durante o teste vai para uma lista no momento em que é criado, com o que é, onde está e como remover. Tentar reconstruir isso de memória no último dia é como termina a maior parte dos itens esquecidos. A lista custa segundos por item e resolve o problema inteiro.\n\nO conteúdo dessa lista é sempre parecido: contas criadas, arquivos enviados, registros inseridos, permissões alteradas, configurações mudadas para viabilizar um teste, sessões abertas e credenciais obtidas. Cada linha precisa terminar com uma marca de removido, com data, ou com uma nota explicando por que a remoção depende do cliente.",
+                },
+                {
+                    type: "table",
+                    value: '[["Artefato criado","Risco se ficar para trás","Como encerrar"],["Conta de teste","Acesso ativo sem dono responsável","Remover ou pedir remoção com confirmação"],["Arquivo enviado","Conteúdo acessível a qualquer visitante","Apagar e verificar que não responde mais"],["Registro inserido","Dado sujo em base de produção","Remover e informar a chave usada"],["Permissão alterada","Privilégio ampliado que ninguém revisou","Restaurar e registrar o valor anterior"],["Credencial obtida","Segredo do cliente fora do ambiente","Destruir e recomendar a troca dela"],["Sessão aberta","Acesso válido além do fim do teste","Encerrar e conferir a expiração"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O que só o cliente pode fazer\n\nParte da devolução não está no seu alcance, e precisa ser dita de forma explícita em vez de ficar implícita. Toda credencial que você obteve durante o teste deve ser trocada pelo cliente, mesmo que você a destrua: a suposição correta é que um segredo que saiu do lugar dele deixou de ser segredo. Isso vale para senha de serviço, chave de integração e token de acesso.\n\nO mesmo raciocínio vale para o que você não conseguiu desfazer. Se uma alteração exigiu privilégio que você não tem, ou se remover traria risco de quebrar algo, a lista entregue ao cliente precisa dizer exatamente o que fazer, onde e com que urgência. Deixar essa pendência dentro de um parágrafo do relatório, sem destaque, é a forma mais eficiente de garantir que ninguém faça.\n\nA seção de limpeza fecha com uma declaração simples e valiosa: o que foi criado, o que foi removido, o que permanece e o que depende do cliente. Poucas páginas geram tanta confiança quanto essa, porque ela mostra que a equipe controlou o próprio rastro. E ela evita a situação constrangedora, meses depois, de um analista encontrar um artefato e não saber se aquilo foi o testador ou foi um invasor.",
+                },
+                {
+                    type: "quote",
+                    value: "Toda credencial obtida no teste deve ser trocada pelo cliente. Segredo que saiu do lugar dele deixou de ser segredo, mesmo que você tenha destruído a sua cópia.",
+                },
+                {
+                    type: "text",
+                    value: "## Entrega e transição\n\nO encerramento técnico do teste não é o fim do serviço. Existe uma transição para o cliente que costuma valer mais do que a última tarde de exploração: uma reunião curta em que a equipe técnica dele ouve os achados principais, pergunta o que quiser e sai com a lista do que fazer primeiro.\n\nEssa reunião tem um efeito prático que o documento sozinho não tem. Ela transforma o relatório de um arquivo que alguém vai ler eventualmente em um plano que várias pessoas discutiram juntas. Times que passam por essa conversa corrigem mais e corrigem melhor, e é comum ali aparecer contexto que ajusta a severidade de um ou dois itens.\n\nE deixe claro o que acontece depois: quanto tempo você guarda o material, qual é a data de destruição, como funciona o reteste e por qual canal falar em caso de dúvida sobre um achado. Fechar o projeto com essas quatro respostas escritas evita a maior parte dos atritos que aparecem semanas depois, quando todo mundo já esqueceu o que foi combinado.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quando a limpeza de um teste deve começar?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "No momento em que cada artefato é criado", isCorrect: true },
+                        { text: "No último dia da janela de execução", isCorrect: false },
+                        { text: "Após a entrega do relatório ao cliente", isCorrect: false },
+                        { text: "Durante a reunião de encerramento técnico", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que credenciais obtidas devem ser trocadas mesmo depois de destruídas?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Segredo que saiu do lugar dele não é mais segredo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A destruição do material não pode ser comprovada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O contrato de teste exige troca periódica de senha",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A credencial pode ter expirado durante o próprio teste",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma alteração feita no teste não pode ser desfeita por falta de privilégio. Como proceder?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Entregar instrução destacada com local e urgência",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Solicitar acesso adicional e desfazer por conta própria",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Citar em um parágrafo do corpo do relatório final",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Deixar como está, pois a mudança já foi documentada",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que a seção de limpeza do relatório deve declarar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O que foi criado, removido, permanece e cabe ao cliente",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A lista completa de ferramentas usadas em cada etapa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O tempo gasto em cada fase da metodologia adotada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A relação de todos os alvos varridos durante o teste",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual é o principal ganho da reunião de transição com o time técnico do cliente?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O relatório vira plano discutido em vez de arquivo lido",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O cliente aprova formalmente a conclusão do projeto ali",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A equipe demonstra ao vivo os achados mais importantes",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O prazo de reteste passa a contar a partir daquela data",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - O relatório e a carreira",
+    aulas: [
+        {
+            titulo: "O relatório é o produto",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O que o cliente leva para casa\n\nDurante duas semanas você trabalhou em terminais, telas e anotações. Nada disso o cliente viu. O que ele recebe, o que ele paga e o que sobra do projeto daqui a um ano é um documento. Tratar o relatório como anexo burocrático é confundir o esforço com o produto, e é a razão pela qual profissionais tecnicamente muito bons perdem contrato para gente que sabe escrever.\n\nA consequência prática é de planejamento. Escrever bem exige tempo, e esse tempo precisa estar no cronograma desde a proposta, não sair das horas de teste. Uma proporção comum em serviços sérios reserva algo entre um quarto e um terço do projeto para consolidação e redação. Quem deixa o relatório para a última tarde entrega um documento pior do que o trabalho que fez, e é pelo documento que será julgado.\n\nExiste um teste simples de qualidade que vale aplicar antes de entregar. Um desenvolvedor que não participou de nada consegue, lendo apenas o achado, entender o que está errado, reproduzir e saber o que mudar. Se a resposta for não, o achado ainda não está pronto, por mais impressionante que tenha sido a exploração por trás dele.",
+                },
+                {
+                    type: "table",
+                    value: '[["Seção do relatório","Quem lê de verdade","O que ela precisa entregar"],["Sumário executivo","Diretoria e jurídico","Situação, risco e decisão em uma página"],["Escopo e limitações","Auditoria e time técnico","O que foi e o que não foi testado"],["Metodologia","Auditoria e cliente futuro","Como o trabalho pode ser repetido"],["Achados detalhados","Quem vai corrigir","Impacto, evidência, reprodução e correção"],["Plano recomendado","Gestão de tecnologia","Ordem realista do que fazer primeiro"],["Anexos e evidências","Quem contesta um achado","Material que sustenta cada conclusão"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Escrever para leitores diferentes\n\nO mesmo documento será aberto por pessoas com objetivos incompatíveis. A diretoria quer saber se precisa se preocupar e quanto vai custar. O gerente de tecnologia quer saber o que priorizar com a equipe que tem. O desenvolvedor quer saber exatamente o que mudar no código dele. O auditor quer saber se o trabalho foi feito com método.\n\nA solução não é escrever quatro documentos, é estruturar em camadas de profundidade crescente e deixar claro onde cada leitor deve parar. Sumário executivo sem termo técnico, visão geral com a lista priorizada, achados detalhados para quem corrige e anexos para quem precisa provar. Cada camada precisa fazer sentido sozinha, porque ninguém lê tudo.\n\nUm cuidado que rende: a mesma informação aparecendo em camadas diferentes precisa ser consistente. Achado descrito como crítico no detalhe e citado como preocupação moderada no sumário destrói a confiança no documento inteiro. Revisar a coerência entre camadas é uma das últimas etapas antes de entregar, e é onde aparecem os erros mais constrangedores.",
+                },
+                {
+                    type: "quote",
+                    value: "O cliente não viu o seu terminal. Ele viu um documento. É por ele que o trabalho será julgado, e é nele que profissionais tecnicamente bons costumam perder contrato.",
+                },
+                {
+                    type: "text",
+                    value: "## Erros que aparecem em relatório real\n\nO primeiro é o despejo de ferramenta: páginas de saída bruta coladas, com dezenas de itens informativos misturados aos três achados que importam. Isso não é mais completude, é menos: o leitor não consegue separar o relevante e acaba não fazendo nada.\n\nO segundo é a recomendação genérica. Escrever que o cliente deve aplicar as melhores práticas do setor, manter os sistemas atualizados e treinar a equipe é o mesmo que não escrever nada. Recomendação útil aponta o que mudar, onde e com que efeito, no sistema daquele cliente.\n\nO terceiro é o tom. Relatório de segurança não é lugar para ironia, para exibir habilidade ou para constranger quem construiu o sistema. Quem vai corrigir é quem escreveu aquele código, e vai lê-lo sentado ao lado do chefe. Texto respeitoso e factual aumenta a chance de correção, e texto arrogante gera defesa e discussão sobre a validade do achado.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que o relatório é considerado o produto do teste?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "É o que o cliente recebe e o que sobra do projeto",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "É a exigência formal de auditoria em qualquer teste",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "É onde a metodologia adotada precisa ser comprovada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "É a peça que define o valor cobrado pelo serviço",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Que teste simples indica que um achado está bem escrito?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Alguém de fora entende, reproduz e sabe o que mudar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O texto cita a referência pública e a nota atribuída",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A descrição cabe em menos de uma página do documento",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A evidência anexada mostra a tela do sistema afetado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como atender leitores com objetivos diferentes no mesmo documento?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Camadas de profundidade que funcionam sozinhas", isCorrect: true },
+                        { text: "Documentos separados para cada público-alvo", isCorrect: false },
+                        { text: "Glossário técnico no início do relatório", isCorrect: false },
+                        { text: "Resumo repetido no começo de cada seção", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual é o problema de colar a saída bruta da ferramenta no relatório?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O leitor não separa o relevante e acaba não agindo",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O documento fica grande demais para ser distribuído",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A licença da ferramenta costuma proibir esse uso",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "As notas do fabricante conflitam com as do mercado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que o tom do relatório afeta o resultado prático do trabalho?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Quem corrige é quem escreveu, e texto arrogante gera defesa",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O jurídico do cliente revisa a linguagem antes de aprovar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A auditoria avalia a formalidade do documento entregue",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O contrato costuma prever revisão do texto pelo cliente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Escrevendo um achado",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Cinco perguntas, sempre na mesma ordem\n\nUm achado bem escrito responde cinco coisas: o que está errado, onde está, o que isso permite, como comprovar e o que fazer. Manter essa ordem em todos os itens do relatório tem um efeito prático grande, porque o leitor aprende o formato no primeiro achado e navega os outros vinte em segundos.\n\nO título merece atenção desproporcional ao tamanho, porque é o que aparece em planilha de acompanhamento e em reunião de gestão. Título bom descreve o problema e o lugar, não a categoria genérica. Falha de controle de acesso na exportação de relatórios permite ler dados de outra empresa diz tudo; controle de acesso quebrado não diz nada.\n\nA seção de impacto é a que mais gente escreve mal, porque repete a descrição com outras palavras. Impacto não é o que a falha é, é o que ela causa. A pergunta que resolve: se um adversário usar isso amanhã de manhã, o que ele consegue, com quantos cliques, sobre quantos registros. Se você não consegue responder, o achado ainda não foi analisado até o fim.",
+                },
+                {
+                    type: "table",
+                    value: '[["Campo do achado","Pergunta que responde","Erro frequente"],["Título","Qual é o problema e onde","Categoria genérica sem contexto"],["Descrição","O que exatamente está errado","Explicação teórica da classe de falha"],["Impacto","O que isso permite fazer","Repetir a descrição com outras palavras"],["Evidência","Como sei que é verdade","Captura solta sem contexto nem horário"],["Reprodução","Como ver acontecer de novo","Passos que só funcionam para o autor"],["Correção","O que mudar, onde e por quê","Recomendação genérica de boa prática"],["Severidade","Quanto isso pesa aqui","Nota do catálogo sem ajuste de contexto"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Reprodução e correção são para o outro\n\nOs passos de reprodução precisam funcionar para alguém que não esteve lá. Isso significa dizer com qual perfil começar, qual é o estado inicial necessário, qual é a sequência exata e qual é o resultado esperado. O erro clássico é escrever passos que dependem de contexto que só existia na sua sessão, e o sintoma disso aparece no reteste, quando ninguém consegue confirmar a falha nem a correção.\n\nA recomendação precisa ser específica e viável para aquele cliente. Trocar o componente por uma versão corrigida é específico. Adotar defesa em profundidade não é. E vale reconhecer restrição real: se o sistema é um pacote de terceiro que não recebe atualização, a recomendação certa não é corrigir o código, é restringir acesso, monitorar o uso e planejar substituição, com o risco residual declarado.\n\nUm hábito que eleva muito a qualidade percebida é oferecer duas opções quando elas existem: a correção definitiva e a mitigação imediata. O time raramente consegue trocar o componente central nesta semana, mas quase sempre consegue restringir o acesso hoje. Escrever as duas coisas, com a diferença de proteção entre elas, é o tipo de detalhe que faz o cliente voltar a te contratar.",
+                },
+                {
+                    type: "quote",
+                    value: "Impacto não é o que a falha é, é o que ela causa. Se você não sabe dizer o que um adversário consegue amanhã de manhã, o achado ainda não foi analisado até o fim.",
+                },
+                {
+                    type: "text",
+                    value: "## O achado que ninguém consegue corrigir\n\nAlguns achados não têm correção simples porque são consequência de decisão de arquitetura. Uma aplicação que autentica bem mas nunca separou dados entre clientes, um sistema legado sem suporte que sustenta um processo central, uma integração que exige credencial compartilhada por desenho. Escrever isso como se fosse um item de correção rápida cria frustração e faz o achado ser ignorado.\n\nO tratamento adequado separa o que é conserto do que é projeto. Descreva o risco, proponha a mitigação possível no curto prazo, aponte a mudança estrutural necessária e diga que ela é um projeto com prazo e orçamento próprios. Isso dá ao cliente linguagem para levar o tema adiante internamente, que é o que ele precisa.\n\nExiste também a categoria de achado que o cliente vai aceitar como risco, e isso é legítimo. Nem todo risco precisa ser eliminado; parte é assumida conscientemente. O seu papel é garantir que a aceitação seja informada: consequência descrita, condições em que ela mudaria e quem decidiu aceitar. Risco aceito com registro é gestão; risco aceito por esquecimento é acidente esperando data.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais perguntas um achado bem escrito responde?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "O que, onde, o que permite, como provar e o que fazer",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Quem achou, quando achou, com qual ferramenta e nota",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Qual classe, qual catálogo, qual versão e qual produto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Qual risco, qual custo, qual prazo e qual responsável",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza um bom título de achado?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Descreve o problema e o lugar em que ele ocorre",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Cita a categoria técnica reconhecida no mercado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Informa a nota de severidade logo na primeira linha",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Menciona a ferramenta que encontrou aquele problema",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual é o erro mais comum na seção de impacto?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Repetir a descrição da falha com outras palavras",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Usar linguagem simples demais para o time técnico",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Citar a nota atribuída pelo catálogo público usado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Descrever o caminho completo até o dado alcançado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O sistema é um pacote de terceiro sem atualização disponível. Qual recomendação cabe?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Restringir acesso, monitorar uso e planejar substituição",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Aplicar correção no código-fonte do pacote adquirido",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Aguardar a próxima versão publicada pelo fornecedor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Remover o sistema do escopo por ausência de solução",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O cliente decide aceitar um risco em vez de corrigir. Qual é o seu papel nisso?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Garantir que a aceitação fique informada e registrada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Insistir na correção até que a decisão seja revertida",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Retirar o achado do relatório a pedido do contratante",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Elevar a severidade para forçar a revisão da decisão",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Sumário executivo sem jargão",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma página para quem decide\n\nO sumário executivo é lido por quem aprova orçamento e por quem responde legalmente pela empresa. Essas pessoas têm pouco tempo, não vão abrir o anexo e frequentemente vão decidir com base apenas nessa página. Escrevê-la bem é a habilidade de comunicação mais valiosa da profissão, e a que menos se pratica.\n\nA regra número um é eliminar jargão. Não é simplificar até virar vazio, é dizer a mesma coisa em português comum. Em vez de escrever que foi identificada referência direta insegura a objeto, escreva que um usuário comum conseguiu acessar documentos de outra empresa apenas trocando um número no endereço. A segunda frase é mais precisa, não menos, e qualquer pessoa entende.\n\nA estrutura que funciona tem quatro partes curtas. O que foi avaliado e em que período. Qual é a situação geral, em uma frase honesta. Quais são os dois ou três pontos que exigem decisão, com a consequência de cada um. E o que se recomenda fazer, em que ordem e com que urgência. Nada de gráfico de aranha, nada de tabela com dezenas de linhas, nada de nome de ferramenta.",
+                },
+                {
+                    type: "table",
+                    value: '[["Em vez de escrever","Escreva","Por quê"],["Referência insegura a objeto","Trocar um número no endereço abre dados de outro cliente","Descreve o efeito, não o rótulo"],["Ausência de segundo fator","Só a senha basta para entrar em sistema de folha","Diz o que protege e o que não protege"],["Injeção detectada no filtro de busca","Uma busca alterada permitiu consultar a base inteira","Mostra a consequência concreta"],["Superfície de ataque elevada","Existem sistemas na internet fora do controle da TI","Fala do problema de gestão, não do termo"],["Risco crítico identificado","Um estranho chegaria aos contratos em poucas horas","Substitui adjetivo por cenário verificável"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Honestidade sobre o que não foi visto\n\nUm sumário executivo bom diz o que não foi testado, e essa é a parte que separa profissional de vendedor. Se um sistema ficou fora por indisponibilidade do ambiente, se metade dos perfis não foi coberta por falta de credencial, se a janela permitiu apenas testes leves em produção, isso precisa estar visível na primeira página, e não escondido no apêndice.\n\nO motivo é direto. Executivo que lê um relatório sem ressalvas conclui que a empresa está avaliada, e passa a tomar decisão sobre uma cobertura que não existiu. Quando o incidente acontecer justamente na parte não testada, a conversa vai ser sobre o que o seu documento deixou implícito. Limitação declarada protege o cliente e protege você.\n\nO oposto também vale: não escreva que a empresa está segura. Nenhum teste autoriza essa frase. O que se pode afirmar com honestidade é que, no período avaliado, com o escopo e o tempo definidos, foram encontrados os problemas listados e não foram encontrados outros. Essa formulação parece burocrática na primeira leitura e é o que mantém a sua palavra confiável ao longo de uma carreira inteira.",
+                },
+                {
+                    type: "quote",
+                    value: "Nenhum teste autoriza dizer que a empresa está segura. O que se afirma é o que foi avaliado, em que período, e o que foi encontrado dentro desse recorte.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quem é o leitor real do sumário executivo?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Quem aprova orçamento e responde pela empresa", isCorrect: true },
+                        {
+                            text: "O time de desenvolvimento que vai corrigir tudo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O auditor que avalia a metodologia do trabalho",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O analista que conduzirá o reteste dos achados",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como reescrever um termo técnico para o sumário executivo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Descrevendo o efeito concreto em português comum",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Adicionando a definição do termo entre parênteses",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Mantendo o termo e incluindo um glossário no fim",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Substituindo por um adjetivo de gravidade adequado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quais partes compõem um sumário executivo eficaz?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O que foi avaliado, situação, pontos e recomendação",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Metodologia, ferramentas, cronograma e equipe usada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Lista de achados, notas, evidências e correções",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Escopo, contatos, janela de execução e limitações",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que declarar as limitações logo na primeira página?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Sem elas, o executivo decide sobre cobertura inexistente",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A auditoria exige esse item no início de todo relatório",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O documento fica mais curto ao evitar repetição depois",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O cliente costuma pedir desconto quando algo ficou fora",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual formulação é honesta ao concluir sobre a postura de segurança avaliada?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "No escopo e período avaliados, foi encontrado o que segue",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A empresa apresenta postura de segurança adequada ao setor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Não foram identificadas vulnerabilidades críticas no ambiente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O ambiente está protegido contra os ataques mais comuns hoje",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Reteste e acompanhamento",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O trabalho só termina quando a falha some\n\nEntregar o relatório e sumir é o padrão de mercado, e é também a razão pela qual muita empresa acumula testes sem melhorar. Reteste é a etapa em que você verifica se a correção aplicada realmente resolveu, e ela costuma valer mais para o cliente do que o teste original, porque é ali que o dinheiro gasto vira redução de risco.\n\nO reteste tem três resultados possíveis, e vale nomear os três. Corrigido: o caminho não funciona mais e a causa foi tratada. Mitigado: o caminho foi bloqueado por uma barreira externa, mas a falha continua existindo por baixo. Não corrigido: nada mudou, ou a mudança não afeta o problema. Chamar mitigado de corrigido é o erro mais comum e o mais perigoso, porque a barreira externa pode ser removida numa mudança de arquitetura sem que ninguém lembre do que ela protegia.\n\nExiste um quarto resultado que aparece com frequência e merece atenção especial: a correção resolveu o caminho testado e não resolveu a classe. O time consertou o endpoint que você citou no relatório e deixou os outros seis que têm o mesmo padrão. Isso acontece porque o relatório descreveu um caso, e o desenvolvedor corrigiu o caso. Escrever explicitamente que a falha é de padrão, e não de local, reduz muito essa perda.",
+                },
+                {
+                    type: "table",
+                    value: '[["Resultado do reteste","O que significa","Como registrar"],["Corrigido","A causa foi tratada e o caminho não existe","Fechar com a evidência da nova tentativa"],["Mitigado","Barreira externa bloqueia, falha permanece","Manter aberto com risco residual descrito"],["Não corrigido","Nada mudou no comportamento observado","Reafirmar impacto e prazo recomendado"],["Parcial","O caso citado foi tratado, o padrão não","Listar os pontos equivalentes encontrados"],["Regressão","Voltou depois de uma nova implantação","Sinalizar falha de processo, não só técnica"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Combinar o reteste antes, não depois\n\nA hora de definir reteste é na proposta, junto com o escopo. Quantas rodadas estão incluídas, em que prazo depois da entrega, o que exatamente será verificado e o que acontece se o cliente pedir depois do prazo. Deixar isso em aberto produz duas situações ruins: o cliente que acha que reteste é de graça e infinito, e o cliente que nunca faz porque não sabia que podia pedir.\n\nO escopo do reteste também precisa estar claro. O padrão razoável é verificar os achados reportados e o que estiver diretamente ligado a eles. Se a aplicação mudou bastante desde o teste original, verificar apenas os achados antigos dá uma sensação de segurança que não corresponde ao sistema atual, e isso deve ser dito no documento de reteste.\n\nUm efeito colateral bom do reteste é o aprendizado que ele te dá sobre o próprio relatório. Achado que ninguém conseguiu reproduzir estava mal escrito. Achado corrigido de forma errada foi explicado de forma ambígua. Achado que o time não priorizou talvez tivesse o impacto mal traduzido. Poucas coisas melhoram tanto a qualidade da escrita quanto ver o que aconteceu com o que você escreveu.",
+                },
+                {
+                    type: "quote",
+                    value: "Mitigado não é corrigido. A barreira externa que bloqueia o caminho hoje pode sair numa mudança de arquitetura, e ninguém vai lembrar do que ela estava protegendo.",
+                },
+                {
+                    type: "text",
+                    value: "## Acompanhar sem virar consultoria eterna\n\nEntre o relatório e o reteste existe um espaço em que o cliente vai ter dúvidas, e responder a elas é bom para todo mundo. O limite profissional é simples: esclarecer o achado e a recomendação faz parte do serviço; projetar a solução, revisar código e acompanhar a implementação é outro trabalho, com outro contrato.\n\nEsse limite também protege a independência de quem avalia. Testador que desenha a correção e depois valida a própria correção perde a distância necessária para avaliar. Em ambientes com exigência de auditoria isso é explicitamente proibido, e mesmo onde não é, vale manter a separação por higiene profissional.\n\nO fechamento ideal de um ciclo é um documento curto de reteste, com o estado de cada achado, a evidência da verificação e o que permanece em aberto com o risco residual declarado. Esse documento é o que o cliente leva para a auditoria, para o cliente dele e para a diretoria, e é frequentemente o que motiva a contratação do ciclo seguinte.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais são os resultados possíveis de um reteste?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Corrigido, mitigado, não corrigido, parcial ou regressão",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Aprovado, reprovado, pendente, adiado ou cancelado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Aceito, tratado, transferido, evitado ou monitorado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Confirmado, refutado, inconclusivo, novo ou repetido",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que chamar um achado mitigado de corrigido é perigoso?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "A barreira externa pode sair e a falha continua ali",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O cliente deixa de pagar pela rodada de verificação",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A auditoria não aceita mitigação como tratamento",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A nota de severidade original deixa de ser válida",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O time corrigiu o endpoint citado e deixou seis outros com o mesmo padrão. O que reduz isso?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Escrever que a falha é de padrão, e não de local",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Listar todos os endpoints afetados no anexo final",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Elevar a severidade do achado para forçar atenção",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Repetir o mesmo achado uma vez para cada endpoint",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quando o reteste deve ser combinado?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Na proposta, com rodadas, prazo e escopo definidos",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Na entrega do relatório, conforme o interesse do cliente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Após a correção, quando o time avisar que terminou",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "No fim do prazo contratual, se ainda houver saldo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que quem testou não deveria projetar e depois validar a própria correção?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Perde a distância necessária para avaliar com isenção",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Aumenta o custo total do projeto para o contratante",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Exige conhecimento de desenvolvimento que ele não tem",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Atrasa o cronograma de correção definido pelo cliente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Carreira, certificação e o que você leva daqui",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma profissão que se sustenta em confiança\n\nO ativo central de quem faz teste de intrusão não é a técnica: é a confiança. Empresas entregam a você credenciais, código-fonte, acesso a sistemas que sustentam o faturamento e a informação de que estão vulneráveis. Isso só funciona porque existe uma expectativa de conduta, e ela é construída em anos e perdida em um episódio.\n\nNa prática, isso se traduz em comportamentos chatos e inegociáveis. Não testar o que não está autorizado, nem por curiosidade. Não guardar material de cliente além do prazo. Não usar caso real como exemplo em palestra, curso ou conversa de bar, nem anonimizado, porque quem é do ramo reconhece. Não inflar achado para justificar preço. Não aceitar projeto que você sabe que não vai ajudar.\n\nCertificação entra nessa conversa como ferramenta, não como identidade. Ela abre porta em processo seletivo, atende exigência de edital e organiza estudo, e isso já é bastante. O que ela não faz é substituir julgamento: existe gente muito certificada que escreve relatório ruim e gente sem certificação nenhuma que o cliente chama todo ano. As duas coisas convivem, e vale escolher com objetivo declarado, e não por ansiedade.",
+                },
+                {
+                    type: "table",
+                    value: '[["Investimento","O que ele resolve de fato","O que ele não resolve"],["Certificação prática","Prova que você executa e documenta","Julgamento de escopo e conversa com cliente"],["Certificação de gestão","Vocabulário de risco e conformidade","Habilidade técnica de encontrar falha"],["Laboratório próprio","Prática segura e repetível","Realismo de ambiente corporativo"],["Programa de recompensa","Exposição a alvos reais com regra","Método completo de um projeto pago"],["Escrever e revisar relatório","Comunicação, que é o gargalo real","Profundidade técnica em pilha nova"],["Trabalhar com quem tem estrada","Critério, que não se aprende sozinho","Tempo, que nenhum atalho substitui"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Como continuar praticando com honestidade\n\nA parte difícil da carreira ofensiva é praticar sem alvo. A resposta correta é laboratório próprio, com máquinas virtuais e aplicações feitas para isso, e programas de recompensa com política publicada, respeitando o escopo à risca. Fora disso não existe atalho legítimo, e a curiosidade que ignora esse limite é a que termina em processo, como o módulo um descreveu.\n\nUm exercício que rende mais do que parece: pegue uma aplicação de treino, encontre uma falha e escreva o achado completo como se fosse entregar a um cliente, com impacto, evidência, reprodução e correção. Depois releia uma semana depois e tente reproduzir seguindo só o que escreveu. Isso treina exatamente o que o mercado paga e quase ninguém pratica de propósito.\n\nOutro caminho subestimado é olhar do outro lado. Quem já defendeu, respondeu a incidente ou escreveu código de produção testa melhor, porque entende o que é viável corrigir, o que gera alerta e por que certas decisões ruins foram tomadas. A experiência de construir e a de defender melhoram o testador de um jeito que nenhum curso ofensivo consegue.",
+                },
+                {
+                    type: "quote",
+                    value: "O ativo dessa profissão é confiança. Ela se constrói em anos de conduta chata e inegociável, e some em um episódio que você vai passar o resto da carreira explicando.",
+                },
+                {
+                    type: "text",
+                    value: "# O que esta trilha te deixou\n\nVocê começou entendendo que a diferença entre profissão e crime é uma assinatura, e não uma técnica. Passou por escopo, autorização e regras de engajamento, que são a parte do trabalho que nenhuma ferramenta faz por você. Percorreu reconhecimento, análise de vulnerabilidade, raciocínio de exploração e pós-exploração como um método encadeado, em que cada fase existe para responder uma pergunta específica.\n\nO fio condutor foi um só: julgamento acima de execução. Decidir o que testar e o que deixar de fora, quando parar, o que uma falha significa naquele ambiente, quanto de prova é suficiente e como dizer isso para quem decide. Comandos mudam a cada versão; essas decisões são as mesmas há vinte anos e continuarão sendo.\n\nA próxima trilha do seu roadmap vai pegar esse repertório e aplicar em outro recorte, e a melhor forma de chegar nela é praticando o que você viu aqui: método escrito, escopo respeitado, achado bem redigido. Se você levar uma única frase, leve esta: o produto do seu trabalho não é o acesso que você obteve, é a decisão que o cliente conseguiu tomar por causa dele.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é o ativo central de quem faz teste de intrusão?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "A confiança que o cliente deposita no profissional",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A profundidade técnica nas ferramentas mais usadas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A quantidade de certificações obtidas na carreira",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A rede de contatos construída dentro do mercado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual é o papel correto de uma certificação na carreira?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Abrir porta e organizar estudo, sem substituir julgamento",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Comprovar que o profissional domina qualquer ambiente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Garantir acesso aos contratos de maior valor do mercado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Dispensar a necessidade de prática em laboratório próprio",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde praticar teste ofensivo de forma legítima?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Laboratório próprio e programas com política publicada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Sites públicos, desde que a falha seja comunicada depois",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ambiente de ex-empregadores em que o acesso ainda existe",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Alvos escolhidos ao acaso, com testes leves e sem impacto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que quem já defendeu ou escreveu código de produção tende a testar melhor?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Entende o que é viável corrigir e o que gera alerta",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Conhece as ferramentas ofensivas com mais profundidade",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Tem acesso facilitado a ambientes reais para praticar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Consegue negociar escopos maiores com o time técnico",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual é o fio condutor desta trilha?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Julgamento profissional acima da execução técnica",
+                            isCorrect: true,
+                        },
+                        { text: "Domínio de ferramentas ofensivas atualizadas", isCorrect: false },
+                        { text: "Aderência estrita a uma metodologia pública", isCorrect: false },
+                        { text: "Documentação detalhada de todas as etapas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log(
+                "Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.",
+            );
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluido: " +
+            MODULOS.length +
+            " modulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questoes.",
+    );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}


### PR DESCRIPTION
Terceira trilha do roadmap **Segurança**: **Pentest com Método** (avançado, 20h), estágio 7. Entra depois de #346 e #347, já mergeadas.

É a primeira trilha ofensiva do catálogo, e o escopo dela foi decidido antes de escrever a primeira linha.

## O corte de escopo, e por que ele é assim

A trilha ensina teste de intrusão como **método e profissão**: metodologia, escopo e autorização, ética e lei, reconhecimento, análise de vulnerabilidade, o raciocínio por trás da exploração, tradução de impacto para o negócio e o relatório profissional.

Fica deliberadamente de fora: código de exploração pronto, comando de ataque para copiar, técnica de evasão de detecção e construção de infraestrutura de comando e controle.

O motivo é duplo. Responsabilidade, porque receita pronta serve a quem não deveria tê-la. E pedagogia, porque decorar comando não forma profissional: quem entende por que a falha existe resolve casos que o comando não cobre, e quem só decorou trava no primeiro ambiente diferente.

**Verificado, não prometido.** Varri os sete módulos atrás dos termos que não podiam aparecer (ferramentas de exploração conhecidas, shell reverso, payload, evasão, ferramentas de credencial): nenhuma ocorrência. A trilha tem **zero blocos de código**, ou seja, nenhum comando executável em nenhuma das 35 aulas.

## Conteúdo

7 módulos, 35 aulas, 175 questões, zero aviso de régua:

1. **O que é um teste de intrusão**: teste, varredura e simulação de adversário são coisas distintas; caixa preta, cinza e branca escolhidas pela ameaça que se teme; escopo, regras de engajamento e quem tem poder de assinar; o art. 154-A, com a autorização como única fronteira entre profissão e crime; PTES, NIST 800-115, WSTG, ASVS e OSSTMM com o uso real de cada um.
2. **Antes de tocar em qualquer coisa**: descobrir o problema por trás do pedido; escopo sem buraco e sem ativo de terceiro; janela, canal fora do ambiente testado e plano de contingência; critérios de parada e o protocolo para quando se encontra comprometimento prévio; diário cronológico separado da lista de achados.
3. **Reconhecimento**: fontes abertas e o limite entre coletar e usar; rastro ativo lido como métrica da defesa do cliente; enumeração em que configuração rende mais que versão; mapeamento web como inventário; fator humano só com autorização própria, medindo denúncia e não taxa de clique.
4. **Análise de vulnerabilidade**: o scanner como fila de hipóteses, não como resultado; validação em três perguntas com reprodutibilidade obrigatória; severidade ajustada por contexto e separada de prioridade; encadeamento que atravessa fronteira; a lista do que não se testa e a pergunta da menor ação que prova o ponto.
5. **Raciocínio de exploração**: explorar como quebrar uma suposição do desenvolvedor; autenticação e sessão; autorização e lógica de negócio, o território que scanner não alcança; injeção pelo modelo de dado virando instrução; prova de conceito mínima, reversível e verificável.
6. **Pós-exploração e o que ela demonstra**: impacto em vez de coleção de acessos; alcance técnico separado de autorização; tradução para vazamento, interrupção, fraude e obrigação legal; evidência com custódia do dado do cliente; limpeza registrada e devolução do ambiente.
7. **O relatório e a carreira**: o documento como produto, em camadas para leitores diferentes; o achado com correção viável e risco aceito registrado; sumário executivo sem jargão e sem afirmar que a empresa está segura; reteste com mitigado distinto de corrigido; carreira e certificação como ferramenta.

Fontes abertas apenas: PTES, OWASP, NIST, OSSTMM, CIS.

## Integração

- `seed-trilha-pentest-com-metodo.ts` novo (idempotente, 20h).
- Entradas em detalhes e na categoria Cibersegurança.
- O estágio 7 já está declarado no seed do roadmap; rodá-lo de novo conecta a referência.

## Seeds em prod (após merge e release, nesta ordem)

```
docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-pentest-com-metodo.ts
docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-roadmap-seguranca.ts
docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-detalhes-trilhas.ts
docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-categorias-trilhas.ts
docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-conquistas-trilhas.ts
```

Validado em Postgres efêmero: 35 aulas publicadas, 175 questões, 700 opções, nenhuma aula fora do padrão de 5 questões, nenhuma questão com número errado de corretas, e rodar de novo não duplica. tsc e prettier limpos.