### PR TITLE
feat: registra o roadmap que o aluno segue para acertar a próxima trilha

### DIFF
--- a/backend/drizzle/0054_user_roadmaps.sql
+++ b/backend/drizzle/0054_user_roadmaps.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "user_roadmaps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"roadmap_id" uuid NOT NULL,
+	"explicito" boolean DEFAULT false NOT NULL,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_roadmaps_user_id_roadmap_id_unique" UNIQUE("user_id","roadmap_id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_roadmaps" ADD CONSTRAINT "user_roadmaps_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_roadmaps" ADD CONSTRAINT "user_roadmaps_roadmap_id_roadmaps_id_fk" FOREIGN KEY ("roadmap_id") REFERENCES "public"."roadmaps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_roadmaps_user_id_idx" ON "user_roadmaps" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "user_roadmaps_roadmap_id_idx" ON "user_roadmaps" USING btree ("roadmap_id");

--- a/backend/drizzle/meta/0054_snapshot.json
+++ b/backend/drizzle/meta/0054_snapshot.json
@@ -1,0 +1,4567 @@
+{
+  "id": "f3459b7b-9ac6-4cb6-94d0-b40e01306c4b",
+  "prevId": "e6d67f65-a0d7-4141-967e-29b7f23c6477",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "certificates_trail_id_idx": {
+          "name": "certificates_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_trail_id_trails_id_fk": {
+          "name": "certificates_trail_id_trails_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificates_code_unique": {
+          "name": "certificates_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "certificates_user_id_trail_id_unique": {
+          "name": "certificates_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_comments": {
+      "name": "challenge_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_comments_challenge_id_idx": {
+          "name": "challenge_comments_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_comments_user_id_idx": {
+          "name": "challenge_comments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_comments_challenge_id_challenges_id_fk": {
+          "name": "challenge_comments_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_comments",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_comments_user_id_users_id_fk": {
+          "name": "challenge_comments_user_id_users_id_fk",
+          "tableFrom": "challenge_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_submissions_user_id_idx": {
+          "name": "challenge_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_submissions_challenge_id_idx": {
+          "name": "challenge_submissions_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "challenge_tests_challenge_id_idx": {
+          "name": "challenge_tests_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comment_likes": {
+      "name": "community_comment_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_comment_likes_user_id_idx": {
+          "name": "community_comment_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comment_likes_comment_id_community_comments_id_fk": {
+          "name": "community_comment_likes_comment_id_community_comments_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_comment_likes_user_id_users_id_fk": {
+          "name": "community_comment_likes_user_id_users_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_comment_likes_comment_id_user_id_unique": {
+          "name": "community_comment_likes_comment_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_comments_post_id_idx": {
+          "name": "community_comments_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_comments_user_id_idx": {
+          "name": "community_comments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_comments_parent_id_idx": {
+          "name": "community_comments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_comments_user_id_users_id_fk": {
+          "name": "community_comments_user_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_comments_parent_id_community_comments_id_fk": {
+          "name": "community_comments_parent_id_community_comments_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_likes": {
+      "name": "community_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_likes_user_id_idx": {
+          "name": "community_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_likes_post_id_community_posts_id_fk": {
+          "name": "community_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_likes_user_id_users_id_fk": {
+          "name": "community_likes_user_id_users_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_likes_post_id_user_id_unique": {
+          "name": "community_likes_post_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_post_tags": {
+      "name": "community_post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_post_tags_post_id_community_posts_id_fk": {
+          "name": "community_post_tags_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_tags",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_post_tags_post_id_tag_unique": {
+          "name": "community_post_tags_post_id_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "community_post_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_language": {
+          "name": "code_language",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_posts_user_id_idx": {
+          "name": "community_posts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_user_id_users_id_fk": {
+          "name": "community_posts_user_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comunicado_respostas_user_id_idx": {
+          "name": "comunicado_respostas_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flag_users": {
+      "name": "feature_flag_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "flag_id": {
+          "name": "flag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flag_users_user_id_idx": {
+          "name": "feature_flag_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_flag_users_flag_id_feature_flags_id_fk": {
+          "name": "feature_flag_users_flag_id_feature_flags_id_fk",
+          "tableFrom": "feature_flag_users",
+          "tableTo": "feature_flags",
+          "columnsFrom": [
+            "flag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feature_flag_users_user_id_users_id_fk": {
+          "name": "feature_flag_users_user_id_users_id_fk",
+          "tableFrom": "feature_flag_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flag_users_flag_id_user_id_unique": {
+          "name": "feature_flag_users_flag_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flag_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "feature_flag_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lessons_progress_lesson_id_idx": {
+          "name": "lessons_progress_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lessons_trail_id_idx": {
+          "name": "lessons_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_module_id_idx": {
+          "name": "lessons_module_id_idx",
+          "columns": [
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "modules_trail_id_idx": {
+          "name": "modules_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_accounts_user_id_idx": {
+          "name": "oauth_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_answers_question_id_idx": {
+          "name": "question_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_answers_selected_option_id_idx": {
+          "name": "question_answers_selected_option_id_idx",
+          "columns": [
+            {
+              "expression": "selected_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "question_options_question_id_idx": {
+          "name": "question_options_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_lesson_id_idx": {
+          "name": "questions_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resume_analyses": {
+      "name": "resume_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "resume_analysis_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breakdown": {
+          "name": "breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords_found": {
+          "name": "keywords_found",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords_partial": {
+          "name": "keywords_partial",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords_missing": {
+          "name": "keywords_missing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resume_analyses_user_id_idx": {
+          "name": "resume_analyses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resume_analyses_user_id_users_id_fk": {
+          "name": "resume_analyses_user_id_users_id_fk",
+          "tableFrom": "resume_analyses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_stage_completions_stage_id_idx": {
+          "name": "roadmap_stage_completions_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "roadmap_stage_refs_stage_id_idx": {
+          "name": "roadmap_stage_refs_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_stages_roadmap_id_idx": {
+          "name": "roadmap_stages_roadmap_id_idx",
+          "columns": [
+            {
+              "expression": "roadmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_attempt_answers_question_id_idx": {
+          "name": "simulado_attempt_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulado_attempt_answers_option_id_idx": {
+          "name": "simulado_attempt_answers_option_id_idx",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "simulado_attempt_questions_question_id_idx": {
+          "name": "simulado_attempt_questions_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalizado": {
+          "name": "personalizado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topicos": {
+          "name": "topicos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "simulado_attempts_user_id_idx": {
+          "name": "simulado_attempts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulado_attempts_simulado_id_idx": {
+          "name": "simulado_attempts_simulado_id_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_options_question_id_idx": {
+          "name": "simulado_options_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulado_questions_simulado_id_idx": {
+          "name": "simulado_questions_simulado_id_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pendente'"
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'abacatepay'"
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tokens_user_id_idx": {
+          "name": "tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_reviews_trail_id_idx": {
+          "name": "trail_reviews_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trail_tags_tag_id_idx": {
+          "name": "trail_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified": {
+          "name": "notified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_achievements_achievement_id_idx": {
+          "name": "user_achievements_achievement_id_idx",
+          "columns": [
+            {
+              "expression": "achievement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_following_id_idx": {
+          "name": "user_follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follows_follower_id_following_id_unique": {
+          "name": "user_follows_follower_id_following_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roadmaps": {
+      "name": "user_roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explicito": {
+          "name": "explicito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_roadmaps_user_id_idx": {
+          "name": "user_roadmaps_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_roadmaps_roadmap_id_idx": {
+          "name": "user_roadmaps_roadmap_id_idx",
+          "columns": [
+            {
+              "expression": "roadmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roadmaps_user_id_users_id_fk": {
+          "name": "user_roadmaps_user_id_users_id_fk",
+          "tableFrom": "user_roadmaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_roadmaps_roadmap_id_roadmaps_id_fk": {
+          "name": "user_roadmaps_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "user_roadmaps",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roadmaps_user_id_roadmap_id_unique": {
+          "name": "user_roadmaps_user_id_roadmap_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "roadmap_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_kind": {
+          "name": "weekly_goal_kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_target": {
+          "name": "weekly_goal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_url": {
+          "name": "background_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_dim": {
+          "name": "background_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special",
+        "streak_days",
+        "challenges_facil",
+        "challenges_medio",
+        "challenges_dificil",
+        "trail_completed"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.community_post_kind": {
+      "name": "community_post_kind",
+      "schema": "public",
+      "values": [
+        "duvida",
+        "solucao",
+        "conquista",
+        "post"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.feature_flag_status": {
+      "name": "feature_flag_status",
+      "schema": "public",
+      "values": [
+        "off",
+        "beta",
+        "on"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.resume_analysis_engine": {
+      "name": "resume_analysis_engine",
+      "schema": "public",
+      "values": [
+        "heuristica",
+        "ia"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "mensal",
+        "trimestral",
+        "anual",
+        "pix_auto"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pendente",
+        "ativa",
+        "cancelada"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1785931371631,
       "tag": "0053_feature_flags",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1786112440521,
+      "tag": "0054_user_roadmaps",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -631,6 +631,33 @@ export const roadmapStageRefs = pgTable(
     (table) => [index("roadmap_stage_refs_stage_id_idx").on(table.stageId)],
 );
 
+// Qual roadmap o aluno está seguindo. Guarda INTENÇÃO e RECÊNCIA, nunca progresso:
+// o progresso do roadmap continua derivado do progresso das trilhas, como sempre foi.
+// Existe porque a mesma trilha vive em vários roadmaps, e sem isso o app só conseguia
+// adivinhar qual caminho o aluno segue ao sugerir a próxima trilha.
+export const userRoadmaps = pgTable(
+    "user_roadmaps",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        userId: uuid("user_id")
+            .references(() => users.id)
+            .notNull(),
+        roadmapId: uuid("roadmap_id")
+            .references(() => roadmaps.id)
+            .notNull(),
+        // Verdadeiro quando o próprio aluno escolheu seguir; falso quando foi inferido
+        // do progresso dele. A escolha explícita sempre vence a inferência.
+        explicito: boolean("explicito").default(false).notNull(),
+        startedAt: timestamp("started_at", { withTimezone: true }).defaultNow().notNull(),
+        lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).defaultNow().notNull(),
+    },
+    (table) => [
+        unique().on(table.userId, table.roadmapId),
+        index("user_roadmaps_user_id_idx").on(table.userId),
+        index("user_roadmaps_roadmap_id_idx").on(table.roadmapId),
+    ],
+);
+
 export const comunicadoKind = pgEnum("comunicado_kind", ["aviso", "pesquisa"]);
 export const comunicadoRespostaStatus = pgEnum("comunicado_resposta_status", [
     "respondido",

--- a/backend/scripts/backfill-roadmap-seguido.ts
+++ b/backend/scripts/backfill-roadmap-seguido.ts
@@ -1,0 +1,154 @@
+// Preenche user_roadmaps para quem já estudava antes da tabela existir, inferindo
+// o caminho a partir do progresso. Grava como INFERIDO (explicito = false), então
+// a escolha do próprio aluno depois sempre vence.
+//
+// Dois sinais, os mesmos do runtime. O prefixo contínuo (quantos estágios seguidos,
+// a partir do primeiro, ele concluiu) captura a SEQUÊNCIA seguida, e é o que separa
+// casos que o volume não separa: quem fez Lógica, Python e SQL tem prefixo 3 em
+// Engenharia de Dados e 2 em Ciência de Dados, porque pulou Estatística. O peso por
+// exclusividade da trilha desempata: trilha que está em sete roadmaps quase não
+// informa, trilha exclusiva decide.
+//
+// Empate NÃO vira palpite: o aluno fica de fora e será resolvido no runtime assim
+// que tocar uma trilha que diferencie. Medido na base de produção em 2026-08-07,
+// decide cerca de um terço; o resto só fez trilha compartilhada e genuinamente
+// ainda não revelou caminho nenhum.
+//
+// Idempotente: quem já tem linha não é tocado. Só INSERE, nunca apaga nem altera
+// linha existente, então o pior caso é uma associação errada que o aluno corrige
+// sozinho ao seguir outro roadmap.
+//
+// ANTES DE RODAR EM PROD: tire um dump na hora. A rotina diária roda às 6h UTC e
+// guarda em /opt/ensinadev/backups na PRÓPRIA máquina do banco, então ela cobre
+// erro de operação e não cobre perda da VPS.
+//
+//   docker compose -f docker-compose.prod.yml exec -T db pg_dump -U <user> -Fc <db> > antes-backfill.dump
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/backfill-roadmap-seguido.ts
+import { db } from "../db.ts";
+import {
+    roadmaps,
+    roadmapStages,
+    roadmapStageRefs,
+    lessons,
+    lessonProgress,
+    userRoadmaps,
+} from "../schema.ts";
+import { eq, and } from "drizzle-orm";
+
+async function backfill() {
+    const publicados = await db.select().from(roadmaps).where(eq(roadmaps.published, true));
+    const etapas = await db.select().from(roadmapStages);
+    const refs = await db
+        .select()
+        .from(roadmapStageRefs)
+        .where(eq(roadmapStageRefs.refType, "trail"));
+
+    // trilha -> em quantos roadmaps publicados ela aparece (o peso)
+    const roadmapDaEtapa = new Map(etapas.map((e) => [e.id, e.roadmapId]));
+    const publicadosIds = new Set(publicados.map((r) => r.id));
+    const roadmapsDaTrilha = new Map<string, Set<string>>();
+    for (const r of refs) {
+        const rid = roadmapDaEtapa.get(r.stageId);
+        if (!rid || !publicadosIds.has(rid)) continue;
+        const s = roadmapsDaTrilha.get(r.refId) ?? new Set<string>();
+        s.add(rid);
+        roadmapsDaTrilha.set(r.refId, s);
+    }
+
+    // trilha -> aulas publicadas dela (para saber se o aluno concluiu a trilha)
+    const aulas = await db
+        .select({ id: lessons.id, trailId: lessons.trailId })
+        .from(lessons)
+        .where(eq(lessons.published, true));
+    const aulasDaTrilha = new Map<string, string[]>();
+    for (const a of aulas) {
+        const arr = aulasDaTrilha.get(a.trailId) ?? [];
+        arr.push(a.id);
+        aulasDaTrilha.set(a.trailId, arr);
+    }
+
+    // etapas por roadmap, em ordem, com as trilhas de cada uma
+    const etapasDoRoadmap = new Map<string, { position: number; trilhas: string[] }[]>();
+    for (const e of etapas) {
+        if (!publicadosIds.has(e.roadmapId)) continue;
+        const lista = etapasDoRoadmap.get(e.roadmapId) ?? [];
+        lista.push({
+            position: e.position,
+            trilhas: refs.filter((r) => r.stageId === e.id).map((r) => r.refId),
+        });
+        etapasDoRoadmap.set(e.roadmapId, lista);
+    }
+    for (const lista of etapasDoRoadmap.values()) lista.sort((a, b) => a.position - b.position);
+
+    const progresso = await db
+        .select({ userId: lessonProgress.userId, lessonId: lessonProgress.lessonId })
+        .from(lessonProgress);
+    const aulasDoAluno = new Map<string, Set<string>>();
+    for (const p of progresso) {
+        const s = aulasDoAluno.get(p.userId) ?? new Set<string>();
+        s.add(p.lessonId);
+        aulasDoAluno.set(p.userId, s);
+    }
+
+    const jaTem = new Set((await db.select().from(userRoadmaps)).map((u) => u.userId));
+
+    let decididos = 0;
+    let empatados = 0;
+    let pulados = 0;
+    for (const [userId, feitas] of aulasDoAluno) {
+        if (jaTem.has(userId)) {
+            pulados++;
+            continue;
+        }
+        const concluiu = (trailId: string) => {
+            const as = aulasDaTrilha.get(trailId);
+            return !!as?.length && as.every((id) => feitas.has(id));
+        };
+
+        const pontuados = publicados
+            .map((r) => {
+                const lista = etapasDoRoadmap.get(r.id) ?? [];
+                if (!lista.length) return null;
+                let prefixo = 0;
+                for (const e of lista) {
+                    if (!e.trilhas.some(concluiu)) break;
+                    prefixo++;
+                }
+                let pontos = 0;
+                for (const e of lista)
+                    for (const t of e.trilhas)
+                        if (concluiu(t)) pontos += 1 / (roadmapsDaTrilha.get(t)?.size ?? 1);
+                return { roadmapId: r.id, slug: r.slug, prefixo, pontos };
+            })
+            .filter((x): x is NonNullable<typeof x> => x !== null && x.pontos > 0);
+
+        if (!pontuados.length) continue;
+        const melhor = pontuados.reduce((a, b) =>
+            b.prefixo !== a.prefixo ? (b.prefixo > a.prefixo ? b : a) : b.pontos > a.pontos ? b : a,
+        );
+        const empate = pontuados.filter(
+            (p) => p.prefixo === melhor.prefixo && Math.abs(p.pontos - melhor.pontos) < 1e-9,
+        );
+        if (empate.length > 1) {
+            empatados++;
+            continue;
+        }
+
+        await db
+            .insert(userRoadmaps)
+            .values({ userId, roadmapId: melhor.roadmapId, explicito: false });
+        decididos++;
+    }
+
+    console.log(
+        `Backfill concluido: ${decididos} aluno(s) associados, ${empatados} sem sinal suficiente (ficam para o runtime), ${pulados} ja tinham registro.`,
+    );
+}
+
+backfill()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no backfill:", e);
+        process.exit(1);
+    });

--- a/backend/src/controllers/RoadmapController.ts
+++ b/backend/src/controllers/RoadmapController.ts
@@ -14,6 +14,8 @@ import {
     excluirEstagio,
     adicionarRef,
     removerRef,
+    seguirRoadmap,
+    registrarVisita,
 } from "../services/roadmap.service.ts";
 import {
     createRoadmapSchema,
@@ -37,7 +39,25 @@ export const getRoadmap = async (req: Request, res: Response, next: NextFunction
         const slug = typeof req.params.slug === "string" ? req.params.slug : "";
         const roadmap = await obterRoadmap(slug, req.userId);
         if (!roadmap) return res.status(404).json({ erro: "Roadmap não encontrado" });
+        // Abrir o detalhe atualiza a recência de quem JÁ segue, e só isso: abrir
+        // não faz ninguém passar a seguir, senão bastaria espiar um roadmap para
+        // o app achar que você mudou de caminho.
+        if (req.userId) await registrarVisita(req.userId, roadmap.id);
         res.json(roadmap);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// O aluno declara que está seguindo este roadmap. Idempotente: chamar de novo só
+// atualiza a data do último acesso.
+export const seguir = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const slug = typeof req.params.slug === "string" ? req.params.slug : "";
+        const roadmap = await obterRoadmap(slug, req.userId);
+        if (!roadmap) return res.status(404).json({ erro: "Roadmap não encontrado" });
+        await seguirRoadmap(req.userId!, roadmap.id, true);
+        res.status(204).end();
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/roadmap.routes.ts
+++ b/backend/src/routes/roadmap.routes.ts
@@ -15,6 +15,7 @@ import {
     deleteStageRef,
     completeStage,
     getProximaTrilha,
+    seguir,
 } from "../controllers/RoadmapController.ts";
 
 const router = Router();
@@ -36,6 +37,8 @@ router.delete("/roadmap-stages/:id", autenticar, exigirAdmin, deleteStage);
 router.post("/roadmap-stages/:id/concluir", autenticar, completeStage);
 router.post("/roadmap-stages/:id/refs", autenticar, exigirAdmin, createStageRef);
 router.delete("/roadmap-stage-refs/:id", autenticar, exigirAdmin, deleteStageRef);
+
+router.post("/roadmaps/:slug/seguir", autenticar, seguir);
 
 // Detalhe do aluno por slug (por último, para não capturar as rotas acima).
 router.get("/roadmaps/:slug", autenticar, getRoadmap);

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -12,8 +12,9 @@ import {
     simuladoAttempts,
     challenges,
     challengeSubmissions,
+    userRoadmaps,
 } from "../../schema.ts";
-import { eq, and, asc, desc, inArray, count } from "drizzle-orm";
+import { eq, and, asc, desc, inArray, count, countDistinct } from "drizzle-orm";
 import type { z } from "zod";
 import type {
     createRoadmapSchema,
@@ -361,14 +362,126 @@ export async function obterRoadmap(slug: string, userId?: string) {
             status: statusPorProgresso(feitos, total),
         },
         currentStageId: atual?.id ?? null,
+        // A tela precisa saber para não oferecer "seguir" a quem já segue.
+        seguindo: userId ? await estaSeguindo(userId, roadmap.id) : false,
         stages: comCadeado,
     };
 }
 
+async function estaSeguindo(userId: string, roadmapId: string) {
+    const [ja] = await db
+        .select({ id: userRoadmaps.id })
+        .from(userRoadmaps)
+        .where(and(eq(userRoadmaps.userId, userId), eq(userRoadmaps.roadmapId, roadmapId)));
+    return !!ja;
+}
+
+// ============ Qual roadmap o aluno está seguindo ============
+
+/**
+ * Marca que o aluno segue este roadmap. `explicito` distingue a escolha dele
+ * (botão de seguir) da inferência feita a partir do progresso: escolha explícita
+ * nunca é rebaixada por inferência posterior.
+ */
+export async function seguirRoadmap(userId: string, roadmapId: string, explicito = true) {
+    const [ja] = await db
+        .select()
+        .from(userRoadmaps)
+        .where(and(eq(userRoadmaps.userId, userId), eq(userRoadmaps.roadmapId, roadmapId)));
+    if (ja) {
+        await db
+            .update(userRoadmaps)
+            .set({ lastSeenAt: new Date(), explicito: ja.explicito || explicito })
+            .where(eq(userRoadmaps.id, ja.id));
+        return;
+    }
+    await db.insert(userRoadmaps).values({ userId, roadmapId, explicito });
+}
+
+/**
+ * Abrir o detalhe do roadmap atualiza a recência de quem já segue. NÃO cria
+ * vínculo: espiar um roadmap não pode fazer o app achar que o aluno mudou de
+ * caminho, senão a curiosidade viraria declaração.
+ */
+export async function registrarVisita(userId: string, roadmapId: string) {
+    await db
+        .update(userRoadmaps)
+        .set({ lastSeenAt: new Date() })
+        .where(and(eq(userRoadmaps.userId, userId), eq(userRoadmaps.roadmapId, roadmapId)));
+}
+
+/**
+ * Quantos roadmaps publicados contêm cada trilha. É o peso da inferência: trilha
+ * que está em quase todo roadmap (Lógica de Programação, em sete) quase não
+ * informa; trilha exclusiva de um caminho decide sozinha.
+ */
+async function roadmapsPorTrilha(trailIds: string[]): Promise<Map<string, number>> {
+    if (!trailIds.length) return new Map();
+    const linhas = await db
+        .select({ trailId: roadmapStageRefs.refId, n: countDistinct(roadmapStages.roadmapId) })
+        .from(roadmapStageRefs)
+        .innerJoin(roadmapStages, eq(roadmapStages.id, roadmapStageRefs.stageId))
+        .where(
+            and(eq(roadmapStageRefs.refType, "trail"), inArray(roadmapStageRefs.refId, trailIds)),
+        )
+        .groupBy(roadmapStageRefs.refId);
+    return new Map(linhas.map((l) => [l.trailId, Number(l.n)]));
+}
+
+type DetalheRoadmap = NonNullable<Awaited<ReturnType<typeof obterRoadmap>>>;
+
+/**
+ * Adivinha o roadmap a partir do progresso, quando o aluno não declarou nenhum.
+ *
+ * Dois sinais, nesta ordem. O prefixo contínuo (quantos estágios seguidos, a
+ * partir do primeiro, ele concluiu) captura a SEQUÊNCIA que ele vem seguindo, e
+ * é o que separa casos que o volume não separa: quem fez Lógica, Python e SQL
+ * tem prefixo 3 em Engenharia de Dados e 2 em Ciência de Dados, porque pulou
+ * Estatística. O peso por exclusividade desempata.
+ *
+ * Devolve null quando empata, e isso é de propósito: melhor perguntar do que
+ * cravar um caminho errado. Medido contra a base de produção, decide cerca de um
+ * terço dos alunos; o resto ainda não revelou caminho nenhum.
+ */
+async function inferirRoadmap(detalhes: DetalheRoadmap[]): Promise<DetalheRoadmap | null> {
+    const trilhasConcluidas = new Set<string>();
+    for (const d of detalhes)
+        for (const s of d.stages)
+            if (s.completed)
+                for (const r of s.refs) if (r.refType === "trail") trilhasConcluidas.add(r.refId);
+
+    const peso = await roadmapsPorTrilha([...trilhasConcluidas]);
+
+    const pontuados = detalhes.map((d) => {
+        let prefixo = 0;
+        for (const s of d.stages) {
+            if (!s.completed) break;
+            prefixo++;
+        }
+        let pontos = 0;
+        for (const s of d.stages)
+            if (s.completed)
+                for (const r of s.refs)
+                    if (r.refType === "trail") pontos += 1 / (peso.get(r.refId) ?? 1);
+        return { d, prefixo, pontos };
+    });
+
+    const melhor = pontuados.reduce((a, b) =>
+        b.prefixo !== a.prefixo ? (b.prefixo > a.prefixo ? b : a) : b.pontos > a.pontos ? b : a,
+    );
+    const empatados = pontuados.filter(
+        (p) => p.prefixo === melhor.prefixo && Math.abs(p.pontos - melhor.pontos) < 1e-9,
+    );
+    return empatados.length === 1 ? melhor.d : null;
+}
+
 // Depois de concluir uma trilha: em qual roadmap ela vive e qual é a próxima
-// trilha dele. Com a trilha em mais de um roadmap, vale o de maior progresso do
-// usuário (desempate pela posição do roadmap). Só oferece etapa destravada; no
-// fim do roadmap (ou sem etapa elegível), proximaTrilha volta nula.
+// trilha dele. Com a trilha em mais de um roadmap a escolha segue esta ordem:
+// o que o aluno declarou seguir, depois a inferência pelo progresso e, se as
+// duas falharem, a heurística antiga de maior número de estágios concluídos.
+// `origem` diz qual delas decidiu, para a tela poder oferecer a troca em vez de
+// fingir certeza. Só oferece etapa destravada; no fim do roadmap (ou sem etapa
+// elegível), proximaTrilha volta nula.
 export async function proximaTrilhaAposConcluir(userId: string, trailId: string) {
     const candidatos = await db
         .selectDistinct({ slug: roadmaps.slug, position: roadmaps.position })
@@ -405,14 +518,48 @@ export async function proximaTrilhaAposConcluir(userId: string, trailId: string)
     };
 
     // Prefere um roadmap que tenha o que oferecer; entre eles (e no fallback
-    // sem oferta), o de maior progresso do usuário, já ordenados por posição.
-    const comProxima = detalhes
-        .map((d) => ({ d, ref: refDaProxima(d) }))
-        .filter((x) => x.ref !== null);
-    const escolhaEntre = comProxima.length ? comProxima : detalhes.map((d) => ({ d, ref: null }));
-    const { d: escolhido, ref: refTrilha } = escolhaEntre.reduce((melhor, x) =>
-        x.d.progress.stagesDone > melhor.d.progress.stagesDone ? x : melhor,
+    // sem oferta), o escolhido pela ordem: declarado, inferido, heurística.
+    const comProxima = detalhes.filter((d) => refDaProxima(d) !== null);
+    const elegiveis = comProxima.length ? comProxima : detalhes;
+
+    // 1. O que o aluno declarou seguir. Escolha explícita vem antes da inferida,
+    // e entre iguais vale a mais recente.
+    const seguidos = await db
+        .select()
+        .from(userRoadmaps)
+        .where(
+            and(
+                eq(userRoadmaps.userId, userId),
+                inArray(
+                    userRoadmaps.roadmapId,
+                    elegiveis.map((d) => d.id),
+                ),
+            ),
+        );
+    seguidos.sort(
+        (a, b) =>
+            Number(b.explicito) - Number(a.explicito) ||
+            b.lastSeenAt.getTime() - a.lastSeenAt.getTime(),
     );
+    const declarado = seguidos.length
+        ? (elegiveis.find((d) => d.id === seguidos[0].roadmapId) ?? null)
+        : null;
+
+    // 2. Inferência pelo progresso. 3. Heurística antiga, que erra em empate mas
+    // é melhor que não sugerir nada.
+    const inferido = declarado ? null : await inferirRoadmap(elegiveis);
+    const escolhido =
+        declarado ??
+        inferido ??
+        elegiveis.reduce((melhor, d) =>
+            d.progress.stagesDone > melhor.progress.stagesDone ? d : melhor,
+        );
+    const origem: "declarado" | "inferido" | "heuristica" = declarado
+        ? "declarado"
+        : inferido
+          ? "inferido"
+          : "heuristica";
+    const refTrilha = refDaProxima(escolhido);
 
     let proximaTrilha = null;
     if (refTrilha) {
@@ -422,9 +569,15 @@ export async function proximaTrilhaAposConcluir(userId: string, trailId: string)
             .where(eq(trails.id, refTrilha.refId));
         proximaTrilha = t ?? null;
     }
+    // Quando a trilha vive em mais de um roadmap e a escolha não foi declarada
+    // pelo aluno, a tela precisa saber para oferecer a troca em vez de afirmar.
     return {
         roadmap: { slug: escolhido.slug, name: escolhido.name },
         proximaTrilha,
+        origem,
+        outrosRoadmaps: elegiveis
+            .filter((d) => d.id !== escolhido.id)
+            .map((d) => ({ slug: d.slug, name: d.name })),
     };
 }
 

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -23,7 +23,11 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { BlocosConteudo, md, TextoMath } from '../../components/BlocosConteudo';
 import { getTrailLang } from '../../utils/trailLang';
-import { proximaTrilhaRoadmap, type ProximaTrilhaRoadmap } from '../../services/roadmaps';
+import {
+  proximaTrilhaRoadmap,
+  seguirRoadmap,
+  type ProximaTrilhaRoadmap,
+} from '../../services/roadmaps';
 
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
@@ -59,6 +63,22 @@ export function Aula() {
       setBuscandoProxima(false);
     }
     navigate('/trilhas');
+  }
+
+  // O aluno corrige o palpite: passa a seguir o roadmap que escolheu e a sugestão
+  // é recalculada a partir dele, agora com origem declarada.
+  async function trocarRoadmap(slug: string) {
+    try {
+      await seguirRoadmap(slug);
+      const r = await proximaTrilhaRoadmap(trailId!);
+      setProximaRoadmap(r);
+      if (!r.roadmap || !r.proximaTrilha) {
+        setPerguntaTrilha(false);
+        navigate('/trilhas');
+      }
+    } catch (err) {
+      console.error('Falha ao trocar o roadmap seguido.', err);
+    }
   }
 
   useEffect(() => {
@@ -154,6 +174,26 @@ export function Aula() {
                   {NIVEL_LABEL[proximaRoadmap.proximaTrilha.level]}
                 </span>
               </div>
+              {/* Esta trilha vive em mais de um roadmap e o aluno nunca disse qual
+                  segue, então a sugestão é um palpite. Melhor admitir e deixar ele
+                  corrigir do que mandá-lo para o caminho errado em silêncio. */}
+              {proximaRoadmap.origem !== 'declarado' && !!proximaRoadmap.outrosRoadmaps?.length && (
+                <div className="solve-next__troca">
+                  <span className="solve-next__troca-aviso">
+                    Está seguindo outro caminho? Escolha e nós lembramos:
+                  </span>
+                  {proximaRoadmap.outrosRoadmaps.map((r) => (
+                    <button
+                      key={r.slug}
+                      type="button"
+                      className="solve-next__troca-opcao"
+                      onClick={() => trocarRoadmap(r.slug)}
+                    >
+                      {r.name}
+                    </button>
+                  ))}
+                </div>
+              )}
               <div className="solve-next__acoes">
                 <button
                   className="solve-next__ficar"

--- a/frontend/src/pages/Roadmaps/Detalhe.tsx
+++ b/frontend/src/pages/Roadmaps/Detalhe.tsx
@@ -9,7 +9,15 @@ import { Flame, Check, ChevronRight, ChevronLeft, Play } from '../../components/
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
-import { concluirEstagio, obterRoadmap, type RoadmapDetalhe, type RoadmapStage, type RoadmapRef, type RoadmapPhase } from '../../services/roadmaps';
+import {
+  concluirEstagio,
+  obterRoadmap,
+  type RoadmapDetalhe,
+  type RoadmapStage,
+  type RoadmapRef,
+  type RoadmapPhase,
+  seguirRoadmap,
+} from '../../services/roadmaps';
 import { obterTrilha } from '../../services/trails';
 import { getTrailLang } from '../../utils/trailLang';
 
@@ -59,11 +67,26 @@ export function RoadmapDetalhe() {
   const [concluindo, setConcluindo] = useState(false);
   const [carregando, setCarregando] = useState(true);
   const [erro, setErro] = useState('');
+  const [seguindo, setSeguindo] = useState(false);
+
+  async function marcarComoSeguido() {
+    if (!rm || seguindo) return;
+    setSeguindo(true);
+    try {
+      await seguirRoadmap(rm.slug);
+    } catch (err) {
+      console.error('Falha ao seguir o roadmap.', err);
+      setSeguindo(false);
+    }
+  }
 
   useEffect(() => {
     if (!slug) return;
     obterRoadmap(slug)
-      .then(setRm)
+      .then((r) => {
+        setRm(r);
+        setSeguindo(r.seguindo);
+      })
       .catch(() => setErro('Não foi possível carregar o roadmap.'))
       .finally(() => setCarregando(false));
   }, [slug]);
@@ -81,7 +104,9 @@ export function RoadmapDetalhe() {
         const detalhe = await obterTrilha(ref.trailId, getTrailLang(ref.trailId));
         const aulas = detalhe.modules.flatMap((m) => m.lessons);
         const alvo =
-          aulas.find((l) => l.state === 'current') ?? aulas.find((l) => l.state !== 'locked') ?? aulas[0];
+          aulas.find((l) => l.state === 'current') ??
+          aulas.find((l) => l.state !== 'locked') ??
+          aulas[0];
         return navigate(alvo ? `/trilhas/${ref.trailId}/aula/${alvo.id}` : '/trilhas');
       } catch {
         return navigate('/trilhas');
@@ -147,9 +172,7 @@ export function RoadmapDetalhe() {
 
           {carregando && <p className="track__desc">Carregando roadmap...</p>}
           {erro && <div className="auth__alert">{erro}</div>}
-          {!carregando && !erro && !rm && (
-            <p className="track__desc">Roadmap não encontrado.</p>
-          )}
+          {!carregando && !erro && !rm && <p className="track__desc">Roadmap não encontrado.</p>}
 
           {rm && (
             <>
@@ -158,6 +181,16 @@ export function RoadmapDetalhe() {
                   <div className="rmd-hero__kicker">Roadmap de carreira</div>
                   <h1 className="rmd-hero__title">{rm.name}</h1>
                   <p className="rmd-hero__desc">{rm.description}</p>
+                  {/* Declarar o caminho é o que permite acertar a próxima trilha
+                      quando ela vive em vários roadmaps. Sem isso o app adivinha. */}
+                  <button
+                    type="button"
+                    className={`rmd-seguir${seguindo ? ' rmd-seguir--ativo' : ''}`}
+                    onClick={marcarComoSeguido}
+                    disabled={seguindo}
+                  >
+                    {seguindo ? 'Você está seguindo este roadmap' : 'Seguir este roadmap'}
+                  </button>
                 </div>
                 <Ring percent={rm.progress.percent} />
               </div>
@@ -239,7 +272,11 @@ export function RoadmapDetalhe() {
               <button className="btn btn--ghost" onClick={() => setConfirmando(null)}>
                 Cancelar
               </button>
-              <button className="btn btn--accent" onClick={confirmarConclusao} disabled={concluindo}>
+              <button
+                className="btn btn--accent"
+                onClick={confirmarConclusao}
+                disabled={concluindo}
+              >
                 {concluindo ? 'Concluindo...' : 'Concluir mesmo assim'}
               </button>
             </div>

--- a/frontend/src/services/roadmaps.ts
+++ b/frontend/src/services/roadmaps.ts
@@ -51,6 +51,8 @@ export interface RoadmapDetalhe {
   premium: boolean;
   progress: { stagesTotal: number; stagesDone: number; percent: number; status: RoadmapStatus };
   currentStageId: string | null;
+  /** Se o aluno declarou que segue este roadmap. */
+  seguindo: boolean;
   stages: RoadmapStage[];
 }
 
@@ -64,14 +66,25 @@ export async function obterRoadmap(slug: string) {
   return data;
 }
 
+/** Como o backend escolheu o roadmap da sugestão. Só 'declarado' é certeza:
+ *  nos outros dois a tela oferece a troca em vez de afirmar. */
+export type OrigemSugestao = 'declarado' | 'inferido' | 'heuristica';
+
 export interface ProximaTrilhaRoadmap {
   roadmap: { slug: string; name: string } | null;
   proximaTrilha: { id: string; name: string; level: Nivel } | null;
+  origem?: OrigemSugestao;
+  outrosRoadmaps?: { slug: string; name: string }[];
 }
 
 export async function proximaTrilhaRoadmap(trailId: string) {
   const { data } = await api.get<ProximaTrilhaRoadmap>(`/roadmaps/proxima-trilha/${trailId}`);
   return data;
+}
+
+/** Declara que o aluno segue este roadmap. Idempotente. */
+export async function seguirRoadmap(slug: string) {
+  await api.post(`/roadmaps/${slug}/seguir`);
 }
 
 // ===================== ADMIN (estúdio) =====================

--- a/frontend/src/styles/roadmap.css
+++ b/frontend/src/styles/roadmap.css
@@ -52,3 +52,55 @@
     box-shadow: none;
   }
 }
+
+/* ---------- Seguir o roadmap e trocar o palpite ---------- */
+.rmd-seguir {
+  margin-top: 16px;
+  padding: 9px 16px;
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.rmd-seguir:hover {
+  filter: brightness(1.06);
+}
+/* Já seguindo vira estado, não botão: sem cursor de clique e sem destaque. */
+.rmd-seguir--ativo,
+.rmd-seguir--ativo:hover {
+  background: var(--surface-2);
+  color: var(--muted);
+  border-color: var(--border);
+  cursor: default;
+  filter: none;
+}
+.solve-next__troca {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+.solve-next__troca-aviso {
+  width: 100%;
+  font-size: 13px;
+  color: var(--muted);
+}
+.solve-next__troca-opcao {
+  padding: 6px 12px;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+.solve-next__troca-opcao:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}


### PR DESCRIPTION
Corrige o bug relatado em produção: cursando **Engenharia de Dados**, ao concluir Python o app ofereceu **Estatística**, que é a próxima de Ciência de Dados. A próxima de Engenharia é Banco de Dados e SQL.

## A causa, encontrada nos dados

Python é estágio de três roadmaps. A função `proximaTrilhaAposConcluir` escolhia pelo maior número de estágios concluídos, sobre uma lista ordenada por posição do roadmap, com `>` estrito. O aluno tinha 2 estágios concluídos nos dois candidatos (Lógica e Python): **empate**. Com `>` estrito o empate mantém o primeiro, e o primeiro é o de menor posição. Ciência de Dados é posição 3 e Engenharia é 4, então Ciência venceu por ser mais antiga no catálogo.

A raiz é mais funda que o desempate: **não existia nada no banco ligando aluno a roadmap**. O progresso do roadmap é derivado do progresso das trilhas, decisão antiga e correta, e por isso o sistema só conseguia adivinhar. Mexer no critério de desempate apenas trocaria qual caso erra.

## O que muda

**Tabela `user_roadmaps`** (migration 0054), com única por par usuário e roadmap e índice nas duas chaves estrangeiras. Ela guarda **intenção e recência, não progresso**: o progresso continua derivado como sempre foi. O campo `explicito` separa a escolha do aluno da inferência, e escolha explícita nunca é rebaixada.

**A escolha passa a seguir três degraus**, e o backend informa qual decidiu, no campo `origem`:

1. `declarado`: o aluno clicou em seguir o roadmap. Entre vários, o explícito primeiro e o mais recente depois.
2. `inferido`: adivinhação a partir do progresso, por dois sinais. O **prefixo contínuo** (quantos estágios seguidos, do primeiro em diante, ele concluiu) captura a sequência que ele vem seguindo, e é o que separa casos que o volume não separa: quem fez Lógica, Python e SQL tem prefixo 3 em Engenharia e 2 em Ciência, porque pulou Estatística. O **peso por exclusividade** desempata, porque trilha que está em sete roadmaps quase não informa e trilha exclusiva decide. Empate devolve nulo de propósito.
3. `heuristica`: o critério antigo, mantido como último recurso. Erra em empate, e ainda é melhor que não sugerir nada.

**Na tela**, botão de seguir o roadmap no detalhe, e o modal de próxima trilha passa a oferecer a troca quando a origem não é declarada. Trocar já grava a escolha, então o erro se corrige sozinho e não volta.

Abrir o detalhe atualiza a recência de quem **já segue**, e só isso. Abrir não cria vínculo, senão espiar um roadmap faria o app achar que o aluno mudou de caminho.

## Backfill

`backfill-roadmap-seguido.ts` roda a mesma inferência sobre quem já estudava. Medido contra a base de produção antes de escrever:

| Método | Alunos decididos (de 372 com progresso) |
|---|---|
| Só peso por exclusividade | 104 |
| Só prefixo contínuo | 68 |
| **Combinado, que é o implementado** | **130** |

Os 242 restantes ficam de fora **de propósito**: a grande maioria só fez Lógica de Programação, que está em quase todo roadmap, e atribuir um caminho a essas pessoas seria inventar dado. Elas se resolvem sozinhas no runtime, no instante em que tocarem uma trilha que diferencie, porque é o mesmo código.

O script só insere, nunca apaga nem altera, e é idempotente. **Não roda em prod neste PR**: entra depois do merge e da release, com autorização, e o cabeçalho dele manda tirar um dump na hora antes, porque a rotina diária é das 6h UTC e guarda na própria máquina do banco.

## Testado

Reproduzi o bug num Postgres efêmero, com os dois roadmaps, as trilhas e o progresso do aluno:

| Cenário | Roadmap escolhido | Origem |
|---|---|---|
| Só Lógica e Python (empate genuíno) | Ciência de Dados | heuristica |
| **Depois de concluir SQL (o caso do bug)** | **Engenharia de Dados** | **inferido** |
| Aluno declara seguir Ciência de Dados | Ciência de Dados | declarado |

O backfill foi testado no mesmo banco: associou o aluno a Engenharia de Dados como inferido, e a segunda execução não duplicou. tsc limpo nos dois lados, build do front passa, lint sem erro nos arquivos tocados.