### PR TITLE
feat: cartões dos módulos 3 e 4 de Banco de Dados e SQL

### DIFF
--- a/backend/scripts/data/flashcards/banco-de-dados-e-sql.ts
+++ b/backend/scripts/data/flashcards/banco-de-dados-e-sql.ts
@@ -146,5 +146,153 @@ export const bancoDeDadosESql: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que uma coluna com DEFAULT dispensa no INSERT?",
+                        verso: "Informar aquele valor: o banco preenche sozinho.",
+                    },
+                    {
+                        frente: "O que acontece ao omitir no INSERT uma coluna NOT NULL sem padrão?",
+                        verso: "O banco rejeita a inserção.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que a cláusula WHERE faz dentro de um UPDATE?",
+                        verso: "Define quais linhas o SET vai alterar.",
+                    },
+                    {
+                        frente: "Como alterar duas colunas no mesmo UPDATE?",
+                        verso: "Separando as atribuições do SET por vírgula.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Qual é a diferença entre UPDATE e DELETE?",
+                        verso: "UPDATE altera colunas da linha; DELETE remove a linha inteira.",
+                    },
+                    {
+                        frente: "O que acontece num DELETE sem WHERE?",
+                        verso: "Todas as linhas somem, mas a estrutura da tabela permanece.",
+                    },
+                    {
+                        frente: "O que é soft delete?",
+                        verso: "Marcar a linha como removida em vez de apagá-la de fato.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o BEGIN faz?",
+                        verso: "Inicia a transação: os comandos seguintes ficam provisórios.",
+                    },
+                    {
+                        frente: "O que o ROLLBACK desfaz?",
+                        verso: "Todas as alterações feitas desde o BEGIN.",
+                    },
+                    {
+                        frente: "Por que dois UPDATE soltos numa transferência são arriscados?",
+                        verso: "Falhando no meio, o dinheiro sai de um lado e não entra no outro.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a atomicidade do ACID garante?",
+                        verso: "A transação roda por inteiro, ou não roda nada.",
+                    },
+                    {
+                        frente: "O que a durabilidade do ACID garante?",
+                        verso: "Depois do COMMIT, a mudança sobrevive a uma falha do banco.",
+                    },
+                    {
+                        frente: "O que a consistência do ACID garante?",
+                        verso: "Que os dados nunca violam as regras declaradas no banco.",
+                    },
+                    {
+                        frente: "O que o isolamento do ACID garante?",
+                        verso: "Que uma transação não enxerga o meio do caminho de outra.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Qual é a ideia central da normalização no dia a dia?",
+                        verso: "Cada fato mora em um lugar só, separado por entidade.",
+                    },
+                    {
+                        frente: "O que acontece quando o email do cliente se repete em toda linha?",
+                        verso: "Mudou o email, é preciso atualizar linha por linha, e alguma escapa.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que uma chave estrangeira impede?",
+                        verso: "Inserir uma linha apontando para um registro que não existe.",
+                    },
+                    {
+                        frente: "Como se chama a garantia de que a chave estrangeira aponta para algo real?",
+                        verso: "Integridade referencial.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Num relacionamento de um para muitos, onde fica a chave estrangeira?",
+                        verso: "No lado muitos da relação.",
+                    },
+                    {
+                        frente: "O que transforma um relacionamento de um para muitos em um para um?",
+                        verso: "Uma restrição de unicidade na coluna da chave estrangeira.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Por que uma chave estrangeira só não representa muitos para muitos?",
+                        verso: "Uma coluna guarda um valor só, e os dois lados têm vários.",
+                    },
+                    {
+                        frente: "O que é uma tabela de junção?",
+                        verso: "A tabela criada para representar a relação de muitos para muitos.",
+                    },
+                    {
+                        frente: "O que a tabela de junção costuma guardar além das duas chaves?",
+                        verso: "Dados da própria relação, como quantidade e preço no momento.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a cláusula ON define num JOIN?",
+                        verso: "A condição que casa as linhas das duas tabelas.",
+                    },
+                    {
+                        frente: "Que JOIN traz todos os registros da tabela da esquerda?",
+                        verso: "O LEFT JOIN, com nulo onde não há correspondência.",
+                    },
+                    {
+                        frente: "O que o INNER JOIN faz com quem não tem correspondência?",
+                        verso: "Deixa de fora do resultado.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Módulos 3 (escrita de dados e transações) e 4 (modelagem e JOIN).

> **Base:** sai de `feat/cartas-sql-1` (#405).

## O que entra

- **Escrita e transações**: o que DEFAULT dispensa no INSERT, o que sobra depois de um DELETE sem WHERE, o que é soft delete, e **as quatro letras do ACID uma a uma**. O quiz cobra só atomicidade e durabilidade, então consistência e isolamento entram aqui.
- **Modelagem**: onde a chave estrangeira mora num relacionamento de um para muitos, o que transforma esse relacionamento em um para um, por que uma FK só não representa muitos para muitos, e o que a tabela de junção guarda além das duas chaves.

## Verificação

Seed real contra a estrutura da trilha.