### PR TITLE
fix: símbolo de diferente aparecia como igual nas trilhas de matemática

### DIFF
--- a/frontend/src/components/BlocosConteudo.tsx
+++ b/frontend/src/components/BlocosConteudo.tsx
@@ -3,6 +3,8 @@ import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
+import { opcoesKatex } from '../utils/katex';
+
 import { parseGrid } from '../utils/tabela';
 import { glossariar, criarMatcher } from './Glossario';
 import { useGlossario } from '../hooks/useGlossario';
@@ -149,7 +151,7 @@ export function BlocosConteudo({ blocks }: { blocks: Bloco[] }) {
           <ReactMarkdown
             key={i}
             remarkPlugins={[remarkGfm, remarkMath]}
-            rehypePlugins={[rehypeKatex]}
+            rehypePlugins={[[rehypeKatex, opcoesKatex]]}
             components={componentes}
           >
             {b.value}
@@ -167,7 +169,7 @@ export function TextoMath({ children }: { children: string }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex]}
+      rehypePlugins={[[rehypeKatex, opcoesKatex]]}
       components={{
         p: ({ children }) => <>{children}</>,
         pre: ({ children }) => (

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -22,6 +22,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { BlocosConteudo, md, TextoMath } from '../../components/BlocosConteudo';
+import { opcoesKatex } from '../../utils/katex';
 import { getTrailLang } from '../../utils/trailLang';
 import {
   proximaTrilhaRoadmap,
@@ -320,7 +321,7 @@ function ConteudoAula({
         <div className="lesson__md">
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath]}
-            rehypePlugins={[rehypeKatex]}
+            rehypePlugins={[[rehypeKatex, opcoesKatex]]}
             components={md}
           >
             {aula.content}
@@ -593,7 +594,7 @@ function Quiz({
               <div className="quiz__solucao-corpo lesson__md">
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm, remarkMath]}
-                  rehypePlugins={[rehypeKatex]}
+                  rehypePlugins={[[rehypeKatex, opcoesKatex]]}
                   components={md}
                 >
                   {explicacao}

--- a/frontend/src/utils/katex.ts
+++ b/frontend/src/utils/katex.ts
@@ -1,0 +1,23 @@
+/**
+ * Opções do KaTeX usadas em TODA renderização de fórmula do app.
+ *
+ * O macro do \neq existe por um bug de renderização confirmado em produção. O
+ * KaTeX monta esse símbolo com dois caracteres, U+E020 (uma barra que deveria ter
+ * largura zero e cair em cima) seguido de U+3D (o igual), contando com a
+ * sobreposição. Ela não acontece aqui, e a barra vira um caractere separado à
+ * esquerda: a aula escreve "b \neq 0" e o aluno lê "b /= 0". Em alguns pontos a
+ * barra some de vez e vira "b = 0", que é o significado oposto.
+ *
+ * A fonte TEM o glifo correto de ≠ (U+2260); o KaTeX é que não o usa. Apontar
+ * direto para ele resolve sem tocar nas 51 aulas, 12 enunciados, 18 alternativas
+ * e 30 resoluções que já usam \neq, e passa a valer para todo conteúdo futuro.
+ *
+ * Os outros símbolos negados (\notin, \nleq, \ngeq, \nsubseteq, \nmid) foram
+ * conferidos um a um e renderizam certo, porque têm glifo próprio na fonte AMS.
+ */
+export const opcoesKatex = {
+  macros: {
+    '\\neq': '\\mathrel{\\char"2260}',
+    '\\ne': '\\mathrel{\\char"2260}',
+  },
+};


### PR DESCRIPTION
Um aluno relatou que o símbolo de diferente na trilha de matemática aparece como `/=` e confunde. Investigando, o problema é bem pior do que confusão visual: **em vários pontos o símbolo perde a barra e vira `=`, invertendo o significado da frase.**

## Confirmado em produção, não em teste sintético

Abri a aula "Conjuntos numéricos e a reta real" de Pré-cálculo, logado, e inspecionei o elemento:

- O conteúdo da aula é `b \neq 0` e o MathML acessível diz `b≠0`, tudo correto.
- O **texto visível** é `b=0`.
- O elemento do símbolo contém `U+E020 U+3D`.

Na tela, a frase "com a e b inteiros e b ≠ 0" aparece como **"b /= 0"**, e a definição do conjunto dos racionais aparece com a mesma quebra. Numa aula em que "b diferente de zero" é justamente a condição que define o conjunto, o aluno lê o oposto.

## A causa

O KaTeX não usa o glifo ≠ da fonte. Ele monta o símbolo com dois caracteres: `U+E020`, uma barra da área de uso privado que deveria ter largura zero e cair em cima, seguida de `U+3D`, o igual. A sobreposição não acontece no nosso ambiente, então a barra vira um caractere solto à esquerda, e em alguns tamanhos ela simplesmente não desenha.

A fonte não tem culpa: **ela tem o glifo correto**. Confirmei injetando `≠` (U+2260) com `font-family: KaTeX_Main` na própria página de produção, e ele desenha perfeito.

## A correção

Um macro do KaTeX apontando `\neq` e `\ne` para o caractere real, aplicado nos quatro pontos onde o app renderiza fórmula.

Isso resolve sem tocar em nenhuma linha de conteúdo, o que importa porque o alcance é grande: **51 aulas, 12 enunciados de questão, 18 alternativas e 30 resoluções passo a passo** usam `\neq`. E passa a valer para tudo que for escrito daqui pra frente.

A constante ficou em `utils/katex.ts` em vez de dentro do componente, para não acrescentar aviso de lint.

## Escopo verificado

Conferi um a um os outros símbolos negados: `\notin`, `\nleq`, `\ngeq`, `\nsubseteq` e `\nmid` renderizam **corretos**, porque têm glifo próprio na fonte AMS. Só `\neq` e `\not\equiv` usam a sobreposição quebrada, e `\not\equiv` não é usado em nenhuma aula.

## Testado

Comparativo renderizado com o CSS e as fontes reais de produção, usando o texto exato da aula que quebrou: antes, `b = 0` e `ℚ = { a/b : a,b ∈ ℤ, b = 0 }`; depois, `b ≠ 0` e `ℚ = { a/b : a,b ∈ ℤ, b ≠ 0 }`.

Também verifiquei que o macro não afeta o resto: dez construções comuns (`\leq`, `\geq`, `\in`, `\notin`, fração, raiz, integral, somatório e as duas formas de diferente) renderizam sem erro. tsc e build passam, e o lint fica no mesmo número de problemas da develop, sem nenhum novo.

## Nota de honestidade

No caminho eu levantei duas hipóteses erradas antes de chegar aqui, `box-sizing` do reset global e corrida de carregamento de fonte, e descartei as duas com teste. O diagnóstico só fechou quando fui olhar a tela real em vez de reproduzir em página sintética, onde os resultados eram inconsistentes.