### PR TITLE
fix: registrar o caminho que o aluno percorre em vez de deduzi-lo

### DIFF
--- a/backend/scripts/backfill-roadmap-seguido.ts
+++ b/backend/scripts/backfill-roadmap-seguido.ts
@@ -11,8 +11,8 @@
 //
 // Empate NÃO vira palpite: o aluno fica de fora e será resolvido no runtime assim
 // que tocar uma trilha que diferencie. Medido na base de produção em 2026-08-07,
-// decide cerca de um terço; o resto só fez trilha compartilhada e genuinamente
-// ainda não revelou caminho nenhum.
+// decide 112 dos 489 alunos com progresso; o resto só tocou trilha compartilhada
+// e genuinamente ainda não revelou caminho nenhum.
 //
 // Idempotente: quem já tem linha não é tocado. Só INSERE, nunca apaga nem altera
 // linha existente, então o pior caso é uma associação errada que o aluno corrige
@@ -101,10 +101,11 @@ async function backfill() {
             pulados++;
             continue;
         }
-        const concluiu = (trailId: string) => {
-            const as = aulasDaTrilha.get(trailId);
-            return !!as?.length && as.every((id) => feitas.has(id));
-        };
+        // Trilha TOCADA, não concluída: quem está na décima aula de Python já
+        // revelou o caminho. A primeira versão exigia a trilha inteira e por isso
+        // decidiu 16 alunos onde a medição prometia 112.
+        const tocou = (trailId: string) =>
+            (aulasDaTrilha.get(trailId) ?? []).some((id) => feitas.has(id));
 
         const pontuados = publicados
             .map((r) => {
@@ -112,13 +113,13 @@ async function backfill() {
                 if (!lista.length) return null;
                 let prefixo = 0;
                 for (const e of lista) {
-                    if (!e.trilhas.some(concluiu)) break;
+                    if (!e.trilhas.some(tocou)) break;
                     prefixo++;
                 }
                 let pontos = 0;
                 for (const e of lista)
                     for (const t of e.trilhas)
-                        if (concluiu(t)) pontos += 1 / (roadmapsDaTrilha.get(t)?.size ?? 1);
+                        if (tocou(t)) pontos += 1 / (roadmapsDaTrilha.get(t)?.size ?? 1);
                 return { roadmapId: r.id, slug: r.slug, prefixo, pontos };
             })
             .filter((x): x is NonNullable<typeof x> => x !== null && x.pontos > 0);

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -440,29 +440,44 @@ type DetalheRoadmap = NonNullable<Awaited<ReturnType<typeof obterRoadmap>>>;
  * Estatística. O peso por exclusividade desempata.
  *
  * Devolve null quando empata, e isso é de propósito: melhor perguntar do que
- * cravar um caminho errado. Medido contra a base de produção, decide cerca de um
- * terço dos alunos; o resto ainda não revelou caminho nenhum.
+ * cravar um caminho errado. Medido contra a base de produção, decide 112 dos 489
+ * alunos com progresso; o resto só tocou trilha compartilhada e genuinamente ainda
+ * não revelou caminho nenhum.
  */
-async function inferirRoadmap(detalhes: DetalheRoadmap[]): Promise<DetalheRoadmap | null> {
-    const trilhasConcluidas = new Set<string>();
-    for (const d of detalhes)
-        for (const s of d.stages)
-            if (s.completed)
-                for (const r of s.refs) if (r.refType === "trail") trilhasConcluidas.add(r.refId);
+async function inferirRoadmap(
+    userId: string,
+    detalhes: DetalheRoadmap[],
+): Promise<DetalheRoadmap | null> {
+    // Conta trilha TOCADA (ao menos uma aula feita), não trilha concluída. Quem
+    // está na décima aula de Python já revelou o caminho; exigir as 35 adia a
+    // resposta para depois de ela deixar de ser útil. Medido na base: com
+    // "concluída" a inferência decide 16 alunos, com "tocada" decide 112.
+    const tocadas = new Set(
+        (
+            await db
+                .selectDistinct({ trailId: lessons.trailId })
+                .from(lessonProgress)
+                .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
+                .where(eq(lessonProgress.userId, userId))
+        ).map((r) => r.trailId),
+    );
 
-    const peso = await roadmapsPorTrilha([...trilhasConcluidas]);
+    const tocou = (s: DetalheRoadmap["stages"][number]) =>
+        s.refs.some((r) => r.refType === "trail" && tocadas.has(r.refId));
+
+    const peso = await roadmapsPorTrilha([...tocadas]);
 
     const pontuados = detalhes.map((d) => {
         let prefixo = 0;
         for (const s of d.stages) {
-            if (!s.completed) break;
+            if (!tocou(s)) break;
             prefixo++;
         }
         let pontos = 0;
         for (const s of d.stages)
-            if (s.completed)
-                for (const r of s.refs)
-                    if (r.refType === "trail") pontos += 1 / (peso.get(r.refId) ?? 1);
+            for (const r of s.refs)
+                if (r.refType === "trail" && tocadas.has(r.refId))
+                    pontos += 1 / (peso.get(r.refId) ?? 1);
         return { d, prefixo, pontos };
     });
 
@@ -541,13 +556,18 @@ export async function proximaTrilhaAposConcluir(userId: string, trailId: string)
             Number(b.explicito) - Number(a.explicito) ||
             b.lastSeenAt.getTime() - a.lastSeenAt.getTime(),
     );
-    const declarado = seguidos.length
+    // O vínculo vale para escolher, mas SÓ o explícito vira certeza. Vínculo
+    // inferido continua sendo palpite: apresentá-lo como declarado esconde a
+    // opção de trocar na tela, e o aluno fica preso num caminho que ele nunca
+    // escolheu. Foi exatamente o que aconteceu depois do backfill.
+    const seguido = seguidos.length
         ? (elegiveis.find((d) => d.id === seguidos[0].roadmapId) ?? null)
         : null;
+    const declarado = seguido && seguidos[0].explicito ? seguido : null;
 
     // 2. Inferência pelo progresso. 3. Heurística antiga, que erra em empate mas
     // é melhor que não sugerir nada.
-    const inferido = declarado ? null : await inferirRoadmap(elegiveis);
+    const inferido = declarado ? null : (seguido ?? (await inferirRoadmap(userId, elegiveis)));
     const escolhido =
         declarado ??
         inferido ??


### PR DESCRIPTION
Dois defeitos meus, encontrados com a feature já em produção. O relato foi direto: concluí Python no roadmap de Engenharia de Dados e o app ofereceu Protocolos da Web, dizendo ser o roadmap de **Engenharia de IA**, sem opção de corrigir.

## 1. Vínculo inferido se passava por escolha do aluno

A tabela `user_roadmaps` guarda um campo `explicito` justamente para separar o que o aluno escolheu do que o sistema adivinhou. **Eu não usei esse campo na decisão.** Qualquer linha, inclusive as gravadas pelo backfill, era reportada como `origem: "declarado"`.

A consequência é a pior possível para um palpite: a tela só oferece a troca quando a origem **não** é declarada, então o aluno ficou preso num caminho que nunca escolheu, sem saída na interface. O backfill, que eu mesmo rodei, transformou palpite em fato.

Agora `declarado` exige `explicito = true`. Vínculo inferido continua valendo para escolher o roadmap, mas se apresenta como inferido, e a troca reaparece.

**Por que o palpite não foi absurdo, aliás:** o aluno tocou Lógica, Python e Protocolos da Web. Protocolos é o estágio 3 de Engenharia de IA, então o prefixo contínuo dele lá é 3, contra 2 em Engenharia de Dados, onde o estágio 3 é SQL, ainda não iniciado. O algoritmo acertou pela própria regra. O erro foi não deixar o aluno discordar.

## 2. A inferência exigia trilha concluída, não iniciada

Levantei os números com uma definição e implementei com outra. Medi contando trilha **tocada** (ao menos uma aula) e escrevi o código exigindo trilha **concluída inteira**.

Os dados mostram o tamanho da diferença: **489 alunos tocaram alguma trilha, mas só 70 concluíram alguma**, e desses 70, cinquenta e cinco concluíram exatamente uma, o que quase nunca desempata entre roadmaps.

| Definição | Alunos decididos |
|---|---|
| Trilha concluída (o que estava no código) | 16 |
| Trilha tocada (o que eu havia medido) | 112 |

Trocado para tocada nos dois lugares, runtime e backfill. Para inferir o caminho, começar a trilha já é sinal; exigir as 35 aulas adia a resposta para depois de ela deixar de ser útil.

## Estado da produção

O backfill já foi aplicado com a definição corrigida, direto no banco e com dump prévio guardado: **112 alunos vinculados**, todos como inferidos, sem duplicidade e sem referência órfã. Este PR alinha o código ao que está no banco e conserta o defeito que escondia a troca.

## Testado

Cenário idêntico ao relatado, em Postgres efêmero: aluno com Lógica e Python completas, Protocolos da Web parcial (1 de 3 aulas) e vínculo **inferido** para Engenharia de IA.

- Antes de declarar: sugere Engenharia de IA com `origem: inferido` e oferece trocar para Ciência de Dados ou Engenharia de Dados.
- Depois de declarar Engenharia de Dados: sugere **Banco de Dados e SQL** com `origem: declarado`.

A trilha parcial entrando na conta é justamente o que a definição antiga ignorava. tsc e prettier limpos.

## Correção de registro

O corpo do PR #351 anuncia 130 alunos decididos. Aquele número veio da medição por trilha tocada e não correspondia ao código entregue, que decidia 16. O número correto para a lógica atual é 112.

---

## 3. O sinal que dispensa a dedução (a correção que importa)

Os dois defeitos acima são reais, mas a conversa com o usuário expôs algo maior: **eu estava refinando um palpite quando o sinal verdadeiro estava disponível de graça.**

O relato foi: "eu nem tinha feito Eng de IA, eu fiz a trilha de Lógica no roadmap de Eng de Dados". E ele estava certo. Quando o aluno clica numa trilha a partir da tela de um roadmap, o sistema sabe **exatamente** de onde ele veio. Não é dedução, é o clique dele.

Por que a dedução errou no caso dele, para registro:

| Trilha | Progresso |
|---|---|
| Python | 100% |
| Lógica de Programação | 66% |
| **Protocolos da Web** | **43%** |
| AWS CLF-C02 | 28% |

Protocolos da Web é o estágio 3 de Engenharia de IA. Com isso o prefixo contínuo dele virou 3 ali, contra 2 em Engenharia de Dados. **Uma trilha pela metade, tocada por fora, decidiu o roadmap inteiro** contra duas trilhas muito mais avançadas.

Cheguei a medir uma variante que exige 60% de progresso para o prefixo continuar. Ela decidia 101 alunos em vez de 112 e **continuava errando o caso dele**. Ou seja: mais heurística não resolvia. Parei de refinar o palpite.

### O que entra

, chamado quando o aluno abre uma trilha a partir da tela do roadmap. Cria o vínculo se não houver e sempre atualiza a recência, então a decisão "seguido mais recente" passa a refletir o caminho que ele percorre agora.

Fica como inferido, não explícito, de propósito: entrar numa trilha é ato de estudo, não declaração de caminho, e o aluno continua podendo trocar na tela. A diferença para a inferência por progresso é que aqui **não há adivinhação nenhuma**.

A chamada falha em silêncio: registrar o caminho nunca pode impedir a navegação.

Com isso a inferência por progresso vira o que deveria ter sido desde o começo: um recurso de último caso, para quem chegou antes de a tabela existir.

### Testado

Cenário idêntico ao relatado, em Postgres efêmero: aluno com Python completa, Lógica completa, Protocolos da Web parcial e vínculo inferido para Engenharia de IA.

- Só com o palpite do backfill: sugere Engenharia de IA.
- Depois de clicar numa trilha dentro de Engenharia de Dados: sugere **Banco de Dados e SQL**.

Um clique resolve o que nenhuma heurística resolveu.