### PR TITLE
fix: pergunta repetida e ordem fixa na revisão

### DIFF
--- a/backend/scripts/dedupe-flashcards.ts
+++ b/backend/scripts/dedupe-flashcards.ts
@@ -1,0 +1,93 @@
+// Remove do baralho dos alunos a carta gêmea: a mesma pergunta aberta duas vezes na
+// mesma trilha.
+//
+// Como aconteceu: trilha com dois trilhos de linguagem tem a mesma aula duas vezes,
+// uma por linguagem. O cartão conceitual vale para os dois e foi semeado nas duas
+// aulas, virando duas linhas de flashcards com a MESMA pergunta. Quem estudou os
+// dois trilhos concluiu as duas aulas e abriu as duas cartas, e via a pergunta
+// repetida na revisão.
+//
+// O código já não cria mais essas gêmeas (ver abrirCartoesDaAula). Este script é só
+// a limpeza do que ficou para trás.
+//
+// Qual das duas fica: a mais estudada, contando repetições e lapsos. Entre duas com
+// a mesma bagagem fica a de menor estabilidade, que volta mais cedo para a fila:
+// entre esconder uma carta que o aluno talvez não saiba e mostrá-la de novo, mostrar
+// é o erro barato.
+//
+// O histórico em card_reviews NÃO é tocado. O aluno respondeu aquelas cartas de
+// verdade, e apagar as respostas reescreveria as estatísticas e o histórico de
+// sessões dele.
+//
+// Idempotente: rodar de novo não acha mais nada.
+//
+// Conferir sem gravar:  node scripts/dedupe-flashcards.ts
+// Aplicar de verdade:   node scripts/dedupe-flashcards.ts --aplicar
+import { db } from "../db.ts";
+import { sql } from "drizzle-orm";
+
+// A gêmea é a segunda em diante dentro do grupo (aluno, trilha, pergunta).
+const GEMEAS = sql`
+    select uc.id
+    from (
+        select uc.id,
+               row_number() over (
+                   partition by uc.user_id, l.trail_id, f.frente
+                   order by (uc.repeticoes + uc.lapsos) desc, uc.estabilidade asc, uc.id asc
+               ) as posicao
+        from user_cards uc
+        join flashcards f on f.id = uc.origem_id and uc.origem = 'flashcard'
+        join lessons l on l.id = f.lesson_id
+    ) uc
+    where uc.posicao > 1
+`;
+
+async function conferir() {
+    const { rows } = await db.execute<{
+        trilha: string;
+        alunos: string;
+        gemeas: string;
+    }>(sql`
+        select t.name as trilha,
+               count(distinct uc.user_id)::text as alunos,
+               count(*)::text as gemeas
+        from user_cards uc
+        join flashcards f on f.id = uc.origem_id and uc.origem = 'flashcard'
+        join lessons l on l.id = f.lesson_id
+        join trails t on t.id = l.trail_id
+        where uc.id in (${GEMEAS})
+        group by t.name
+        order by count(*) desc
+    `);
+    return rows;
+}
+
+async function limpar() {
+    const linhas = await conferir();
+    if (!linhas.length) {
+        console.log("Nenhuma carta gêmea no baralho de ninguém. Nada a fazer.");
+        return;
+    }
+
+    let total = 0;
+    for (const l of linhas) {
+        console.log(`${l.trilha}: ${l.gemeas} gêmea(s) em ${l.alunos} aluno(s).`);
+        total += Number(l.gemeas);
+    }
+    console.log(`Total: ${total} carta(s) a remover do baralho.`);
+
+    if (!process.argv.includes("--aplicar")) {
+        console.log("\nSimulação. Rode com --aplicar para gravar.");
+        return;
+    }
+
+    const apagadas = await db.execute(sql`delete from user_cards where id in (${GEMEAS})`);
+    console.log(`\nRemovidas ${apagadas.rowCount ?? total} carta(s) do baralho.`);
+}
+
+limpar()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha ao remover as cartas gemeas:", e);
+        process.exit(1);
+    });

