### PR TITLE
fix: texto do seletor de revisão ainda falava em carta vencida

### DIFF
--- a/frontend/src/pages/Revisao/index.tsx
+++ b/frontend/src/pages/Revisao/index.tsx
@@ -811,14 +811,23 @@ export function Revisao() {
                 />
               </div>
 
+              {/* Fila vazia deixou de significar "está tudo em dia": a sessão serve
+                  todo o conteúdo escolhido. Sobrou um motivo só, e o texto diz qual,
+                  separando "não estudei nada ainda" de "escolhi o baralho errado". */}
               {vazio && (
                 <p className="rev-escolha__vazio">
-                  Nada venceu no que você escolheu. Marque outro conteúdo.
+                  {baralhoVazio
+                    ? 'Você ainda não tem cartas. Elas nascem quando você conclui uma aula.'
+                    : 'Não há cartas no que você escolheu. Marque outro conteúdo.'}
                 </p>
               )}
 
               <div className="rev-escolha__rodape">
-                <button className="btn btn--accent" onClick={() => void comecar()}>
+                <button
+                  className="btn btn--accent"
+                  onClick={() => void comecar()}
+                  disabled={baralhoVazio}
+                >
                   Começar revisão
                 </button>
               </div>


### PR DESCRIPTION
Sobrou do estado anterior. O seletor de conteúdo dizia **"Nada venceu no que você escolheu"** quando a fila voltava vazia. Desde que a sessão passou a servir todo o conteúdo escolhido, nada "vence" mais, então a frase mandava o aluno procurar um problema que não existe.

## O que muda

O texto passa a separar os dois motivos reais de uma fila vazia:

- **Sem nenhuma carta no baralho:** diz que as cartas nascem ao concluir uma aula.
- **Baralho cheio, escolha sem carta:** manda trocar o conteúdo.

E o botão de começar fica desabilitado quando não há carta nenhuma, em vez de aceitar o clique e responder com uma mensagem de erro.

## Contexto de como apareceu

Foi reportado como "a fila devolve vazio mas tenho 116 cartas". Investigando, o backend estava certo: rodei `filaDoDia` direto em produção e ele devolve 230 sem filtro e 116 filtrando Lógica de Programação, como esperado.

O que confundiu foi a conta. A conta admin nunca concluiu uma aula, então tem baralho zerado e seletor sem nenhuma trilha; a conta de estudo é a que tem as 116. Com o texto antigo, o baralho vazio era anunciado como se fosse um problema de agendamento.