### PR TITLE
feat: a sala de revisão serve a trilha inteira, igual ao botão da trilha

### DIFF
--- a/backend/src/controllers/FlashcardController.ts
+++ b/backend/src/controllers/FlashcardController.ts
@@ -36,8 +36,7 @@ export const getFila = async (req: Request, res: Response, next: NextFunction) =
             .map((t) => t.trim())
             .filter((t) => UUID.test(t));
         const glossario = req.query.glossario === "1";
-        const adiantado = req.query.adiantado === "1";
-        res.json(await filaDoDia(req.userId!, limite, { trilhas, glossario, adiantado }));
+        res.json(await filaDoDia(req.userId!, limite, { trilhas, glossario }));
     } catch (err) {
         next(err);
     }

--- a/backend/src/services/flashcard.service.ts
+++ b/backend/src/services/flashcard.service.ts
@@ -10,7 +10,7 @@ import {
     trails,
     glossary,
 } from "../../schema.ts";
-import { and, asc, count, desc, eq, gt, inArray, isNotNull, lte, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, isNotNull, lte, sql } from "drizzle-orm";
 import { AppError } from "../errors/AppError.ts";
 
 /**
@@ -308,19 +308,28 @@ interface CartaoNaFila {
  * quiser para na hora que cansar, que dá no mesmo. O limite alto que sobra é só uma
  * trava de payload, para um baralho gigante não virar uma resposta de megabytes.
  */
