### PR TITLE
fix: fórmula de bloco das trilhas de matemática saía espremida

### DIFF
--- a/frontend/src/components/BlocosConteudo.tsx
+++ b/frontend/src/components/BlocosConteudo.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
-import { opcoesKatex } from '../utils/katex';
+import { normalizarFormulasEmBloco, opcoesKatex } from '../utils/katex';
 
 import { parseGrid } from '../utils/tabela';
 import { glossariar, criarMatcher } from './Glossario';
@@ -154,7 +154,7 @@ export function BlocosConteudo({ blocks }: { blocks: Bloco[] }) {
             rehypePlugins={[[rehypeKatex, opcoesKatex]]}
             components={componentes}
           >
-            {b.value}
+            {normalizarFormulasEmBloco(b.value)}
           </ReactMarkdown>
         );
       })}
@@ -188,7 +188,7 @@ export function TextoMath({ children }: { children: string }) {
         },
       }}
     >
-      {children}
+      {normalizarFormulasEmBloco(children)}
     </ReactMarkdown>
   );
 }

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -22,7 +22,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { BlocosConteudo, md, TextoMath } from '../../components/BlocosConteudo';
-import { opcoesKatex } from '../../utils/katex';
+import { normalizarFormulasEmBloco, opcoesKatex } from '../../utils/katex';
 import { getTrailLang } from '../../utils/trailLang';
 import {
   proximaTrilhaRoadmap,
@@ -372,7 +372,7 @@ function ConteudoAula({
             rehypePlugins={[[rehypeKatex, opcoesKatex]]}
             components={md}
           >
-            {aula.content}
+            {normalizarFormulasEmBloco(aula.content)}
           </ReactMarkdown>
         </div>
       ) : (
@@ -668,7 +668,7 @@ function Quiz({
                   rehypePlugins={[[rehypeKatex, opcoesKatex]]}
                   components={md}
                 >
-                  {explicacao}
+                  {normalizarFormulasEmBloco(explicacao)}
                 </ReactMarkdown>
               </div>
             )}

--- a/frontend/src/utils/katex.ts
+++ b/frontend/src/utils/katex.ts
@@ -21,3 +21,40 @@ export const opcoesKatex = {
     '\\ne': '\\mathrel{\\char"2260}',
   },
 };
+
+/**
+ * Põe os `$$` de uma fórmula de bloco em linhas próprias, que é o único formato
+ * que o remark-math trata como fórmula de display.
+ *
+ * O remark-math é mais estrito que o resto do ecossistema: `$$x=1$$` numa linha
+ * só vira nó `inlineMath`, e só `$$` / fórmula / `$$` em três linhas vira nó
+ * `math`. Como o KaTeX renderiza inline em textstyle, a fórmula sai pequena,
+ * alinhada à esquerda e com as frações aninhadas espremidas a ponto de os
+ * expoentes colidirem.
+ *
+ * Todo o conteúdo de matemática foi autorado na forma de uma linha, que é como
+ * GitHub, Obsidian e Jupyter aceitam: 245 aulas em 8 trilhas. Normalizar aqui
+ * conserta as 245 de uma vez, vale para o conteúdo futuro e não depende de quem
+ * autora conhecer a exigência do parser.
+ *
+ * Cerca de código é respeitada: `$$` dentro de ``` fica intacto. Indentação de 4
+ * espaços ou mais também é pulada, porque ali a linha já era bloco de código.
+ */
+export function normalizarFormulasEmBloco(texto: string): string {
+  if (!texto.includes('$$')) return texto;
+
+  let emCerca = false;
+  return texto
+    .split('\n')
+    .map((linha) => {
+      if (/^\s*(```|~~~)/.test(linha)) {
+        emCerca = !emCerca;
+        return linha;
+      }
+      if (emCerca) return linha;
+
+      const achou = /^( {0,3})\$\$(.+?)\$\$[ \t]*$/.exec(linha);
+      return achou ? `${achou[1]}$$\n${achou[2]}\n${achou[1]}$$` : linha;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
Reportado como "está bem ruim a visualização dos números na trilha", em Cálculo 1, módulo 2, aula de limites no infinito.

## A causa

O `remark-math` é mais estrito que o resto do ecossistema:

| Como está escrito | Nó gerado | Como o KaTeX renderiza |
|---|---|---|
| `$$x=1$$` numa linha só | `inlineMath` | inline, em textstyle |
| `$$` / fórmula / `$$` em três linhas | `math` | display, centralizado |

Como o KaTeX renderiza inline em textstyle, a fórmula saía pequena, alinhada à esquerda e com as frações aninhadas espremidas a ponto de os expoentes colidirem, que é exatamente o print do relato.

Todo o conteúdo de matemática foi autorado na forma de uma linha, que é como GitHub, Obsidian e Jupyter aceitam. **São 245 aulas em 8 trilhas**: Cálculo 1, 2 e 3, Álgebra Linear, Geometria Analítica, Estatística Matemática, Pré-cálculo e AWS CLF-C02.

## A correção

Normalizar na renderização, não no conteúdo. Conserta as 245 aulas de uma vez, vale para o que for autorado depois e não depende de quem escreve conhecer a exigência do parser.

Aplicada nos **quatro** pontos que renderizam fórmula: bloco de aula, texto de quiz, conteúdo antigo em markdown e resolução passo a passo.

Cerca de código é respeitada (`$$` dentro de ``` fica intacto) e linha indentada com quatro espaços é pulada, porque ali já era bloco de código.

## O que eu descartei antes de concluir

Duas hipóteses plausíveis foram testadas e eliminadas, em vez de assumidas:

1. **Fonte do KaTeX não carregando.** Conferi: os 59 arquivos de fonte estão publicados em produção e as URLs no CSS resolvem.
2. **CSS do app interferindo.** Baixei o CSS de produção com as fontes na mesma origem e renderizei as mesmas fórmulas: o resultado é idêntico ao KaTeX limpo. O CSS é inocente.

Um teste intermediário chegou a acusar o CSS, mas era artefato meu: as fontes vinham de outra origem e o CORS bloqueava. Refiz na mesma origem e o falso positivo sumiu.

## Verificação

- Sete casos de borda da normalização: bloco simples, com texto em volta, `$$` inline no meio de frase, dentro de cerca de código, indentado com quatro espaços, já multilinha, e texto sem fórmula. Todos passam.
- Conteúdo real da aula pelo pipeline: **antes** 0 nós de display e 8 inline; **depois** 2 display e 6 inline, que é a divisão correta.
- Comparação visual antes e depois com o CSS de produção aplicado.