### PR TITLE
feat: páginas de Termos de Uso e Política de Privacidade

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Só entram aqui as páginas que um visitante sem conta consegue abrir. Hoje são
-  duas: o catálogo inteiro (trilhas, roadmaps, simulados) vive atrás de login e
-  por isso não é indexável. Quando alguma vitrine pública existir, este arquivo
-  passa a ser gerado pelo backend a partir do banco.
+  Só entram aqui as páginas que um visitante sem conta consegue abrir: a landing,
+  o cadastro e os dois documentos legais. O catálogo inteiro (trilhas, roadmaps,
+  simulados) vive atrás de login e por isso não é indexável. Quando alguma
+  vitrine pública existir, este arquivo passa a ser gerado pelo backend a partir
+  do banco.
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
@@ -17,5 +18,17 @@
     <lastmod>2026-08-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ensinadev.com.br/termos</loc>
+    <lastmod>2026-08-08</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://ensinadev.com.br/privacidade</loc>
+    <lastmod>2026-08-08</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
   </url>
 </urlset>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -87,6 +87,10 @@ const OAuthCallback = lazy(() =>
 const CertificadoValidar = lazy(() =>
   import('./pages/CertificadoValidar').then((m) => ({ default: m.CertificadoValidar })),
 );
+const Privacidade = lazy(() =>
+  import('./pages/Legal/Privacidade').then((m) => ({ default: m.Privacidade })),
+);
+const Termos = lazy(() => import('./pages/Legal/Termos').then((m) => ({ default: m.Termos })));
 const PerfilPublico = lazy(() =>
   import('./pages/PerfilPublico').then((m) => ({ default: m.PerfilPublico })),
 );
@@ -160,6 +164,9 @@ function AppRoutes() {
           <Route path="/redefinir-senha" element={<RedefinirSenha />} />
           <Route path="/auth/callback" element={<OAuthCallback />} />
           <Route path="/certificados/:code" element={<CertificadoValidar />} />
+          {/* Públicas mesmo logado: são documentos, e o link do rodapé leva aqui. */}
+          <Route path="/privacidade" element={<Privacidade />} />
+          <Route path="/termos" element={<Termos />} />
           <Route
             path="/completar-perfil"
             element={

--- a/frontend/src/data/legal.ts
+++ b/frontend/src/data/legal.ts
@@ -1,0 +1,10 @@
+// Dados dos documentos legais em um lugar só: o email aparece em três seções da
+// política e nos termos, e a data de atualização precisa bater entre os dois.
+//
+// O endereço abaixo precisa existir de verdade. A LGPD (art. 18) exige um canal
+// pelo qual o titular consiga exercer os direitos dele, e política que aponta
+// para caixa inexistente é o mesmo que não ter canal.
+export const CONTATO_LEGAL = 'contato@ensinadev.com.br';
+
+/** Data da última revisão dos dois documentos, no formato exibido na página. */
+export const ATUALIZADO_EM = '8 de agosto de 2026';

--- a/frontend/src/data/seo.ts
+++ b/frontend/src/data/seo.ts
@@ -32,6 +32,18 @@ const ROTAS: Record<string, MetaPagina> = {
   '/auth/callback': { titulo: 'Entrando | Ensina Dev', indexar: false },
   '/completar-perfil': { titulo: 'Completar perfil | Ensina Dev', indexar: false },
   '/certificados/:code': { titulo: 'Validação de certificado | Ensina Dev', indexar: false },
+  // Indexáveis de propósito: documento legal precisa ser encontrável por quem
+  // procura, e não só por quem já está dentro do cadastro.
+  '/privacidade': {
+    titulo: 'Política de Privacidade | Ensina Dev',
+    descricao:
+      'Que dados o Ensina Dev coleta, por que coleta cada um, com quem compartilha e como pedir a exclusão.',
+  },
+  '/termos': {
+    titulo: 'Termos de Uso | Ensina Dev',
+    descricao:
+      'As regras de uso do Ensina Dev: conta, comunidade, execução de código, certificados e apoio ao projeto.',
+  },
 
   '/home': { titulo: 'Início | Ensina Dev', indexar: false },
   '/trilhas': { titulo: 'Trilhas | Ensina Dev', indexar: false },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,4 +11,5 @@
 @import './styles/landing.css';
 @import './styles/lab.css';
 @import './styles/curriculo.css';
+@import './styles/legal.css';
 @import './styles/mobile.css';

--- a/frontend/src/pages/Landing/index.tsx
+++ b/frontend/src/pages/Landing/index.tsx
@@ -409,6 +409,11 @@ export function Landing() {
             <Link to="/cadastro">Criar conta</Link>
             <Link to="/recuperar-senha">Recuperar senha</Link>
           </nav>
+          <nav className="lp-rodape__col">
+            <h4>Legal</h4>
+            <Link to="/termos">Termos de Uso</Link>
+            <Link to="/privacidade">Política de Privacidade</Link>
+          </nav>
         </div>
         <div className="lp-container lp-rodape__base">
           <span>© {new Date().getFullYear()} Ensina Dev. Todos os direitos reservados.</span>

--- a/frontend/src/pages/Legal/LegalShell.tsx
+++ b/frontend/src/pages/Legal/LegalShell.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { ATUALIZADO_EM } from '../../data/legal';
+
+type LegalShellProps = {
+  titulo: string;
+  resumo: string;
+  /** Link para o documento irmão, exibido no rodapé da página. */
+  irmao: { to: string; label: string };
+  children: ReactNode;
+};
+
+/**
+ * Casca das páginas de Termos e Política. São páginas públicas: quem chega aqui
+ * pode não ter conta, então a barra do topo leva para a landing e não para /home.
+ */
+export function LegalShell({ titulo, resumo, irmao, children }: LegalShellProps) {
+  return (
+    <div className="legal">
+      <header className="legal__topo">
+        <Logo variant="solid" size={18} to="/" />
+        <Link className="link" to="/">
+          Voltar ao início
+        </Link>
+      </header>
+
+      <article className="legal__doc">
+        <h1>{titulo}</h1>
+        <p className="legal__resumo">{resumo}</p>
+        <p className="legal__data">Última atualização: {ATUALIZADO_EM}</p>
+        {children}
+      </article>
+
+      <footer className="legal__rodape">
+        <Link className="link" to={irmao.to}>
+          {irmao.label}
+        </Link>
+        <span>© {new Date().getFullYear()} Ensina Dev</span>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/pages/Legal/Privacidade.tsx
+++ b/frontend/src/pages/Legal/Privacidade.tsx
@@ -1,0 +1,286 @@
+import { useSeo } from '../../hooks/useSeo';
+import { CONTATO_LEGAL } from '../../data/legal';
+import { LegalShell } from './LegalShell';
+
+export function Privacidade() {
+  useSeo();
+
+  return (
+    <LegalShell
+      titulo="Política de Privacidade"
+      resumo="Que dados o Ensina Dev coleta, por que coleta cada um, com quem compartilha e como você pede para apagar."
+      irmao={{ to: '/termos', label: 'Ler os Termos de Uso' }}
+    >
+      <h2>1. Quem é o responsável pelos seus dados</h2>
+      <p>
+        O Ensina Dev é uma plataforma gratuita de estudos de programação. Somos o controlador dos
+        dados pessoais tratados aqui, nos termos da Lei 13.709/2018 (LGPD). Para qualquer assunto
+        relacionado a esta política, incluindo o exercício dos seus direitos, o canal é{' '}
+        <a className="link" href={`mailto:${CONTATO_LEGAL}`}>
+          {CONTATO_LEGAL}
+        </a>
+        .
+      </p>
+
+      <h2>2. Que dados coletamos</h2>
+
+      <h3>2.1. O que você informa</h3>
+      <ul>
+        <li>
+          <strong>Para criar a conta:</strong> nome, email, nome de usuário, data de nascimento e
+          senha. A senha nunca é guardada como você digitou: gravamos apenas um hash, e nem nós
+          conseguimos ler a original.
+        </li>
+        <li>
+          <strong>Se você entra pelo Google ou pelo GitHub:</strong> recebemos do provedor o seu
+          nome, email e foto de perfil. Não recebemos e não temos acesso à sua senha desses
+          serviços.
+        </li>
+        <li>
+          <strong>No perfil, tudo opcional:</strong> foto, capa, biografia, telefone, gênero,
+          localização, ocupação, idiomas e os links do seu GitHub, LinkedIn e X.
+        </li>
+        <li>
+          <strong>Ao emitir um certificado:</strong> nome completo e CPF. Eles são impressos no
+          documento e usados na página pública de validação, que existe para um terceiro conferir a
+          autenticidade do certificado que você apresentar.
+        </li>
+        <li>
+          <strong>Ao apoiar o projeto:</strong> os dados que o gateway de pagamento exige para gerar
+          a cobrança Pix. Não vemos, não recebemos e não guardamos número de cartão, senha do banco
+          ou credencial financeira.
+        </li>
+        <li>
+          <strong>Ao analisar um currículo:</strong> o arquivo que você envia e a descrição da vaga.
+          Veja a seção 5, que trata desse caso separadamente.
+        </li>
+      </ul>
+
+      <h3>2.2. O que nasce do seu uso</h3>
+      <ul>
+        <li>
+          Aulas concluídas, respostas dos quizzes, XP, ofensiva, conquistas e posição no ranking.
+        </li>
+        <li>Tentativas de simulado, com as respostas e o resultado de cada uma.</li>
+        <li>O código que você envia nos desafios e nos projetos, junto do resultado dos testes.</li>
+        <li>
+          As revisões em cartões, incluindo quanto tempo você levou para responder cada carta. Esse
+          tempo alimenta as estatísticas da sua tela de revisão e o cálculo de quando a carta volta.
+        </li>
+        <li>Seus posts, comentários, curtidas e quem você segue na comunidade.</li>
+      </ul>
+
+      <h3>2.3. Dados técnicos</h3>
+      <p>
+        Como qualquer site, nosso servidor registra em log informações da conexão, como endereço IP,
+        data, hora e navegador. Isso serve para segurança e diagnóstico de falhas, e é a única
+        finalidade desse registro.
+      </p>
+
+      <h2>3. Por que usamos cada dado</h2>
+      <p>
+        A LGPD exige que todo tratamento tenha uma base legal. As nossas são estas, e nada é usado
+        para finalidade diferente da que está listada:
+      </p>
+      <ul>
+        <li>
+          <strong>Manter sua conta e entregar o que a plataforma promete</strong> (aulas, progresso,
+          certificado, ranking, comunidade): execução de contrato, art. 7, V.
+        </li>
+        <li>
+          <strong>Emitir e validar certificados</strong> com nome e CPF: execução de contrato, art.
+          7, V. Sem essa identificação o certificado não teria valor de comprovação.
+        </li>
+        <li>
+          <strong>Processar o apoio financeiro</strong> e guardar o registro da cobrança: execução
+          de contrato e cumprimento de obrigação legal e fiscal, art. 7, II e V.
+        </li>
+        <li>
+          <strong>Analisar seu currículo</strong>: consentimento, art. 7, I. Você escolhe enviar, e
+          nada acontece sem esse envio.
+        </li>
+        <li>
+          <strong>Enviar código de verificação por WhatsApp</strong>: consentimento, art. 7, I. Só
+          usamos se você tiver cadastrado um telefone e escolhido esse canal.
+        </li>
+        <li>
+          <strong>Enviar emails da plataforma</strong> (verificação de email, recuperação de senha):
+          execução de contrato, art. 7, V.
+        </li>
+        <li>
+          <strong>Proteger a plataforma</strong>, bloquear tentativas de invasão e investigar abuso:
+          legítimo interesse, art. 7, IX.
+        </li>
+      </ul>
+      <p>
+        Não vendemos seus dados, não fazemos publicidade e não usamos seu comportamento na
+        plataforma para montar perfis comerciais.
+      </p>
+
+      <h2>4. Com quem compartilhamos</h2>
+      <p>
+        Compartilhamos o mínimo necessário, e apenas com quem executa uma função concreta da
+        plataforma:
+      </p>
+      <ul>
+        <li>
+          <strong>Google e GitHub:</strong> se você optar pelo login social, para autenticar você.
+        </li>
+        <li>
+          <strong>Gateway de pagamento (AbacatePay):</strong> para gerar e confirmar a cobrança Pix
+          do apoio.
+        </li>
+        <li>
+          <strong>Provedor de IA (DeepSeek):</strong> recebe o texto do currículo e a vaga durante a
+          análise. Detalhado na seção 5.
+        </li>
+        <li>
+          <strong>Provedor de email:</strong> recebe seu endereço para entregar as mensagens da
+          plataforma.
+        </li>
+        <li>
+          <strong>Provedor de envio por WhatsApp:</strong> recebe seu número quando você pede o
+          código por esse canal.
+        </li>
+        <li>
+          <strong>Autoridades:</strong> quando houver ordem judicial ou obrigação legal, e apenas na
+          extensão exigida.
+        </li>
+      </ul>
+      <p>
+        Parte desses serviços está fora do Brasil, o que caracteriza transferência internacional de
+        dados (art. 33 da LGPD). É o caso do provedor de IA usado na análise de currículo. Ao usar
+        essa funcionalidade específica, você concorda com essa transferência.
+      </p>
+
+      <h2>5. Análise de currículo e inteligência artificial</h2>
+      <p>
+        Essa funcionalidade merece uma seção própria porque currículo é o dado mais sensível que
+        passa por aqui. O que acontece quando você usa:
+      </p>
+      <ul>
+        <li>Você envia o arquivo e, se quiser, a descrição de uma vaga.</li>
+        <li>
+          Extraímos o texto e enviamos para o provedor de IA, que devolve a leitura qualitativa. A
+          nota é calculada pelo nosso próprio código, não pela IA.
+        </li>
+        <li>
+          <strong>Nem o arquivo nem o texto extraído são guardados.</strong> Do resultado, ficam
+          salvos apenas a pontuação, as palavras-chave encontradas e as sugestões de melhoria, para
+          você reabrir a análise depois.
+        </li>
+        <li>
+          Se você prefere não enviar nada para fora, simplesmente não use essa funcionalidade. Todo
+          o resto da plataforma funciona sem ela.
+        </li>
+      </ul>
+
+      <h2>6. Cookies e armazenamento no navegador</h2>
+      <p>
+        Não usamos cookies de publicidade, de rastreamento ou de análise de audiência. Não há Google
+        Analytics nem ferramenta equivalente na plataforma. O que usamos:
+      </p>
+      <ul>
+        <li>
+          <strong>Um cookie essencial</strong> chamado refreshToken, que mantém você conectado. Ele
+          é httpOnly, ou seja, nem o JavaScript da própria página consegue ler.
+        </li>
+        <li>
+          <strong>Armazenamento local do navegador</strong> para guardar seu token de sessão, suas
+          preferências de tema e o andamento de uma revisão em curso, de modo que atualizar a página
+          não recomece a sessão.
+        </li>
+      </ul>
+      <p>Sair da conta limpa esse armazenamento.</p>
+
+      <h2>7. O que fica público</h2>
+      <p>
+        Seu perfil é público no endereço ensinadev.com.br seguido do seu nome de usuário. Ficam
+        visíveis para qualquer pessoa: seu nome, nome de usuário, foto, capa, biografia, links
+        sociais, XP, conquistas, trilhas concluídas e sua posição no ranking. Seus posts e
+        comentários na comunidade também são públicos.
+      </p>
+      <p>
+        Não são públicos, em nenhuma hipótese: seu email, telefone, data de nascimento, CPF, o
+        conteúdo do seu currículo e suas análises.
+      </p>
+
+      <h2>8. Por quanto tempo guardamos</h2>
+      <ul>
+        <li>Dados da conta e do seu progresso: enquanto a conta existir.</li>
+        <li>
+          Após o pedido de exclusão: apagamos os dados, exceto o que a lei manda reter, como os
+          registros de acesso exigidos pelo Marco Civil da Internet e os registros fiscais de
+          pagamentos recebidos.
+        </li>
+        <li>Currículos enviados: descartados logo após a análise, como explicado na seção 5.</li>
+        <li>
+          Certificados já emitidos: mantidos enquanto forem válidos, porque a página de validação
+          precisa continuar respondendo a quem for conferir.
+        </li>
+      </ul>
+
+      <h2>9. Segurança</h2>
+      <p>
+        Senhas são guardadas com algoritmo de hash próprio para senhas, e não em texto legível. Todo
+        o tráfego entre o seu navegador e a plataforma é criptografado. A conta é bloqueada
+        temporariamente após várias tentativas de login erradas. O código que você envia nos
+        desafios roda em ambiente isolado, sem acesso à rede nem aos dados de outros usuários.
+      </p>
+      <p>
+        Nenhum sistema é imune. Se acontecer um incidente que possa gerar risco relevante para você,
+        vamos comunicar você e a Autoridade Nacional de Proteção de Dados, como manda o art. 48 da
+        LGPD.
+      </p>
+
+      <h2>10. Seus direitos</h2>
+      <p>O art. 18 da LGPD garante a você, sobre os seus dados, o direito de:</p>
+      <ul>
+        <li>confirmar que existe tratamento e acessar os dados;</li>
+        <li>corrigir dados incompletos, inexatos ou desatualizados;</li>
+        <li>pedir anonimização, bloqueio ou eliminação de dados desnecessários ou excessivos;</li>
+        <li>pedir a portabilidade dos dados;</li>
+        <li>pedir a eliminação dos dados tratados com base no seu consentimento;</li>
+        <li>saber com quem compartilhamos seus dados;</li>
+        <li>revogar o consentimento a qualquer momento.</li>
+      </ul>
+      <p>
+        Boa parte disso você resolve sozinho na tela de configurações, editando ou apagando o que
+        quiser do perfil. Para exclusão da conta inteira, exportação dos seus dados ou qualquer
+        pedido que a tela não cubra, escreva para{' '}
+        <a className="link" href={`mailto:${CONTATO_LEGAL}`}>
+          {CONTATO_LEGAL}
+        </a>
+        . Respondemos em até 15 dias.
+      </p>
+      <p>
+        Você também pode reclamar diretamente à Autoridade Nacional de Proteção de Dados, pelo site
+        gov.br/anpd.
+      </p>
+
+      <h2>11. Menores de idade</h2>
+      <p>
+        A plataforma é aberta a adolescentes, e boa parte de quem estuda aqui está começando cedo.
+        Quem tem menos de 16 anos precisa de autorização dos pais ou responsáveis para criar conta.
+        Se identificarmos conta de criança menor de 12 anos sem consentimento de um responsável, ela
+        será removida. Responsáveis podem pedir acesso ou exclusão dos dados pelo email de contato.
+      </p>
+
+      <h2>12. Mudanças nesta política</h2>
+      <p>
+        Se esta política mudar, a data no topo muda junto. Quando a alteração for relevante, como um
+        novo tipo de dado coletado ou um novo terceiro envolvido, avisamos na própria plataforma
+        antes de a mudança valer.
+      </p>
+
+      <h2>13. Contato</h2>
+      <p>
+        Dúvida, pedido ou reclamação sobre privacidade:{' '}
+        <a className="link" href={`mailto:${CONTATO_LEGAL}`}>
+          {CONTATO_LEGAL}
+        </a>
+        .
+      </p>
+    </LegalShell>
+  );
+}

--- a/frontend/src/pages/Legal/Termos.tsx
+++ b/frontend/src/pages/Legal/Termos.tsx
@@ -1,0 +1,194 @@
+import { Link } from 'react-router-dom';
+import { useSeo } from '../../hooks/useSeo';
+import { CONTATO_LEGAL } from '../../data/legal';
+import { LegalShell } from './LegalShell';
+
+export function Termos() {
+  useSeo();
+
+  return (
+    <LegalShell
+      titulo="Termos de Uso"
+      resumo="As regras de uso do Ensina Dev: o que você pode esperar da plataforma e o que esperamos de você."
+      irmao={{ to: '/privacidade', label: 'Ler a Política de Privacidade' }}
+    >
+      <h2>1. Aceite</h2>
+      <p>
+        Ao criar uma conta ou usar o Ensina Dev, você concorda com estes Termos e com a{' '}
+        <Link className="link" to="/privacidade">
+          Política de Privacidade
+        </Link>
+        . Se não concordar com algum ponto, não use a plataforma.
+      </p>
+
+      <h2>2. O que é o Ensina Dev</h2>
+      <p>
+        Uma plataforma de estudos de programação com trilhas de aulas, quizzes, desafios de código,
+        simulados de certificação, projetos guiados e revisão em cartões. O acesso ao conteúdo é
+        gratuito e não existe parte da plataforma trancada atrás de pagamento.
+      </p>
+      <p>
+        O material é educacional. Fazemos o possível para mantê-lo correto e atualizado, mas ele não
+        substitui documentação oficial, orientação profissional nem curso regulamentado.
+      </p>
+
+      <h2>3. Sua conta</h2>
+      <ul>
+        <li>Informe dados verdadeiros. Conta com identidade falsa pode ser removida.</li>
+        <li>
+          Você é responsável por manter sua senha em segredo e por tudo que acontecer na sua conta.
+          Se desconfiar de acesso indevido, troque a senha e avise a gente.
+        </li>
+        <li>
+          Uma pessoa, uma conta. Contas criadas para inflar ranking ou ofensiva são removidas.
+        </li>
+        <li>
+          Menores de 16 anos precisam de autorização dos pais ou responsáveis para usar a
+          plataforma.
+        </li>
+      </ul>
+
+      <h2>4. Uso aceitável</h2>
+      <p>Não é permitido:</p>
+      <ul>
+        <li>
+          tentar burlar o progresso, o XP, a ofensiva, o ranking ou a emissão de certificados por
+          qualquer meio automatizado;
+        </li>
+        <li>
+          usar robôs, scripts ou raspagem para extrair conteúdo em massa, nem sobrecarregar a
+          infraestrutura de propósito;
+        </li>
+        <li>
+          tentar acessar contas, dados ou áreas administrativas que não são suas, ou explorar falhas
+          de segurança em vez de reportá-las;
+        </li>
+        <li>
+          publicar conteúdo ilegal, ofensivo, discriminatório, de assédio, spam ou propaganda;
+        </li>
+        <li>publicar dados pessoais de terceiros sem autorização.</li>
+      </ul>
+      <p>
+        Encontrou uma falha de segurança? Escreva para{' '}
+        <a className="link" href={`mailto:${CONTATO_LEGAL}`}>
+          {CONTATO_LEGAL}
+        </a>{' '}
+        antes de divulgar. Reporte de boa-fé é bem-vindo e nunca vai gerar retaliação.
+      </p>
+
+      <h2>5. O que você publica</h2>
+      <p>
+        Posts, comentários, imagens e código enviados à comunidade continuam sendo seus. Você apenas
+        nos autoriza a exibir, armazenar e distribuir esse conteúdo dentro da plataforma, para que
+        ele apareça para os outros usuários. Você garante que tem o direito de publicar o que
+        publica.
+      </p>
+      <p>
+        Podemos remover conteúdo que viole estes Termos ou a lei. Conteúdo apagado por você sai da
+        plataforma, ressalvadas cópias em backup, que expiram no ciclo normal de retenção.
+      </p>
+
+      <h2>6. Execução de código</h2>
+      <p>
+        Desafios e projetos executam o código que você envia em ambiente isolado, com tempo e
+        recursos limitados. É proibido usar essa execução para minerar criptomoedas, atacar
+        terceiros, varrer redes, hospedar serviços ou qualquer finalidade que não seja resolver o
+        exercício. Tentativas nesse sentido levam à suspensão imediata da conta.
+      </p>
+
+      <h2>7. Certificados</h2>
+      <p>
+        Ao concluir uma trilha você pode emitir um certificado de conclusão, com seu nome, seu CPF,
+        a carga horária e um código público de validação. Ele comprova que você concluiu aquela
+        trilha aqui dentro, e nada além disso.
+      </p>
+      <p>
+        <strong>
+          O certificado não é diploma, não é curso técnico ou superior e não tem reconhecimento do
+          MEC.
+        </strong>{' '}
+        É um comprovante de estudo livre, útil para portfólio e para o currículo.
+      </p>
+      <p>
+        Certificado emitido com dados falsos, ou obtido burlando o progresso, é cancelado, e a
+        página de validação passa a informar isso.
+      </p>
+
+      <h2>8. Apoio ao projeto</h2>
+      <p>
+        O apoio é voluntário e serve para custear a infraestrutura. Ele não desbloqueia conteúdo,
+        porque não existe conteúdo bloqueado: o que ele dá são benefícios visuais na sua conta, como
+        cor de destaque e imagem de fundo personalizadas, além do selo de apoiador.
+      </p>
+      <ul>
+        <li>
+          As cobranças são feitas por Pix, através de um gateway de pagamento. O valor e a duração
+          de cada plano aparecem na tela de apoio antes da confirmação.
+        </li>
+        <li>
+          O apoio pontual não renova sozinho. Se você escolher a modalidade recorrente, pode
+          cancelar quando quiser, e o período já pago continua valendo até o fim.
+        </li>
+        <li>
+          Você tem 7 dias corridos, contados do pagamento, para desistir e pedir o valor de volta,
+          conforme o art. 49 do Código de Defesa do Consumidor. Basta escrever para o email de
+          contato.
+        </li>
+        <li>
+          Se a plataforma for descontinuada, apoios com período em aberto são devolvidos
+          proporcionalmente.
+        </li>
+      </ul>
+
+      <h2>9. Conteúdo da plataforma</h2>
+      <p>
+        As aulas, questões, desafios, a marca e o design do Ensina Dev pertencem ao projeto e aos
+        seus autores. Você pode estudar, imprimir e compartilhar links à vontade. Republicar o
+        material como se fosse seu, vender o conteúdo ou usá-lo para treinar modelos comerciais sem
+        autorização não é permitido.
+      </p>
+
+      <h2>10. Disponibilidade</h2>
+      <p>
+        A plataforma é oferecida como está. Não prometemos funcionamento ininterrupto: pode haver
+        manutenção, instabilidade e falha. Funcionalidades podem mudar ou ser descontinuadas, e
+        quando isso afetar algo que você já usa, avisamos com antecedência razoável.
+      </p>
+
+      <h2>11. Suspensão e encerramento</h2>
+      <p>
+        Podemos suspender ou encerrar contas que violem estes Termos, e nesses casos explicamos o
+        motivo por email. Você pode encerrar sua conta quando quiser, pelo email de contato, o que
+        também apaga seus dados nos limites descritos na Política de Privacidade.
+      </p>
+
+      <h2>12. Limitação de responsabilidade</h2>
+      <p>
+        O Ensina Dev não responde por decisões de carreira, contratações, reprovações em provas de
+        certificação ou prejuízos decorrentes do uso do conteúdo. Nada aqui afasta os direitos que a
+        legislação brasileira, em especial o Código de Defesa do Consumidor, garante a você.
+      </p>
+
+      <h2>13. Mudanças nestes Termos</h2>
+      <p>
+        Quando estes Termos mudarem, a data no topo muda junto, e alterações relevantes são avisadas
+        na plataforma. Continuar usando depois disso significa que você aceitou a nova versão.
+      </p>
+
+      <h2>14. Lei aplicável</h2>
+      <p>
+        Estes Termos são regidos pela lei brasileira. Fica eleito o foro do domicílio do usuário
+        para resolver qualquer controvérsia.
+      </p>
+
+      <h2>15. Contato</h2>
+      <p>
+        Qualquer dúvida sobre estes Termos:{' '}
+        <a className="link" href={`mailto:${CONTATO_LEGAL}`}>
+          {CONTATO_LEGAL}
+        </a>
+        .
+      </p>
+    </LegalShell>
+  );
+}

--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -222,13 +222,13 @@ export function Register() {
 
       <p className="auth__terms">
         Ao criar a conta, você concorda com os{' '}
-        <a className="link" href="#">
+        <Link className="link" to="/termos">
           Termos
-        </a>{' '}
+        </Link>{' '}
         e a{' '}
-        <a className="link" href="#">
+        <Link className="link" to="/privacidade">
           Política de Privacidade
-        </a>
+        </Link>
         .
       </p>
       <p className="auth__foot">

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -456,7 +456,7 @@
 }
 .lp-rodape__grade {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
   gap: 36px;
 }
 .lp-rodape__marca p {

--- a/frontend/src/styles/legal.css
+++ b/frontend/src/styles/legal.css
@@ -1,0 +1,96 @@
+/* Termos de Uso e Política de Privacidade. Documento longo, então a medida da
+   linha é limitada: texto corrido em coluna larga cansa e faz perder a linha. */
+
+.legal {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+}
+
+.legal__topo,
+.legal__rodape {
+  width: min(100% - 2.5rem, 720px);
+  margin-inline: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.legal__topo {
+  padding-block: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.legal__rodape {
+  margin-top: auto;
+  padding-block: 1.5rem 2.5rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.legal__doc {
+  width: min(100% - 2.5rem, 720px);
+  margin-inline: auto;
+  padding-block: 2.5rem 3rem;
+  line-height: 1.7;
+}
+
+.legal__doc h1 {
+  font-size: clamp(1.6rem, 4vw, 2.1rem);
+  line-height: 1.2;
+  margin: 0;
+}
+
+.legal__resumo {
+  color: var(--muted);
+  font-size: 1.02rem;
+  margin: 0.75rem 0 0;
+}
+
+.legal__data {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0.75rem 0 0;
+  padding-bottom: 1.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.legal__doc h2 {
+  font-size: 1.15rem;
+  margin: 2.25rem 0 0.75rem;
+  scroll-margin-top: 1rem;
+}
+
+.legal__doc h3 {
+  font-size: 1rem;
+  color: var(--muted);
+  margin: 1.5rem 0 0.5rem;
+}
+
+.legal__doc p {
+  margin: 0 0 1rem;
+}
+
+.legal__doc ul {
+  margin: 0 0 1rem;
+  padding-left: 1.15rem;
+}
+
+.legal__doc li {
+  margin-bottom: 0.6rem;
+}
+
+.legal__doc strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .legal__doc {
+    padding-block: 1.75rem 2.25rem;
+  }
+}


### PR DESCRIPTION
No rodapé do cadastro, "Termos" e "Política de Privacidade" apontavam para `href="#"`, e nenhuma das duas páginas existia na aplicação. Quem clicava não ia a lugar nenhum, e o aceite no cadastro não tinha o que aceitar.

## O que entra

Duas páginas públicas em `/termos` e `/privacidade`, com casca própria (`LegalShell`), rota fora do login e SEO indexável. Entraram também no `sitemap.xml` e ganharam a coluna Legal no rodapé da landing.

## Sobre o conteúdo

O texto não é modelo genérico. Cada afirmação foi conferida contra o código antes de entrar:

- **Dados coletados** conferidos no `schema.ts`: campos do perfil, CPF do certificado, progresso e respostas, código dos desafios, tempo de resposta dos cartões, posts da comunidade.
- **Terceiros** levantados em `src/services/`: Google e GitHub no login social, AbacatePay no Pix, DeepSeek na análise de currículo, provedor de email e o gateway de WhatsApp do OTP.
- **Transferência internacional** declarada, por causa do provedor de IA.
- **A análise de currículo não guarda o currículo**, nem o arquivo nem o texto extraído, e isso virou uma seção própria por ser o dado mais sensível que passa pela plataforma.
- **Cookies**: só o `refreshToken`, httpOnly. Não há analytics nem pixel de anúncio no front, então a política afirma isso de forma direta.

Cada finalidade vem com a base legal correspondente da LGPD, e a seção de direitos explica como pedir exportação e exclusão.

Os termos cobrem conta, uso aceitável, conteúdo publicado, execução de código no runner, certificado (com o aviso de que não tem reconhecimento do MEC), apoio ao projeto com o prazo de arrependimento do CDC e limitação de responsabilidade.

## Antes de mergear

- O endereço `contato@ensinadev.com.br` precisa existir. É o canal do art. 18 da LGPD nos dois documentos, e ele está centralizado em `frontend/src/data/legal.ts` para trocar em um lugar só.
- O texto é fiel ao que o código faz, mas fidelidade técnica não é parecer jurídico. Vale uma revisão antes de valer como documento oficial.
- Fica registrado que não existe exclusão de conta self-service. A política resolve pelo email de contato, o que a lei aceita, mas o botão em configurações continua faltando.