### PR TITLE
feat: cartões dos módulos 3 e 4 de Fundamentos de QA

### DIFF
--- a/backend/scripts/data/flashcards/fundamentos-de-qa.ts
+++ b/backend/scripts/data/flashcards/fundamentos-de-qa.ts
@@ -184,5 +184,173 @@ export const fundamentosDeQa: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Quem costuma escrever teste de unidade?",
+                        verso: "Quem programa.",
+                    },
+                    {
+                        frente: "Qual nível de teste tem o custo de manutenção mais alto?",
+                        verso: "Sistema e aceitação, que também são os mais lentos.",
+                    },
+                    {
+                        frente: "O que o nível de integração testa?",
+                        verso: "A conversa entre as partes.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que tipo de caminho tem a maior chance de esconder defeito?",
+                        verso: "A borda, seguida do caminho de erro.",
+                    },
+                    {
+                        frente: "Por que o caminho feliz esconde poucos defeitos?",
+                        verso: "Foi justamente o cenário que quem programou já testou.",
+                    },
+                    {
+                        frente: "Que cenários são caminho de erro numa compra?",
+                        verso: "Cartão recusado, ou estoque acabando no meio da compra.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Qual é a diferença entre teste de carga e de estresse?",
+                        verso: "Carga usa a demanda esperada; estresse vai além, até romper.",
+                    },
+                    {
+                        frente: "Que tipo de teste revela travamento com muito registro?",
+                        verso: "O teste de volume.",
+                    },
+                    {
+                        frente: "Como transformar rapidez em critério verificável?",
+                        verso: "Fixando percentil, tempo e carga: 95% em até 800 ms com 500 usuários.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Qual é a abrangência do smoke?",
+                        verso: "Larga e rasa, para decidir se vale a pena testar.",
+                    },
+                    {
+                        frente: "Qual é a abrangência da sanidade?",
+                        verso: "Estreita e um pouco mais funda, numa área só.",
+                    },
+                    {
+                        frente: "Quando a regressão roda?",
+                        verso: "Depois de qualquer mudança, e ela cresce a cada entrega.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Em que a caixa-branca se baseia para desenhar o teste?",
+                        verso: "Caminhos, condições e cobertura do código.",
+                    },
+                    {
+                        frente: "O que a caixa-cinza conhece, que a caixa-preta não?",
+                        verso: "Parte da estrutura interna, como o fluxo e os efeitos no banco.",
+                    },
+                    {
+                        frente: "Quem costuma usar a abordagem de caixa-branca?",
+                        verso: "Quem programa, no teste de unidade.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Qual é a ideia central da partição de equivalência?",
+                        verso: "Agrupar valores tratados igual e testar um representante de cada.",
+                    },
+                    {
+                        frente: "Por que testar as classes inválidas uma por vez?",
+                        verso: "Com duas juntas, não se sabe qual validação funcionou.",
+                    },
+                    {
+                        frente: "Que classes inválidas um campo de idade costuma ter?",
+                        verso: "Negativo, não numérico e vazio.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Por que a análise de valor limite é tão eficaz?",
+                        verso: "A maioria dos defeitos de faixa acontece exatamente nas bordas.",
+                    },
+                    {
+                        frente: "Que valores testar numa senha de 8 a 20 caracteres?",
+                        verso: "Sete, oito, vinte e vinte e um.",
+                    },
+                    {
+                        frente: "Que valores testar num limite de frete grátis a partir de 200?",
+                        verso: "199,99, 200,00 e 200,01.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Quando a tabela de decisão é a técnica mais adequada?",
+                        verso: "Quando o resultado depende da combinação de várias condições.",
+                    },
+                    {
+                        frente: "Com três condições de sim ou não, quantas combinações surgem?",
+                        verso: "Oito, antes de qualquer simplificação.",
+                    },
+                    {
+                        frente: "Qual é o principal ganho da tabela de decisão?",
+                        verso: "Revelar as combinações que o requisito não descreveu.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Quais são os quatro elementos de um modelo de estados?",
+                        verso: "Estados, eventos, transições e ações.",
+                    },
+                    {
+                        frente: "Por que testar transições inválidas rende defeito interessante?",
+                        verso: "Muitas transições impossíveis simplesmente não foram bloqueadas.",
+                    },
+                    {
+                        frente: "Quando a transição de estados é a técnica indicada?",
+                        verso: "Quando o comportamento depende da situação em que o sistema está.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que três elementos separam a exploração da bagunça?",
+                        verso: "Missão, tempo e registro.",
+                    },
+                    {
+                        frente: "O que o teste exploratório registra, em vez de passos?",
+                        verso: "Missão, achados, dúvidas e cobertura.",
+                    },
+                    {
+                        frente: "Qual é o ponto fraco do teste roteirizado?",
+                        verso: "Só encontra aquilo que alguém já imaginou antes.",
+                    },
+                    {
+                        frente: "Como se chama testar direto onde costuma dar problema?",
+                        verso: "Suposição de erro.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Mais **31 cartões**, cobrindo os módulos 3 (níveis e tipos de teste) e 4 (técnicas de modelagem). Com os anteriores, a trilha chega a 63.

> **Base:** sai de `feat/cartas-qa-1` (#396).

## O que entra

- **Níveis e tipos**: qual nível custa mais caro para manter, que tipo de caminho mais esconde defeito, a diferença entre carga e estresse, a abrangência de smoke contra sanidade, e em que a caixa-branca se baseia.
- **Técnicas**: por que testar classes inválidas uma por vez, os valores exatos de borda de cada regra, quantas combinações três condições geram, os quatro elementos de um modelo de estados, e os três elementos que separam exploração de bagunça.

Um detalhe de qualidade que vale registrar: transformei "o sistema deve ser rápido" no critério verificável que a aula ensina (percentil, tempo e carga juntos), porque a carta que só diz "seja específico" não ensina nada.

## Verificação

Seed real contra a estrutura da trilha.