### PR TITLE
feat: módulos 5, 6 e 7 fecham LLMs em Produção e o roadmap de Engenharia de IA

### DIFF
--- a/backend/scripts/data/flashcards/llms-em-producao.ts
+++ b/backend/scripts/data/flashcards/llms-em-producao.ts
@@ -350,5 +350,271 @@ export const llmsEmProducao: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Por que o estado da conversa não pode viver na RAM da réplica?",
+                        verso: "Com várias réplicas, a próxima requisição cai em outra máquina.",
+                    },
+                    {
+                        frente: "O que a fila com workers absorve na arquitetura?",
+                        verso: "Picos e o trabalho assíncrono, evitando 429 na cara do usuário.",
+                    },
+                    {
+                        frente: "Onde os guardrails devem rodar?",
+                        verso: "No seu backend, antes e depois da chamada ao provedor.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Para que serve o jitter no backoff?",
+                        verso: "Evitar que todos os clientes tentem de novo em sincronia.",
+                    },
+                    {
+                        frente: "O que o circuit breaker faz que o retry não faz?",
+                        verso: "Para de insistir na falha sistêmica e testa a volta em meia-abertura.",
+                    },
+                    {
+                        frente: "Por que homologar o modelo de fallback antes do incidente?",
+                        verso: "Descobrir a qualidade do plano B durante a crise é tarde.",
+                    },
+                    {
+                        frente: "O que fazer quando o principal e o fallback caem juntos?",
+                        verso: "Degradação honesta: mensagem clara, sem nunca fingir que funcionou.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que um 429 esporádico costuma indicar?",
+                        verso: "Rajada local passageira, que o backoff resolve sozinho.",
+                    },
+                    {
+                        frente: "A fila cresce e os workers estão no teto. Escalar workers resolve?",
+                        verso: "Não. O gargalo é o teto: negociar limite ou somar provedor.",
+                    },
+                    {
+                        frente: "O que um 429 constante fora de pico denuncia?",
+                        verso: "Loop ou abuso interno queimando cota.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que é o deploy canário de um prompt?",
+                        verso: "Servir a versão nova a uma fração e comparar as métricas.",
+                    },
+                    {
+                        frente: "Qual é a diferença de propósito entre canário e teste A/B?",
+                        verso: "O canário barra regressão; o A/B escolhe entre versões boas.",
+                    },
+                    {
+                        frente: "Por que fixar a versão do modelo em vez de usar o alias recente?",
+                        verso: "Upgrade silencioso muda o comportamento sem passar na esteira.",
+                    },
+                    {
+                        frente: "Que esteira uma ferramenta nova no agente exige a mais?",
+                        verso: "A suíte adversarial, porque a superfície de ataque cresce.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que é um runbook?",
+                        verso: "Passos prontos por cenário, para agir durante o incidente.",
+                    },
+                    {
+                        frente: "Por que todo alerta precisa de runbook associado?",
+                        verso: "Alerta sem ação clara vira ruído e passa a ser ignorado.",
+                    },
+                    {
+                        frente: "O custo por hora estourou de madrugada. Qual é o primeiro movimento?",
+                        verso: "Achar a feature ou usuário que queima e conter com quota.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Qual é a ordem da escada de intervenção?",
+                        verso: "Prompt primeiro, depois RAG e por último fine-tuning.",
+                    },
+                    {
+                        frente: "O que o fine-tuning oferece a um prompt gigante de instruções?",
+                        verso: "Destilar as instruções no peso e encurtar o prompt em produção.",
+                    },
+                    {
+                        frente: "Como corrigir um caso pontual que errou?",
+                        verso: "Com caso na suíte e ajuste de prompt: cirúrgico e reversível.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que é SFT?",
+                        verso: "Treinar com pares de entrada e saída ideais, para o modelo imitar.",
+                    },
+                    {
+                        frente: "Qualidade ou quantidade no dataset de SFT?",
+                        verso: "Centenas de exemplos excelentes batem milhares medianos.",
+                    },
+                    {
+                        frente: "Qual é o sinal clássico de overfitting no tune?",
+                        verso: "Métrica de treino ótima e desempenho pior na avaliação.",
+                    },
+                    {
+                        frente: "Contra que baseline o modelo ajustado deve ser comparado?",
+                        verso: "Contra o modelo base com um prompt bom, não com baseline fraco.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o DPO otimiza?",
+                        verso: "A escolha entre duas respostas: aprender a preferida.",
+                    },
+                    {
+                        frente: "Por que o DPO virou padrão em times de produto?",
+                        verso: "Treina direto nos pares, sem modelo de recompensa nem RL.",
+                    },
+                    {
+                        frente: "De onde saem bons pares de preferência quase de graça?",
+                        verso: "Do feedback de produção: joinhas e respostas editadas.",
+                    },
+                    {
+                        frente: "Qual é a ordem entre SFT e treino de preferência?",
+                        verso: "Preferência depois do SFT, quando o subjetivo estagna.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Qual é a ideia central do LoRA?",
+                        verso: "Congelar o modelo base e treinar matrizes pequenas anexas.",
+                    },
+                    {
+                        frente: "Como o LoRA viabiliza um modelo por cliente?",
+                        verso: "Um base na GPU e adapters trocados dinamicamente por requisição.",
+                    },
+                    {
+                        frente: "O que o QLoRA acrescenta ao LoRA?",
+                        verso: "Base quantizado no treino: cabe em GPU ainda menor.",
+                    },
+                    {
+                        frente: "De que tamanho é o artefato de uma versão em LoRA?",
+                        verso: "Megabytes, contra gigabytes de um checkpoint completo.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Qual requisito elimina a API fechada de cara?",
+                        verso: "Dado que não pode sair da infraestrutura por regulação.",
+                    },
+                    {
+                        frente: "Por que GPU ociosa muda a conta do self-host?",
+                        verso: "O custo é fixo por mês; sem volume constante, vira prejuízo.",
+                    },
+                    {
+                        frente: "O que o vLLM oferece a quem serve modelo aberto?",
+                        verso: "Inferência eficiente com batching e API compatível.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que são requisitos não funcionais de um produto com IA?",
+                        verso: "Orçamento, latência, disponibilidade, privacidade e segurança.",
+                    },
+                    {
+                        frente: "Para que serve a gap analysis antes de lançar?",
+                        verso: "Mapear o que falta entre o demo e a operação real.",
+                    },
+                    {
+                        frente: "Por que registrar decisões em ADRs curtos?",
+                        verso: "O porquê de cada escolha sobrevive à memória do time.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Por que a suíte inicial já inclui casos adversariais?",
+                        verso: "Para medir a resistência a injection desde o primeiro dia.",
+                    },
+                    {
+                        frente: "O que o baseline registrado permite?",
+                        verso: "Comparar qualquer mudança futura com o ponto de partida.",
+                    },
+                    {
+                        frente: "Qual é o papel da revisão semanal de conversas?",
+                        verso: "Achar padrões que a métrica não pega e gerar casos novos.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que a quota por cliente protege?",
+                        verso: "O orçamento mensal contra abuso e uso desmedido.",
+                    },
+                    {
+                        frente: "O que valida a rota barata antes de ela pegar o grosso do tráfego?",
+                        verso: "A suíte rodada nela, comparada com o baseline.",
+                    },
+                    {
+                        frente: "Por que o layout do prompt importa para o custo?",
+                        verso: "Prefixo fixo estável ativa o cache e corta entrada e TTFT.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Por que ter kill switch separado por feature?",
+                        verso: "Desligar a que tem problema sem derrubar o resto do produto.",
+                    },
+                    {
+                        frente: "O que a checagem de ownership nas ferramentas impede?",
+                        verso: "Um cliente acessar pedido ou dado de outro cliente.",
+                    },
+                    {
+                        frente: "Qual é o objetivo de um game day antes do lançamento?",
+                        verso: "Ensaiar incidentes com tudo de mentira antes do de verdade.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Por que um produto nunca está pronto, e sim operado?",
+                        verso: "O ciclo de feedback, suíte e canário roda sem fim.",
+                    },
+                    {
+                        frente: "O que diferencia demo de produto?",
+                        verso: "Como o sistema se comporta quando as coisas dão errado.",
+                    },
+                    {
+                        frente: "Por que os fundamentos valem mais que o nome das ferramentas?",
+                        verso: "Ferramentas trocam a cada trimestre; fundamentos ficam.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a quinta trilha e, com ela, **o roadmap de Engenharia de IA inteiro**. Mais **50 cartões**, cobrindo os módulos 5 (arquitetura e resiliência), 6 (fine-tuning) e 7 (o projeto de lançamento). A trilha termina com **112 cartas**.

> **Base:** sai de `feat/cartas-producao-2` (#394).

## O roadmap fechado

| Trilha | Cartas | Aulas sem carta |
|---|---|---|
| Fundamentos de LLMs | 117 | 0 de 35 |
| Aplicações com LLMs | 106 | 0 de 35 |
| RAG na Prática | 105 | 0 de 35 |
| Agentes de IA | 117 | 0 de 35 |
| LLMs em Produção | 112 | 0 de 35 |
| **Total** | **557** | **175 aulas cobertas** |

O seeder completo produz **1.013 cartas em doze trilhas**, sem conflito e com o `conferirRegistro()` passando.

## O que entra neste bloco

- **Arquitetura e resiliência**: por que o estado não vive na RAM da réplica, o que o circuit breaker faz além do retry, o que fazer quando principal e fallback caem juntos, a diferença de propósito entre canário e teste A/B, e por que todo alerta precisa de runbook.
- **Fine-tuning**: a ordem da escada de intervenção, contra que baseline comparar o modelo ajustado, de onde saem pares de preferência quase de graça, o que o QLoRA acrescenta ao LoRA, e o tamanho do artefato de uma versão.
- **Projeto**: o que são requisitos não funcionais, para que serve a gap analysis, o que a checagem de ownership impede, e o objetivo de um game day.

## Próximo passo

Com o roadmap de IA fechado, seguem os outros nove roadmaps e, no fim, as trilhas de certificação que não pertencem a roadmap nenhum.