### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Linux e Linha de Comando

### DIFF
--- a/backend/scripts/data/flashcards/linux-e-linha-de-comando.ts
+++ b/backend/scripts/data/flashcards/linux-e-linha-de-comando.ts
@@ -338,5 +338,251 @@ export const linuxELinhaDeComando: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Onde exatamente o shebang precisa ficar no arquivo?",
+                        verso: "Na primeira linha, logo no começo, sem espaço antes.",
+                    },
+                    {
+                        frente: "O que acontece quando o script não tem shebang?",
+                        verso: "O sistema usa o shell padrão, que nem sempre é o Bash.",
+                    },
+                    {
+                        frente: "Que forma de rodar dispensa o chmod, e o que ela ignora?",
+                        verso: "Chamar o interpretador direto; aí o shebang é ignorado.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Por que a atribuição de variável não pode ter espaços em volta?",
+                        verso: "Com espaço, o Bash trata o nome como se fosse um comando.",
+                    },
+                    {
+                        frente: "O que o nome do script e a lista completa representam?",
+                        verso: "O primeiro é o próprio script; a outra traz todos os argumentos.",
+                    },
+                    {
+                        frente: "Que convenção os nomes de variáveis de ambiente seguem?",
+                        verso: "Maiúsculas, como HOME, USER e PATH.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que espaços são obrigatórios nos testes entre colchetes?",
+                        verso: "Os internos: sem eles o teste nem é reconhecido.",
+                    },
+                    {
+                        frente: "Que vantagens o teste duplo do Bash tem sobre o simples?",
+                        verso: "Entende os operadores lógicos e lida melhor com variável vazia.",
+                    },
+                    {
+                        frente: "Que exit code significa sucesso, e o que o if faz com ele?",
+                        verso: "O zero; o if roda o then quando a condição termina em zero.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que faixa o return de uma função aceita, e o que ele define?",
+                        verso: "De zero a 255, e ele define o exit code, não um texto.",
+                    },
+                    {
+                        frente: "Como uma função devolve texto, já que o return não serve?",
+                        verso: "Com echo, capturado por quem chama com a substituição.",
+                    },
+                    {
+                        frente: "Qual é a diferença entre break e continue num loop?",
+                        verso: "O break encerra o loop; o continue pula só a volta atual.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a opção de pipefail acrescenta às outras duas?",
+                        verso: "Faz o pipe falhar se qualquer etapa dele falhar, não só a última.",
+                    },
+                    {
+                        frente: "Onde a linha de proteção do set costuma ficar?",
+                        verso: "Logo depois do shebang, no começo do script.",
+                    },
+                    {
+                        frente: "Em que índice um array do Bash começa?",
+                        verso: "No zero, e as chaves são necessárias ao mexer com índice.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que comando sobe o serviço e o habilita de uma vez?",
+                        verso: "O enable com a opção de agora, que faz as duas coisas.",
+                    },
+                    {
+                        frente: "Que outros tipos de unit existem, além do serviço?",
+                        verso: "socket, timer, mount e target, cada um com a sua extensão.",
+                    },
+                    {
+                        frente: "Que diretório de unit tem prioridade sobre o do pacote?",
+                        verso: "O do administrador, em /etc/systemd/system.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que o journald recolhe automaticamente de cada serviço?",
+                        verso: "A saída padrão e a de erro, mais o kernel e o boot.",
+                    },
+                    {
+                        frente: "Em que formato o journal é guardado?",
+                        verso: "Binário e estruturado, consultado só pelo journalctl.",
+                    },
+                    {
+                        frente: "Que arquivos guardam autenticação em cada família?",
+                        verso: "O auth.log no Debian e o secure no RHEL e derivados.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que quatro ganhos o gerenciador de pacotes entrega?",
+                        verso: "Resolve dependência, atualiza em bloco, verifica assinatura e remove bem.",
+                    },
+                    {
+                        frente: "Onde a lista de repositórios fica em cada família?",
+                        verso: "Em sources.list e no diretório dele no apt; em yum.repos.d no dnf.",
+                    },
+                    {
+                        frente: "O que o gerenciador faz com pacote de assinatura errada?",
+                        verso: "Recusa: cada repositório é assinado com uma chave.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que faixa o campo de dia da semana usa no cron?",
+                        verso: "De zero a sete, com zero e sete valendo domingo.",
+                    },
+                    {
+                        frente: "Que opção do crontab apaga tudo sem pedir confirmação?",
+                        verso: "A de remover, que apaga a crontab inteira de uma vez.",
+                    },
+                    {
+                        frente: "Que vantagens os timers do systemd têm sobre o cron?",
+                        verso: "Log no journal, lista dos próximos disparos e execução perdida coberta.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que letras compõem a combinação mais útil do ss?",
+                        verso: "TCP, escutando, números em vez de nomes, e o processo.",
+                    },
+                    {
+                        frente: "Que utilitários antigos o iproute2 e o ss substituem?",
+                        verso: "O ifconfig e o route, e o ss substitui o netstat.",
+                    },
+                    {
+                        frente: "Que fonte é consultada antes do DNS na resolução de nomes?",
+                        verso: "O arquivo /etc/hosts, uma tabela local e estática.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Em que porta o serviço de SSH escuta por padrão?",
+                        verso: "Na 22, atendida pelo sshd no lado do servidor.",
+                    },
+                    {
+                        frente: "Que protocolo antigo o SSH substituiu, e por quê?",
+                        verso: "O Telnet, que mandava tudo em texto puro pela rede.",
+                    },
+                    {
+                        frente: "Que comando gera o par de chaves, e onde ele guarda?",
+                        verso: "O ssh-keygen, dentro da pasta .ssh do usuário.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que separador o PATH usa, e em que ordem ele é lido?",
+                        verso: "Dois pontos, e o shell percorre os diretórios na ordem.",
+                    },
+                    {
+                        frente: "Que comando mostra qual arquivo o shell escolheu de fato?",
+                        verso: "O which, que revela o caminho do executável usado.",
+                    },
+                    {
+                        frente: "Que arquivo roda no shell de login, e qual no interativo?",
+                        verso: "O profile no login e o bashrc no interativo sem login.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que arquivo descreve as montagens que valem a cada boot?",
+                        verso: "O /etc/fstab, lido durante a subida do sistema.",
+                    },
+                    {
+                        frente: "De que duas formas um disco pode encher?",
+                        verso: "Acabando os blocos de dados ou acabando os inodes.",
+                    },
+                    {
+                        frente: "Que opção do df revela o uso de inodes?",
+                        verso: "A de inodes, útil quando sobra espaço e nada grava.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que dois valores todo limite do ulimit tem?",
+                        verso: "O soft, ajustável pelo usuário, e o hard, só pelo administrador.",
+                    },
+                    {
+                        frente: "Que quatro namespaces a aula cita?",
+                        verso: "O de PID, o de rede, o de mount e o de usuários.",
+                    },
+                    {
+                        frente: "Que diferença separa cgroups de namespaces?",
+                        verso: "cgroups limitam quanto se usa; namespaces limitam o que se vê.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que quatro princípios cobrem a maior parte do hardening?",
+                        verso: "Manter atualizado, menor privilégio, firewall e reduzir o que roda.",
+                    },
+                    {
+                        frente: "Que camadas de firewall o Linux oferece?",
+                        verso: "iptables e o sucessor nftables, com o ufw simplificando por cima.",
+                    },
+                    {
+                        frente: "O que a imagem de um container é, no fim das contas?",
+                        verso: "Só o sistema de arquivos que aquele processo enxerga.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a segunda das cinco trilhas do roadmap de DevOps. Esta trilha também aparece no roadmap de Segurança, então o fechamento ficou neutro quanto ao próximo estágio.

## O que entra
- Módulo 5, scripting: shebang e permissão, variáveis com argumentos posicionais, condicionais decididas por exit code, loops e funções, e robustez com as três proteções do set.
- Módulo 6, sistema em operação: systemd com a diferença entre start e enable, logs no journald e nos arquivos de /var/log, pacotes com apt e dnf, agendamento com cron e timers, e rede com ip, ss e curl.
- Módulo 7, Linux para DevOps: SSH com par de chaves, ambiente do shell com PATH e arquivos de perfil, disco com blocos e inodes, limites com cgroups e namespaces, e hardening com o container como processo isolado.

45 cartas novas, trilha fechada em 105.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 60 já existiam, 0 aulas sem carta.

Empilhado sobre #450.