--- a/backend/src/services/flashcard.service.ts
+++ b/backend/src/services/flashcard.service.ts
@@ -84,6 +84,27 @@ const APOS_ERRO = 0.4;
 
 const entre = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
 
+/**
+ * Fisher-Yates na ordem de APRESENTAÇÃO. Roda sempre depois de o limite já ter
+ * cortado a fila: quem entra na sessão continua sendo decidido pela data de
+ * vencimento, que é trabalho do agendador. Sortear antes do corte faria a carta
+ * atrasada há duas semanas perder a vaga para uma que venceu hoje.
+ *
+ * Por que embaralhar: em ordem fixa a carta anterior vira pista da seguinte, e o
+ * aluno passa a responder a sequência em vez da pergunta. Isso infla a nota que
+ * ele dá, e a nota é justamente o que define a estabilidade e a próxima data. A
+ * ordem fixa não deixa a revisão só monótona, ela distorce o agendador. De
+ * quebra, misturar as aulas é prática intercalada em vez de em bloco, que rende
+ * mais retenção mesmo parecendo mais difícil na hora.
+ */
+function embaralhar<T>(itens: T[]): T[] {
+    for (let i = itens.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [itens[i], itens[j]] = [itens[j], itens[i]];
+    }
+    return itens;
+}
+
 /** A curva: chance de lembrar depois de tantos dias sem rever o cartão. */
 export function retencao(estabilidade: number, dias: number): number {
     if (estabilidade <= 0) return 0;
@@ -350,7 +371,10 @@ export async function filaDoDia(
     }
     if (!linhas.length) return [];
 
-    return montarCartoes(linhas);
+    // A ordem por vencimento acima escolheu QUAIS cartas entram. Daqui para frente
+    // a ordem é sorteada, senão a fila sai em blocos por aula, sempre na mesma
+    // sequência em que as cartas foram autoradas.
+    return montarCartoes(embaralhar(linhas));
 }
 
 async function montarCartoes(
@@ -552,13 +576,15 @@ export async function revisaoDaTrilha(userId: string, trailId: string) {
     // trilho de linguagem chega mesmo depois do baralho limpo. Fica a primeira na
     // ordem da trilha, que é estável.
     const vistas = new Set<string>();
-    return cartoes
-        .filter((c) => {
-            if (vistas.has(c.frente)) return false;
-            vistas.add(c.frente);
-            return true;
-        })
-        .map((c) => ({ ...c, origem: "flashcard" as const }));
+    const unicos = cartoes.filter((c) => {
+        if (vistas.has(c.frente)) return false;
+        vistas.add(c.frente);
+        return true;
+    });
+
+    // A ordem da trilha acima serve ao dedup, que precisa ser estável. A revisão em
+    // si sai sorteada: aqui o objetivo é retenção, não refazer o caminho da trilha.
+    return embaralhar(unicos).map((c) => ({ ...c, origem: "flashcard" as const }));
 }
 
 /** Quantos cartões a trilha já liberou para este aluno. Alimenta a chamada de revisão. */

--- a/backend/src/services/flashcard.service.ts
+++ b/backend/src/services/flashcard.service.ts
@@ -191,6 +191,26 @@ async function termosDaAula(lessonId: string): Promise<string[]> {
 }
 
 /**
+ * As perguntas que o aluno já tem abertas nesta trilha.
+ *
+ * A identidade de um cartão dentro da trilha é a pergunta, não a linha: o QC do
+ * seeder proíbe frente repetida na mesma trilha, então frente igual é sempre o
+ * mesmo cartão. É o que permite reconhecer a gêmea de outro trilho de linguagem.
+ */
+async function frentesAbertas(userId: string, trailId: string): Promise<Set<string>> {
+    const linhas = await db
+        .select({ frente: flashcards.frente })
+        .from(userCards)
+        .innerJoin(
+            flashcards,
+            and(eq(userCards.origem, "flashcard"), eq(flashcards.id, userCards.origemId)),
+        )
+        .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
+        .where(and(eq(userCards.userId, userId), eq(lessons.trailId, trailId)));
+    return new Set(linhas.map((l) => l.frente));
+}
+
+/**
  * Cria o estado dos cartões de uma aula que o aluno acabou de concluir. Cartão de
  * aula não estudada nunca entra: entregaria a resposta antes da hora.
  *
@@ -198,13 +218,26 @@ async function termosDaAula(lessonId: string): Promise<string[]> {
  * definição. É a mesma regra: o aluno só recebe o que já leu.
  */
 export async function abrirCartoesDaAula(userId: string, lessonId: string) {
-    const [cartoes, idsGlossario] = await Promise.all([
-        db.select({ id: flashcards.id }).from(flashcards).where(eq(flashcards.lessonId, lessonId)),
+    const [[aula], cartoes, idsGlossario] = await Promise.all([
+        db.select({ trailId: lessons.trailId }).from(lessons).where(eq(lessons.id, lessonId)),
+        db
+            .select({ id: flashcards.id, frente: flashcards.frente })
+            .from(flashcards)
+            .where(eq(flashcards.lessonId, lessonId)),
         termosDaAula(lessonId),
     ]);
 
+    // Trilha com trilhos de linguagem tem a mesma aula duas vezes, uma por
+    // linguagem, e o cartão conceitual foi semeado nas duas: são linhas
+    // diferentes com a MESMA pergunta. Quem estudou os dois trilhos abriria as
+    // duas e veria a pergunta repetida na revisão. A pergunta que o aluno já tem
+    // na trilha barra a gêmea.
+    const jaPerguntadas = aula ? await frentesAbertas(userId, aula.trailId) : new Set<string>();
+
     const candidatos = [
-        ...cartoes.map((c) => ({ origem: "flashcard" as const, origemId: c.id })),
+        ...cartoes
+            .filter((c) => !jaPerguntadas.has(c.frente))
+            .map((c) => ({ origem: "flashcard" as const, origemId: c.id })),
         ...idsGlossario.map((id) => ({ origem: "glossario" as const, origemId: id })),
     ];
     if (!candidatos.length) return 0;
@@ -447,7 +480,7 @@ async function abrirCartaoAvulso(
     if (origem !== "flashcard") throw new AppError(404, "Cartão não encontrado no seu baralho.");
 
     const [permitido] = await db
-        .select({ id: flashcards.id })
+        .select({ frente: flashcards.frente, trailId: lessons.trailId })
         .from(flashcards)
         .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
         .innerJoin(
@@ -456,6 +489,28 @@ async function abrirCartaoAvulso(
         )
         .where(eq(flashcards.id, origemId));
     if (!permitido) throw new AppError(404, "Cartão não encontrado no seu baralho.");
+
+    // Se a mesma pergunta já está aberta pelo outro trilho de linguagem, responder
+    // aqui mexe naquele cartão em vez de abrir um segundo. Sem isso a gêmea
+    // renasceria no baralho pela porta de trás, que é o caminho da revisão de
+    // trilha (ela lê o catálogo, não o baralho).
+    const [gemea] = await db
+        .select({ uc: userCards })
+        .from(userCards)
+        .innerJoin(
+            flashcards,
+            and(eq(userCards.origem, "flashcard"), eq(flashcards.id, userCards.origemId)),
+        )
+        .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
+        .where(
+            and(
+                eq(userCards.userId, userId),
+                eq(lessons.trailId, permitido.trailId),
+                eq(flashcards.frente, permitido.frente),
+            ),
+        )
+        .limit(1);
+    if (gemea) return gemea.uc;
 
     const [criado] = await db
         .insert(userCards)
@@ -493,13 +548,25 @@ export async function revisaoDaTrilha(userId: string, trailId: string) {
         .where(and(eq(lessons.trailId, trailId), eq(lessons.published, true)))
         .orderBy(asc(modules.position), asc(lessons.position), asc(flashcards.position));
 
-    return cartoes.map((c) => ({ ...c, origem: "flashcard" as const }));
+    // Aqui a leitura é do catálogo, e não do baralho, então a gêmea do outro
+    // trilho de linguagem chega mesmo depois do baralho limpo. Fica a primeira na
+    // ordem da trilha, que é estável.
+    const vistas = new Set<string>();
+    return cartoes
+        .filter((c) => {
+            if (vistas.has(c.frente)) return false;
+            vistas.add(c.frente);
+            return true;
+        })
+        .map((c) => ({ ...c, origem: "flashcard" as const }));
 }
 
 /** Quantos cartões a trilha já liberou para este aluno. Alimenta a chamada de revisão. */
 export async function contarRevisaoDaTrilha(userId: string, trailId: string) {
     const [linha] = await db
-        .select({ n: count() })
+        // Conta pergunta distinta, e não linha, pelo mesmo motivo do dedup em
+        // revisaoDaTrilha: senão o botão promete mais cartas do que vai mostrar.
+        .select({ n: sql<number>`count(distinct ${flashcards.frente})` })
         .from(flashcards)
         .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
         .innerJoin(

--- a/backend/tests/flashcard.test.ts
+++ b/backend/tests/flashcard.test.ts
@@ -1,0 +1,134 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { limparBanco } from "./helpers/db.ts";
+import { db } from "../db.ts";
+import { flashcards, lessonProgress, lessons, modules, trails, users } from "../schema.ts";
+import {
+    abrirCartoesDaAula,
+    contarRevisaoDaTrilha,
+    filaDoDia,
+    revisaoDaTrilha,
+} from "../src/services/flashcard.service.ts";
+
+/**
+ * Trilha com dois trilhos de linguagem: a mesma aula existe duas vezes, uma em
+ * JavaScript e outra em Python, na mesma posição. O cartão conceitual ("O que é um
+ * algoritmo?") vale para os dois e por isso foi semeado nas duas aulas, em linhas
+ * diferentes com a mesma pergunta. Cada trilho ainda tem o cartão de sintaxe dele.
+ */
+async function montarTrilhaComDoisTrilhos() {
+    const [trilha] = await db
+        .insert(trails)
+        .values({ name: "Lógica", trailLevel: "iniciante", description: "trilha de teste" })
+        .returning();
+    const [modulo] = await db
+        .insert(modules)
+        .values({ trailId: trilha.id, title: "Módulo 1", position: 1 })
+        .returning();
+
+    const aulaDe = async (language: string) => {
+        const [aula] = await db
+            .insert(lessons)
+            .values({
+                trailId: trilha.id,
+                moduleId: modulo.id,
+                title: `Algoritmos em ${language}`,
+                position: 1,
+                published: true,
+                language,
+            })
+            .returning();
+        await db.insert(flashcards).values([
+            {
+                lessonId: aula.id,
+                frente: "O que é um algoritmo?",
+                verso: "Sequência de passos",
+                position: 0,
+            },
+            {
+                lessonId: aula.id,
+                frente: `Como declarar variável em ${language}?`,
+                verso: "Depende da linguagem",
+                position: 1,
+            },
+        ]);
+        return aula;
+    };
+
+    return { trilha, js: await aulaDe("javascript"), py: await aulaDe("python") };
+}
+
+async function novoAluno() {
+    const [aluno] = await db
+        .insert(users)
+        .values({
+            name: "Aluno",
+            email: `aluno_${Math.random().toString(36).slice(2)}@email.com`,
+            passwordHash: "x",
+        })
+        .returning();
+    return aluno;
+}
+
+async function concluir(userId: string, lessonId: string) {
+    await db.insert(lessonProgress).values({ userId, lessonId, completedAt: new Date() });
+    await abrirCartoesDaAula(userId, lessonId);
+}
+
+describe("cartões em trilha com trilhos de linguagem", () => {
+    beforeEach(limparBanco);
+
+    test("aluno que estudou os dois trilhos recebe a pergunta comum uma vez só", async () => {
+        const { js, py } = await montarTrilhaComDoisTrilhos();
+        const aluno = await novoAluno();
+
+        await concluir(aluno.id, js.id);
+        await concluir(aluno.id, py.id);
+
+        const fila = await filaDoDia(aluno.id);
+        const perguntas = fila.map((c) => c.frente).sort();
+
+        assert.deepEqual(perguntas, [
+            "Como declarar variável em javascript?",
+            "Como declarar variável em python?",
+            "O que é um algoritmo?",
+        ]);
+    });
+
+    test("aluno de um trilho só continua recebendo a pergunta comum", async () => {
+        const { py } = await montarTrilhaComDoisTrilhos();
+        const aluno = await novoAluno();
+
+        await concluir(aluno.id, py.id);
+
+        const perguntas = (await filaDoDia(aluno.id)).map((c) => c.frente).sort();
+        assert.deepEqual(perguntas, ["Como declarar variável em python?", "O que é um algoritmo?"]);
+    });
+
+    test("a revisão da trilha não repete a pergunta comum", async () => {
+        const { trilha, js, py } = await montarTrilhaComDoisTrilhos();
+        const aluno = await novoAluno();
+
+        await concluir(aluno.id, js.id);
+        await concluir(aluno.id, py.id);
+
+        const cartoes = await revisaoDaTrilha(aluno.id, trilha.id);
+        const perguntas = cartoes.map((c) => c.frente);
+
+        assert.equal(new Set(perguntas).size, perguntas.length, "pergunta repetida na revisão");
+        assert.equal(perguntas.length, 3);
+    });
+
+    test("a contagem da trilha bate com o que a revisão entrega", async () => {
+        const { trilha, js, py } = await montarTrilhaComDoisTrilhos();
+        const aluno = await novoAluno();
+
+        await concluir(aluno.id, js.id);
+        await concluir(aluno.id, py.id);
+
+        const { total } = await contarRevisaoDaTrilha(aluno.id, trilha.id);
+        const cartoes = await revisaoDaTrilha(aluno.id, trilha.id);
+
+        assert.equal(total, cartoes.length);
+    });
+});

--- a/backend/tests/flashcard.test.ts
+++ b/backend/tests/flashcard.test.ts
@@ -2,7 +2,16 @@ import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { limparBanco } from "./helpers/db.ts";
 import { db } from "../db.ts";
-import { flashcards, lessonProgress, lessons, modules, trails, users } from "../schema.ts";
+import {
+    flashcards,
+    lessonProgress,
+    lessons,
+    modules,
+    trails,
+    userCards,
+    users,
+} from "../schema.ts";
+import { and, eq } from "drizzle-orm";
 import {
     abrirCartoesDaAula,
     contarRevisaoDaTrilha,
@@ -130,5 +139,105 @@ describe("cartões em trilha com trilhos de linguagem", () => {
         const cartoes = await revisaoDaTrilha(aluno.id, trilha.id);
 
         assert.equal(total, cartoes.length);
+    });
+});
+
+/** Uma aula com N cartas numeradas, todas já abertas no baralho do aluno. */
+async function aulaCom(quantas: number, userId: string) {
+    const [trilha] = await db
+        .insert(trails)
+        .values({ name: "Trilha", trailLevel: "iniciante", description: "x" })
+        .returning();
+    const [modulo] = await db
+        .insert(modules)
+        .values({ trailId: trilha.id, title: "M1", position: 1 })
+        .returning();
+    const [aula] = await db
+        .insert(lessons)
+        .values({
+            trailId: trilha.id,
+            moduleId: modulo.id,
+            title: "Aula",
+            position: 1,
+            published: true,
+        })
+        .returning();
+
+    await db.insert(flashcards).values(
+        Array.from({ length: quantas }, (_, i) => ({
+            lessonId: aula.id,
+            frente: `Pergunta ${i}?`,
+            verso: `Resposta ${i}`,
+            position: i,
+        })),
+    );
+    await db.insert(lessonProgress).values({ userId, lessonId: aula.id });
+    await abrirCartoesDaAula(userId, aula.id);
+    return { trilha, aula };
+}
+
+/** Vence a carta de uma pergunta há tantos dias. */
+async function vencerHa(userId: string, frente: string, dias: number) {
+    const [card] = await db.select().from(flashcards).where(eq(flashcards.frente, frente));
+    await db
+        .update(userCards)
+        .set({ proximaRevisao: new Date(Date.now() - dias * 86400000) })
+        .where(and(eq(userCards.userId, userId), eq(userCards.origemId, card.id)));
+}
+
+describe("ordem da fila de revisão", () => {
+    beforeEach(limparBanco);
+
+    test("o limite continua escolhendo as cartas mais atrasadas", async () => {
+        const aluno = await novoAluno();
+        await aulaCom(6, aluno.id);
+        // Quanto maior o índice, mais recente o vencimento.
+        for (let i = 0; i < 6; i++) await vencerHa(aluno.id, `Pergunta ${i}?`, 30 - i * 5);
+
+        const fila = await filaDoDia(aluno.id, 3);
+
+        assert.equal(fila.length, 3);
+        assert.deepEqual(
+            new Set(fila.map((c) => c.frente)),
+            new Set(["Pergunta 0?", "Pergunta 1?", "Pergunta 2?"]),
+            "o corte tem de pegar as três mais atrasadas, e não três quaisquer",
+        );
+    });
+
+    test("a ordem em que as cartas aparecem varia entre sessões", async () => {
+        const aluno = await novoAluno();
+        await aulaCom(10, aluno.id);
+
+        const ordens = new Set<string>();
+        for (let i = 0; i < 6; i++) {
+            ordens.add((await filaDoDia(aluno.id)).map((c) => c.frente).join("|"));
+        }
+
+        // Seis sorteios de dez cartas caindo todos na mesma ordem é praticamente
+        // impossível: se acontecer, é porque não há sorteio nenhum.
+        assert.ok(ordens.size > 1, "a fila saiu na mesma ordem nas seis vezes");
+    });
+
+    test("a revisão da trilha também sai sorteada", async () => {
+        const aluno = await novoAluno();
+        const { trilha } = await aulaCom(10, aluno.id);
+
+        const ordens = new Set<string>();
+        for (let i = 0; i < 6; i++) {
+            ordens.add((await revisaoDaTrilha(aluno.id, trilha.id)).map((c) => c.frente).join("|"));
+        }
+
+        assert.ok(ordens.size > 1, "a revisão da trilha saiu na mesma ordem nas seis vezes");
+    });
+
+    test("sortear não perde nem duplica carta", async () => {
+        const aluno = await novoAluno();
+        await aulaCom(10, aluno.id);
+
+        const fila = await filaDoDia(aluno.id);
+        const perguntas = fila.map((c) => c.frente);
+
+        assert.equal(perguntas.length, 10);
+        assert.equal(new Set(perguntas).size, 10);
     });
 });

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -6,6 +6,6 @@ export async function limparBanco() {
     // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
     // porque elas nao referenciam users e nao cairiam no cascade.
     await db.execute(
-        sql`TRUNCATE TABLE feature_flag_users, feature_flags, community_comments, community_likes, community_post_tags, community_posts, user_follows, subscriptions, certificates, roadmap_stage_completions, roadmap_stage_refs, roadmap_stages, roadmaps, comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE feature_flag_users, feature_flags, community_comments, community_likes, community_post_tags, community_posts, user_follows, subscriptions, certificates, roadmap_stage_completions, roadmap_stage_refs, roadmap_stages, roadmaps, comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, card_reports, card_reviews, user_cards, flashcards, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
     );
 }


### PR DESCRIPTION
Rodando a revisão de Lógica de Programação, as mesmas perguntas voltavam dentro da mesma sessão. Investigando isso apareceu um segundo problema, na ordem da fila.

## 1. A pergunta repetida

Em Lógica de Programação toda aula existe **duas vezes**, uma em JavaScript e outra em Python, na mesma posição. Não há aula neutra na trilha.

O seeder monta os cartões de uma aula como `neutra` mais os da linguagem dela. Como o cartão conceitual está em `neutra`, ele foi gravado nas **duas** aulas: duas linhas de `flashcards`, ids diferentes, pergunta idêntica. Quem estudou os dois trilhos concluiu as duas aulas, abriu as duas cartas e via a pergunta duas vezes.

Números de produção, antes da correção:

| | |
|---|---|
| Cartas da trilha | 192, sendo 129 perguntas distintas |
| Gêmeas no catálogo | 63 |
| Alunos afetados | 43 |
| Cartas gêmeas no baralho deles | 2.214 |

Nenhuma outra trilha é afetada: Lógica é a única com trilhos de linguagem.

A identidade de um cartão dentro da trilha passa a ser a **pergunta**, e não a linha. Isso já era verdade no seeder, cujo QC reprova frente repetida na mesma trilha, então frente igual sempre foi o mesmo cartão.

- `abrirCartoesDaAula` não abre a gêmea de uma pergunta que o aluno já tem na trilha. Quem estudou um trilho só continua recebendo o cartão conceitual normalmente, que é o ponto: manter as duas linhas no catálogo é o que garante isso.
- `abrirCartaoAvulso` devolve a gêmea já aberta em vez de criar a segunda. Fecha a porta de trás, que é a revisão de trilha lendo o catálogo.
- `revisaoDaTrilha` e a contagem dela deduplicam por pergunta, porque leem o catálogo direto e alcançam a gêmea mesmo com o baralho limpo.

## 2. A ordem fixa

A fila saía em blocos por aula, e dentro da aula na ordem em que as cartas foram autoradas. Consultando um aluno real em produção, a sequência era sempre a mesma.

Isso é pior do que parece. Numa sequência fixa a carta anterior vira pista da seguinte, e o aluno passa a responder a sequência em vez da pergunta. Isso infla a nota que ele dá, e a nota é justamente o que define a estabilidade e a próxima data. A ordem fixa não deixava a revisão só monótona, ela distorcia o agendador. Misturar as aulas também troca prática em bloco por intercalada, que rende mais retenção.

O sorteio é **só da apresentação**. A seleção continua por data de vencimento: quando o aluno pede 20 cartas, as 20 que entram são as mais atrasadas, e só depois disso a ordem é sorteada. Sortear antes do corte faria carta atrasada há duas semanas perder a vaga para uma que venceu hoje.

## Testes

`backend/tests/flashcard.test.ts`, oito casos no banco efêmero. Cada um foi conferido contra a regressão que deveria pegar:

- sem a correção das gêmeas, dois casos falham;
- sem o sorteio, os dois casos de ordem falham;
- com o sorteio movido para antes do limite, o caso de seleção falha.

## Depois do merge

`backend/scripts/dedupe-flashcards.ts` remove as 2.214 gêmeas já abertas. Simula por padrão e só grava com `--aplicar`. Fica a carta mais estudada; entre iguais, a de menor estabilidade, que volta mais cedo para a fila. Das 2.214, apenas 2 têm qualquer histórico, então a limpeza é quase toda de carta nunca tocada. O histórico em `card_reviews` não é alterado.

**A ordem importa:** deployar antes, limpar depois. Sem a correção no ar, responder uma gêmea na revisão de trilha recria a linha.