### PR TITLE
feat: entrar numa trilha pelo roadmap registra o caminho, sem depender de dedução

### DIFF
--- a/backend/src/controllers/RoadmapController.ts
+++ b/backend/src/controllers/RoadmapController.ts
@@ -16,6 +16,7 @@ import {
     removerRef,
     seguirRoadmap,
     registrarVisita,
+    registrarEntradaPorRoadmap,
 } from "../services/roadmap.service.ts";
 import {
     createRoadmapSchema,
@@ -57,6 +58,20 @@ export const seguir = async (req: Request, res: Response, next: NextFunction) =>
         const roadmap = await obterRoadmap(slug, req.userId);
         if (!roadmap) return res.status(404).json({ erro: "Roadmap não encontrado" });
         await seguirRoadmap(req.userId!, roadmap.id, true);
+        res.status(204).end();
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Registra que o aluno entrou numa trilha vindo deste roadmap. Não é escolha
+// declarada, é o caminho que ele está de fato percorrendo agora.
+export const registrarEntrada = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const slug = typeof req.params.slug === "string" ? req.params.slug : "";
+        const roadmap = await obterRoadmap(slug, req.userId);
+        if (!roadmap) return res.status(404).json({ erro: "Roadmap não encontrado" });
+        await registrarEntradaPorRoadmap(req.userId!, roadmap.id);
         res.status(204).end();
     } catch (err) {
         next(err);

--- a/backend/src/routes/roadmap.routes.ts
+++ b/backend/src/routes/roadmap.routes.ts
@@ -16,6 +16,7 @@ import {
     completeStage,
     getProximaTrilha,
     seguir,
+    registrarEntrada,
 } from "../controllers/RoadmapController.ts";
 
 const router = Router();
@@ -39,6 +40,7 @@ router.post("/roadmap-stages/:id/refs", autenticar, exigirAdmin, createStageRef)
 router.delete("/roadmap-stage-refs/:id", autenticar, exigirAdmin, deleteStageRef);
 
 router.post("/roadmaps/:slug/seguir", autenticar, seguir);
+router.post("/roadmaps/:slug/entrei", autenticar, registrarEntrada);
 
 // Detalhe do aluno por slug (por último, para não capturar as rotas acima).
 router.get("/roadmaps/:slug", autenticar, getRoadmap);

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -399,6 +399,30 @@ export async function seguirRoadmap(userId: string, roadmapId: string, explicito
 }
 
 /**
+ * O aluno entrou numa trilha A PARTIR da tela deste roadmap. É o sinal mais forte
+ * que existe sobre qual caminho ele segue, porque não é dedução: ele clicou ali.
+ *
+ * Cria o vínculo se não houver e atualiza a recência sempre. Fica como inferido,
+ * não explícito, porque entrar numa trilha é um ato de estudo e não uma escolha
+ * de caminho declarada; o aluno continua podendo trocar na tela. A diferença para
+ * a inferência por progresso é que aqui não há adivinhação nenhuma.
+ */
+export async function registrarEntradaPorRoadmap(userId: string, roadmapId: string) {
+    const [ja] = await db
+        .select()
+        .from(userRoadmaps)
+        .where(and(eq(userRoadmaps.userId, userId), eq(userRoadmaps.roadmapId, roadmapId)));
+    if (ja) {
+        await db
+            .update(userRoadmaps)
+            .set({ lastSeenAt: new Date() })
+            .where(eq(userRoadmaps.id, ja.id));
+        return;
+    }
+    await db.insert(userRoadmaps).values({ userId, roadmapId, explicito: false });
+}
+
+/**
  * Abrir o detalhe do roadmap atualiza a recência de quem já segue. NÃO cria
  * vínculo: espiar um roadmap não pode fazer o app achar que o aluno mudou de
  * caminho, senão a curiosidade viraria declaração.

--- a/frontend/src/pages/Roadmaps/Detalhe.tsx
+++ b/frontend/src/pages/Roadmaps/Detalhe.tsx
@@ -17,6 +17,7 @@ import {
   type RoadmapRef,
   type RoadmapPhase,
   seguirRoadmap,
+  registrarEntradaNoRoadmap,
 } from '../../services/roadmaps';
 import { obterTrilha } from '../../services/trails';
 import { getTrailLang } from '../../utils/trailLang';
@@ -94,6 +95,9 @@ export function RoadmapDetalhe() {
   // Leva ao conteúdo do estágio conforme o tipo do ref.
   async function irParaRef(ref?: RoadmapRef) {
     if (!ref) return;
+    // Entrar numa trilha daqui diz, sem adivinhação, qual caminho o aluno segue.
+    // É o que faz a sugestão de próxima trilha acertar depois.
+    if (slug) void registrarEntradaNoRoadmap(slug);
     if (ref.refType === 'simulado' && ref.slug) return navigate(`/simulados/${ref.slug}`);
     if (ref.refType === 'lesson' && ref.trailId && ref.lessonId) {
       return navigate(`/trilhas/${ref.trailId}/aula/${ref.lessonId}`);

--- a/frontend/src/services/roadmaps.ts
+++ b/frontend/src/services/roadmaps.ts
@@ -87,6 +87,19 @@ export async function seguirRoadmap(slug: string) {
   await api.post(`/roadmaps/${slug}/seguir`);
 }
 
+/**
+ * Registra que o aluno entrou numa trilha vindo deste roadmap. É o sinal mais
+ * forte sobre o caminho que ele percorre, porque não é dedução: ele clicou ali.
+ * Falha em silêncio de propósito, já que nunca deve impedir a navegação.
+ */
+export async function registrarEntradaNoRoadmap(slug: string) {
+  try {
+    await api.post(`/roadmaps/${slug}/entrei`);
+  } catch (err) {
+    console.error('Falha ao registrar a entrada pelo roadmap.', err);
+  }
+}
+
 // ===================== ADMIN (estúdio) =====================
 
 export async function concluirEstagio(stageId: string) {


### PR DESCRIPTION
Ficou de fora do #355: o merge pegou só o primeiro commit da branch, e esta parte, que é a que mais importa, não subiu junto. O commit é o mesmo, reaplicado sobre a develop atual.

## Por que isto existe

O #355 corrigiu dois defeitos meus na inferência de roadmap, mas a conversa com o usuário expôs algo maior. O relato foi direto: **"eu nem tinha feito Eng de IA, eu fiz a trilha de Lógica no roadmap de Eng de Dados"**. E a proposta dele foi melhor que tudo que eu vinha tentando: em vez de deduzir, **registrar em qual roadmap o aluno clicou**.

Ele estava certo. Eu estava refinando um palpite quando o sinal verdadeiro estava disponível de graça: ao abrir uma trilha a partir da tela de um roadmap, o sistema sabe exatamente de onde o aluno veio. Não é dedução, é o clique dele.

## Por que a dedução errava, para registro

Progresso real do usuário no momento do relato:

| Trilha | Progresso |
|---|---|
| Python | 100% |
| Lógica de Programação | 66% |
| **Protocolos da Web** | **43%** |
| AWS CLF-C02 | 28% |

Protocolos da Web é o estágio 3 de Engenharia de IA. Com isso o prefixo contínuo virou 3 ali, contra 2 em Engenharia de Dados, onde o estágio 3 é SQL. **Uma trilha pela metade, tocada por fora, decidiu o roadmap inteiro** contra duas trilhas muito mais avançadas.

Cheguei a medir uma variante que exige 60% de progresso para o prefixo continuar: decidia 101 alunos em vez de 112 e **continuava errando o caso dele**. Mais heurística não resolvia, e foi aí que parei de refinar o palpite.

## O que entra

`POST /roadmaps/:slug/entrei`, chamado quando o aluno abre uma trilha a partir da tela do roadmap. Cria o vínculo se não houver e sempre atualiza a recência, então a decisão "seguido mais recente" passa a refletir o caminho percorrido agora.

Fica como inferido, não explícito, de propósito: entrar numa trilha é ato de estudo, não declaração de caminho, e o aluno continua podendo trocar na tela. A diferença para a inferência por progresso é que aqui não há adivinhação nenhuma.

A chamada falha em silêncio: registrar o caminho nunca pode impedir a navegação.

Com isso a inferência por progresso vira o que deveria ter sido desde o começo: recurso de último caso, para quem chegou antes de a tabela existir.

## Testado

Cenário idêntico ao relatado, em Postgres efêmero, agora sobre a develop atual (com as duas correções do #355 já dentro): aluno com Python completa, Lógica completa, Protocolos da Web parcial e vínculo inferido para Engenharia de IA.

- Só com o palpite do backfill: sugere Engenharia de IA.
- Depois de clicar numa trilha dentro de Engenharia de Dados: sugere **Banco de Dados e SQL**.

Um clique resolve o que nenhuma heurística resolveu. tsc, build e lint limpos nos dois lados.