+/**
+ * A fila de revisão do conteúdo escolhido.
+ *
+ * Serve TUDO que o aluno já estudou naquele conteúdo, e não só o que venceu hoje.
+ * A tela da trilha sempre funcionou assim, e ver "4 cartas" na sala de revisão e
+ * "116" no botão da trilha, para o mesmo conteúdo, é diferença que ninguém
+ * consegue explicar para quem está estudando. As duas fazem a mesma coisa, então
+ * entregam o mesmo número.
+ *
+ * O agendador não sai de cena, muda de papel: ele deixa de trancar o que aparece e
+ * passa a mandar na PRIORIDADE. A ordem é do mais atrasado para o mais adiantado,
+ * então quando o aluno pede um número de cartas, quem entra no corte é o que está
+ * mais perto de ser esquecido. Responder continua reagendando cada carta pela
+ * curva, e responder adiantado continua rendendo menos estabilidade, pelo bônus
+ * abaixo de 1.
+ */
 export async function filaDoDia(
     userId: string,
     limite = 500,
-    filtro?: { trilhas?: string[]; glossario?: boolean; adiantado?: boolean },
+    filtro?: { trilhas?: string[]; glossario?: boolean },
 ): Promise<CartaoNaFila[]> {
-    // Modo adiantado serve o que ainda NÃO venceu, do mais perto de vencer para o
-    // mais longe. Existe para quem está em dia e quer estudar mesmo assim, e o
-    // agendador já se protege sozinho: responder cedo cai no bônus abaixo de 1 e
-    // rende menos estabilidade que responder na data.
-    const agora = new Date();
-    const vencidos = filtro?.adiantado
-        ? and(eq(userCards.userId, userId), gt(userCards.proximaRevisao, agora))
-        : and(eq(userCards.userId, userId), lte(userCards.proximaRevisao, agora));
+    const meus = eq(userCards.userId, userId);
 
     // Sem filtro a fila é o baralho inteiro. Com filtro, a seleção de trilhas e o
     // glossário são somados: dá para revisar duas trilhas juntas, ou só o glossário.
@@ -330,7 +339,7 @@ export async function filaDoDia(
         linhas = await db
             .select()
             .from(userCards)
-            .where(vencidos)
+            .where(meus)
             .orderBy(asc(userCards.proximaRevisao))
             .limit(limite);
     } else {
@@ -348,7 +357,7 @@ export async function filaDoDia(
                         ),
                     )
                     .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
-                    .where(and(vencidos, inArray(lessons.trailId, filtro.trilhas)))
+                    .where(and(meus, inArray(lessons.trailId, filtro.trilhas)))
                     .orderBy(asc(userCards.proximaRevisao))
                     .limit(limite)
                     .then((r) => r.map((x) => x.uc)),
@@ -359,7 +368,7 @@ export async function filaDoDia(
                 db
                     .select()
                     .from(userCards)
-                    .where(and(vencidos, eq(userCards.origem, "glossario")))
+                    .where(and(meus, eq(userCards.origem, "glossario")))
                     .orderBy(asc(userCards.proximaRevisao))
                     .limit(limite),
             );
@@ -374,7 +383,42 @@ export async function filaDoDia(
     // A ordem por vencimento acima escolheu QUAIS cartas entram. Daqui para frente
     // a ordem é sorteada, senão a fila sai em blocos por aula, sempre na mesma
     // sequência em que as cartas foram autoradas.
-    return montarCartoes(embaralhar(linhas));
+    return montarCartoes(embaralhar(await semGemeas(linhas)));
+}
+
+/**
+ * Tira da fila a carta gêmea: a mesma pergunta duas vezes na mesma trilha, uma por
+ * trilho de linguagem.
+ *
+ * O código já não abre mais gêmea (ver abrirCartoesDaAula) e existe script para
+ * limpar as antigas, mas enquanto sobrar uma no baralho de alguém ela apareceria
+ * repetida na sessão, e o total da sala não bateria com o da trilha. Como as linhas
+ * chegam ordenadas por vencimento, a que fica é a mais atrasada.
+ *
+ * Cartão de glossário passa direto: o id dele já é único por termo.
+ */
+async function semGemeas<T extends { origem: "flashcard" | "glossario"; origemId: string }>(
+    linhas: T[],
+): Promise<T[]> {
+    const ids = linhas.filter((l) => l.origem === "flashcard").map((l) => l.origemId);
+    if (!ids.length) return linhas;
+
+    const dados = await db
+        .select({ id: flashcards.id, frente: flashcards.frente, trailId: lessons.trailId })
+        .from(flashcards)
+        .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
+        .where(inArray(flashcards.id, ids));
+    const porId = new Map(dados.map((d) => [d.id, `${d.trailId}:${d.frente}`]));
+
+    const vistas = new Set<string>();
+    return linhas.filter((l) => {
+        if (l.origem !== "flashcard") return true;
+        const chave = porId.get(l.origemId);
+        if (!chave) return true;
+        if (vistas.has(chave)) return false;
+        vistas.add(chave);
+        return true;
+    });
 }
 
 async function montarCartoes(

--- a/backend/tests/flashcard.test.ts
+++ b/backend/tests/flashcard.test.ts
@@ -185,6 +185,82 @@ async function vencerHa(userId: string, frente: string, dias: number) {
         .where(and(eq(userCards.userId, userId), eq(userCards.origemId, card.id)));
 }
 
+describe("a fila serve a trilha inteira, e não só o que venceu", () => {
+    beforeEach(limparBanco);
+
+    test("carta agendada para o futuro continua na fila", async () => {
+        const aluno = await novoAluno();
+        await aulaCom(5, aluno.id);
+        // Tudo agendado para daqui a uma semana: pela regra antiga, fila vazia.
+        await db
+            .update(userCards)
+            .set({ proximaRevisao: new Date(Date.now() + 7 * 86400000) })
+            .where(eq(userCards.userId, aluno.id));
+
+        const fila = await filaDoDia(aluno.id);
+
+        assert.equal(fila.length, 5, "a fila tem de servir o que ainda não venceu");
+    });
+
+    test("a sala e a revisão da trilha entregam a mesma quantidade", async () => {
+        const aluno = await novoAluno();
+        const { trilha } = await aulaCom(8, aluno.id);
+        // Metade vencida, metade no futuro: o total não pode depender disso.
+        const cartas = await db.select().from(userCards).where(eq(userCards.userId, aluno.id));
+        for (const [i, c] of cartas.entries())
+            await db
+                .update(userCards)
+                .set({
+                    proximaRevisao: new Date(Date.now() + (i % 2 ? 5 : -5) * 86400000),
+                })
+                .where(eq(userCards.id, c.id));
+
+        const sala = await filaDoDia(aluno.id, 500, { trilhas: [trilha.id] });
+        const daTrilha = await revisaoDaTrilha(aluno.id, trilha.id);
+
+        assert.equal(sala.length, daTrilha.length);
+        assert.deepEqual(
+            new Set(sala.map((c) => c.frente)),
+            new Set(daTrilha.map((c) => c.frente)),
+        );
+    });
+
+    test("a gêmea não conta duas vezes na fila da sala", async () => {
+        const { trilha, js, py } = await montarTrilhaComDoisTrilhos();
+        const aluno = await novoAluno();
+        await concluir(aluno.id, js.id);
+        await concluir(aluno.id, py.id);
+        // Simula o baralho sujo de antes da correção, com a gêmea aberta na mão.
+        const [gemea] = await db
+            .select()
+            .from(flashcards)
+            .where(eq(flashcards.frente, "O que é um algoritmo?"));
+        await db
+            .insert(userCards)
+            .values({ userId: aluno.id, origem: "flashcard", origemId: gemea.id })
+            .onConflictDoNothing();
+
+        const sala = await filaDoDia(aluno.id, 500, { trilhas: [trilha.id] });
+        const perguntas = sala.map((c) => c.frente);
+
+        assert.equal(new Set(perguntas).size, perguntas.length, "pergunta repetida na sala");
+    });
+
+    test("o limite continua priorizando o mais atrasado", async () => {
+        const aluno = await novoAluno();
+        await aulaCom(6, aluno.id);
+        for (let i = 0; i < 6; i++) await vencerHa(aluno.id, `Pergunta ${i}?`, 30 - i * 10);
+
+        const fila = await filaDoDia(aluno.id, 2);
+
+        assert.equal(fila.length, 2);
+        assert.deepEqual(
+            new Set(fila.map((c) => c.frente)),
+            new Set(["Pergunta 0?", "Pergunta 1?"]),
+        );
+    });
+});
+
 describe("ordem da fila de revisão", () => {
     beforeEach(limparBanco);
 

--- a/frontend/src/pages/Revisao/index.tsx
+++ b/frontend/src/pages/Revisao/index.tsx
@@ -46,11 +46,6 @@ const SESSAO = 'ensina:revisao';
 // precisa de um limite para não aceitar número absurdo digitado sem querer.
 const MAX_POR_SESSAO = 100;
 
-// Quantas cartas o modo adiantado serve quando o aluno não pediu um número. Varar o
-// baralho inteiro adiantado desmontaria o agendamento, então aqui o padrão é um
-// punhado, e não "todas" como na fila normal.
-const ADIANTADO_PADRAO = 10;
-
 const HORA = new Intl.DateTimeFormat('pt-BR', { hour: '2-digit', minute: '2-digit' });
 const DIA = new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: 'short' });
 
@@ -110,9 +105,6 @@ export function Revisao() {
   const [comGlossario, setComGlossario] = useState(false);
   const [escolhendo, setEscolhendo] = useState(false);
   const [vazio, setVazio] = useState(false);
-  // Sessão adiantada muda o texto da tela: o aluno precisa saber que está puxando
-  // cartas do futuro, senão estranha por que a fila "vazia" virou cartas.
-  const [adiantando, setAdiantando] = useState(false);
   // Quantas cartas a sessão entrega, como o aluno digitou. Vazio é "vai até acabar".
   const [limiteTexto, setLimiteTexto] = useState('');
   // Nulo é "sessão não começou"; a fila só é buscada quando o aluno manda começar.
@@ -168,23 +160,22 @@ export function Revisao() {
     setAberto(abrir && cartoes.length > 0);
   }, []);
 
-  async function comecar(adiantado = false) {
-    const escolha = { trilhas: [...selecao], glossario: comGlossario, limite, adiantado };
+  async function comecar() {
+    const escolha = { trilhas: [...selecao], glossario: comGlossario, limite };
     setVazio(false);
     try {
-      const cartoes = await filaDoDia(escolha, limite ?? (adiantado ? ADIANTADO_PADRAO : null));
-      // Escolha sem nada vencido é avisada aqui, e não desabilitando a linha na lista:
-      // linha apagada contaria quanto tem em cada baralho, que é o que não queremos
-      // mostrar.
+      const cartoes = await filaDoDia(escolha, limite);
+      // Escolha sem nenhuma carta é avisada aqui, e não desabilitando a linha na
+      // lista: linha apagada contaria quanto tem em cada baralho, que é o que não
+      // queremos mostrar.
       if (!cartoes.length) {
         setVazio(true);
         return;
       }
-      setAdiantando(adiantado);
-      // A sessão fica guardada para sobreviver a um F5. Não guardamos as cartas: no
-      // retorno a fila é remontada do servidor, e o que já foi respondido não vence
-      // mais, então o progresso se preserva sozinho.
-      localStorage.setItem(SESSAO, JSON.stringify(escolha));
+      // A sessão fica guardada para sobreviver a um F5. As cartas não são guardadas:
+      // no retorno a fila é remontada do servidor e as já respondidas são tiradas
+      // pela lista de "feitas".
+      localStorage.setItem(SESSAO, JSON.stringify({ ...escolha, feitas: [] }));
       setEscolhendo(false);
       iniciarSessao(cartoes);
     } catch (err) {
@@ -197,7 +188,6 @@ export function Revisao() {
     localStorage.removeItem(SESSAO);
     setFila(null);
     setAberto(false);
-    setAdiantando(false);
     void carregarSala();
   }
 
@@ -216,6 +206,7 @@ export function Revisao() {
       glossario?: boolean;
       limite?: number | null;
       restam?: number;
+      feitas?: string[];
     };
     try {
       escolha = JSON.parse(bruto);
@@ -227,9 +218,16 @@ export function Revisao() {
     setSelecao(new Set(escolha.trilhas ?? []));
     setComGlossario(Boolean(escolha.glossario));
     setLimiteTexto(escolha.limite ? String(escolha.limite) : '');
-    filaDoDia(escolha, escolha.restam ?? escolha.limite)
+    // A fila é remontada sem limite e cortada aqui, depois de tirar o que já foi
+    // respondido. Pedir "restam" direto ao servidor traria as respondidas de volta
+    // ocupando as vagas, porque elas continuam no baralho.
+    const feitas = new Set(escolha.feitas ?? []);
+    filaDoDia(escolha)
       .then((cartoes) => {
-        if (cartoes.length) iniciarSessao(cartoes, false);
+        const faltando = cartoes.filter((c) => !feitas.has(c.id));
+        const corte = escolha.restam ?? escolha.limite ?? undefined;
+        const fila = corte ? faltando.slice(0, corte) : faltando;
+        if (fila.length) iniciarSessao(fila, false);
         else localStorage.removeItem(SESSAO);
       })
       .catch((err) => {
@@ -342,20 +340,25 @@ export function Revisao() {
       setIndice((i) => i + 1);
     }, SAIDA_MS);
     setFeitos((n) => n + 1);
-    // O que falta é anotado a cada resposta. Sem isso, recarregar no meio de uma
-    // sessão de 10 traria 10 cartas novas em vez das que sobraram.
-    if (limite) {
-      const bruto = localStorage.getItem(SESSAO);
-      if (bruto) {
-        try {
-          localStorage.setItem(
-            SESSAO,
-            JSON.stringify({ ...JSON.parse(bruto), restam: Math.max(0, total - indice - 1) }),
-          );
-        } catch (err) {
-          console.error('Sessão de revisão salva ilegível, descartando.', err);
-          localStorage.removeItem(SESSAO);
-        }
+    // O que falta, e o que já passou, são anotados a cada resposta. O "restam" evita
+    // que recarregar no meio de uma sessão de 10 traga 10 cartas novas. A lista de
+    // respondidas é o que impede a carta que acabou de ser respondida de voltar no
+    // F5: a fila não filtra mais por vencimento, então ela continua no baralho.
+    const bruto = localStorage.getItem(SESSAO);
+    if (bruto) {
+      try {
+        const sessao = JSON.parse(bruto);
+        localStorage.setItem(
+          SESSAO,
+          JSON.stringify({
+            ...sessao,
+            restam: Math.max(0, total - indice - 1),
+            feitas: [...(sessao.feitas ?? []), atual.id],
+          }),
+        );
+      } catch (err) {
+        console.error('Sessão de revisão salva ilegível, descartando.', err);
+        localStorage.removeItem(SESSAO);
       }
     }
     try {
@@ -403,13 +406,15 @@ export function Revisao() {
         ...(baralhos?.trilhas ?? []).filter((t) => selecao.has(t.id)).map((t) => t.nome),
         ...(comGlossario ? ['Glossário'] : []),
       ].join(' + ');
-  // Quantas cartas a escolha atual tem vencidas hoje. Sem trilha marcada, o baralho todo.
+  // Quantas cartas a escolha atual tem, e não quantas venceram: a fila serve tudo
+  // que o aluno já estudou naquele conteúdo. Zero aqui significa que ele ainda não
+  // concluiu nenhuma aula do que marcou, e não que está em dia.
   const escolhidos = tudoMarcado
-    ? (resumo?.vencidos ?? 0)
+    ? (resumo?.total ?? 0)
     : (baralhos?.trilhas ?? [])
         .filter((t) => selecao.has(t.id))
-        .reduce((soma, t) => soma + t.vencidos, 0) +
-      (comGlossario ? (baralhos?.glossario.vencidos ?? 0) : 0);
+        .reduce((soma, t) => soma + t.total, 0) +
+      (comGlossario ? (baralhos?.glossario.total ?? 0) : 0);
 
   return (
     <div className="home-shell">
@@ -484,9 +489,9 @@ export function Revisao() {
             </div>
           )}
 
-          {/* Fila vazia não é falha, é o estado normal de quem está em dia. O texto
-              muda conforme o motivo: baralho ainda sem carta, tudo agendado para
-              frente, ou só a escolha atual sem nada vencido. */}
+          {/* Fila vazia agora só acontece por falta de aula concluída, e não por
+              estar em dia: a fila serve tudo que o aluno estudou. O texto muda
+              conforme o motivo: baralho inteiro sem carta, ou só a escolha atual. */}
           {!trilhaId && baralhos && fila === null && escolhidos === 0 && (
             <div className="rev-sala__aviso">
               <span className="rev-sala__check">
@@ -505,32 +510,19 @@ export function Revisao() {
                 </>
               ) : (
                 <>
-                  <h3>{tudoMarcado ? 'Você está em dia' : 'Este conteúdo está em dia'}</h3>
+                  <h3>Nada por aqui ainda</h3>
                   <p>
-                    {tudoMarcado
-                      ? 'Nenhuma carta venceu ainda. Cada uma volta na data que a sua resposta marcou, e o que você achou fácil volta bem mais tarde.'
-                      : 'Nada venceu no que você escolheu. Troque o conteúdo ou puxe cartas do futuro.'}
+                    Você ainda não concluiu nenhuma aula do que escolheu. Troque o conteúdo ou
+                    estude uma aula dessa trilha para as cartas nascerem.
                   </p>
-                  {!tudoMarcado && (
-                    <button
-                      type="button"
-                      className="rev-sala__selecao"
-                      onClick={() => setEscolhendo(true)}
-                    >
-                      <span>{descricaoSelecao}</span>
-                      <b>Trocar</b>
-                    </button>
-                  )}
-                  {/* Estar em dia virava parede: quem tinha vinte minutos livres não
-                      tinha o que fazer. Puxar cartas que ainda não venceram resolve,
-                      e o agendador já cobra o preço de revisar cedo. */}
-                  <button className="btn btn--ghost" onClick={() => void comecar(true)}>
-                    Revisar adiantado
+                  <button
+                    type="button"
+                    className="rev-sala__selecao"
+                    onClick={() => setEscolhendo(true)}
+                  >
+                    <span>{descricaoSelecao}</span>
+                    <b>Trocar</b>
                   </button>
-                  <p className="rev-sala__nota">
-                    Puxa {limite ?? ADIANTADO_PADRAO} cartas que ainda não venceram. Elas rendem
-                    menos que revisadas na data certa.
-                  </p>
                 </>
               )}
             </div>
@@ -556,9 +548,8 @@ export function Revisao() {
               </span>
               <h3>Sessão concluída</h3>
               <p>
-                {feitos} {feitos === 1 ? 'cartão revisado' : 'cartões revisados'}
-                {adiantando ? ', adiantados' : ''}. Cada um voltou para uma data diferente, conforme
-                você se avaliou.
+                {feitos} {feitos === 1 ? 'cartão revisado' : 'cartões revisados'}. Cada um voltou
+                para uma data diferente, conforme você se avaliou.
               </p>
               <button className="btn btn--accent" onClick={terminar}>
                 Voltar

--- a/frontend/src/services/flashcards.ts
+++ b/frontend/src/services/flashcards.ts
@@ -61,18 +61,19 @@ export async function resumoFlashcards() {
 }
 
 /**
- * Sem seleção vem o baralho inteiro; com seleção, só as trilhas escolhidas. Sem
- * limite vem tudo o que venceu, e a sessão só acaba quando a fila acabar.
+ * Sem seleção vem o baralho inteiro; com seleção, só as trilhas escolhidas. Vem
+ * tudo que o aluno já estudou naquele conteúdo, e não só o que venceu hoje: é a
+ * mesma coisa que o botão de revisar da trilha entrega. Sem limite, a sessão só
+ * acaba quando a fila acabar.
  */
 export async function filaDoDia(
-  selecao?: { trilhas?: string[]; glossario?: boolean; adiantado?: boolean },
+  selecao?: { trilhas?: string[]; glossario?: boolean },
   limite?: number | null,
 ) {
   const q = new URLSearchParams();
   if (limite) q.set('limite', String(limite));
   if (selecao?.trilhas?.length) q.set('trilhas', selecao.trilhas.join(','));
   if (selecao?.glossario) q.set('glossario', '1');
-  if (selecao?.adiantado) q.set('adiantado', '1');
   const { data } = await api.get<Cartao[]>(`/flashcards/fila?${q.toString()}`);
   return data;
 }


### PR DESCRIPTION
Escolher Lógica de Programação na aba **Revisão** dava 4 cartas. O botão de revisar da própria trilha dava 116.

Os dois números estavam certos para o que cada um media: a sala mostrava o que **venceu hoje**, a trilha mostrava **tudo que o aluno estudou**. Só que para quem está estudando as duas telas fazem a mesma coisa, e a tela não tinha como explicar a diferença.

## O que muda

A sala passa a servir tudo que o aluno já estudou no conteúdo escolhido, e não só o vencido. É o que a tela da trilha sempre fez.

O agendador **não sai de cena, muda de papel**: deixa de trancar o que aparece e passa a mandar na prioridade. A fila sai do mais atrasado para o mais adiantado, então quando o aluno digita um número de cartas, quem entra no corte é o que está mais perto de ser esquecido. Responder continua reagendando pela curva, e responder adiantado continua rendendo menos estabilidade pelo bônus abaixo de 1.

## Três coisas que quebrariam em silêncio

Tirar a trava de vencimento derruba duas suposições que o código fazia sem dizer:

1. **A sala mostraria 142 em vez de 116.** O baralho tem linhas gêmeas de antes da correção anterior. A fila agora deduplica na consulta, então o número bate com o da trilha mesmo antes de a limpeza dos dados rodar.
2. **O F5 traria de volta a carta recém-respondida.** A persistência de sessão se apoiava em "o que foi respondido não vence mais". Agora a carta continua no baralho, então a sessão guardada anota as respondidas e o retorno as descarta.
3. **"Revisar adiantado" e "você está em dia" viraram mentira.** Puxar do futuro passou a ser o comportamento normal, então os dois saíram. A tela vazia agora só aparece para quem não concluiu nenhuma aula do que escolheu, e o texto diz exatamente isso.

## Testes

`backend/tests/flashcard.test.ts` foi de 8 para 12 casos. Os quatro novos cobrem: carta futura continua na fila, sala e trilha entregam a mesma quantidade, gêmea não conta duas vezes, e o limite continua priorizando o mais atrasado.

Conferi que os dois casos centrais falham com o serviço antigo e passam com o novo.

## Depois do deploy

Rodar `backend/scripts/dedupe-flashcards.ts --aplicar`. São 2.214 linhas gêmeas em 43 alunos, das quais só 2 têm histórico. O dedup na consulta cobre a tela, mas os dados sujos continuam lá inflando as estatísticas e a contagem de baralho.