### PR TITLE
feat: cartões dos módulos 1 e 2 de SQL para Dados

### DIFF
--- a/backend/scripts/data/flashcards/index.ts
+++ b/backend/scripts/data/flashcards/index.ts
@@ -35,6 +35,7 @@ import { kubernetes } from "./kubernetes.ts";
 import { arquiteturaEEscala } from "./arquitetura-e-escala.ts";
 import { estatisticaEProbabilidade } from "./estatistica-e-probabilidade.ts";
 import { analiseDeDados } from "./analise-de-dados.ts";
+import { sqlParaDados } from "./sql-para-dados.ts";
 
 export const TRILHAS: CartasDaTrilha[] = [
     logicaDeProgramacao,
@@ -72,4 +73,5 @@ export const TRILHAS: CartasDaTrilha[] = [
     arquiteturaEEscala,
     estatisticaEProbabilidade,
     analiseDeDados,
+    sqlParaDados,
 ];

--- a/backend/scripts/data/flashcards/sql-para-dados.ts
+++ b/backend/scripts/data/flashcards/sql-para-dados.ts
@@ -1,0 +1,181 @@
+import type { CartasDaTrilha } from "../../seed-flashcards.ts";
+
+/**
+ * Cartões de SQL para Dados.
+ *
+ * Sem trilhos de linguagem: tudo em "neutra". O quiz cobra a leitura do
+ * cenário e a escolha da cláusula; as cartas guardam as listas fechadas,
+ * o vocabulário próprio e as armadilhas que a aula enuncia de passagem.
+ *
+ * A trilha aparece em mais de um roadmap, então o fechamento não crava
+ * roadmap nem trilha seguinte.
+ */
+export const sqlParaDados: CartasDaTrilha = {
+    trilha: "SQL para Dados",
+    modulos: {
+        1: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que três ganhos a tabela traz sobre a planilha?",
+                        verso: "Responder sem carregar tudo, combinar fontes e confiar no dado.",
+                    },
+                    {
+                        frente: "Que vantagem a consulta em texto tem sobre o clique?",
+                        verso: "Ela versiona no Git e repete o mesmo resultado depois.",
+                    },
+                    {
+                        frente: "O que a planilha deixa como registro do que foi feito?",
+                        verso: "Só a sequência de cliques, que ninguém refaz igual.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que nome o conjunto de valores aceitos por uma coluna tem?",
+                        verso: "Domínio, que restringe o que entra naquela coluna.",
+                    },
+                    {
+                        frente: "Que características as tabelas de dimensão compartilham?",
+                        verso: "São pequenas, mudam pouco e definem os recortes.",
+                    },
+                    {
+                        frente: "Que exemplos de fato a aula cita além de vendas?",
+                        verso: "Eventos de produto e leituras de sensor.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que diferença separa timestamp de timestamptz?",
+                        verso: "O timestamptz guarda o instante com fuso; o outro não.",
+                    },
+                    {
+                        frente: "Que efeito o fuso ignorado produz no relatório diário?",
+                        verso: "O que passa das 21h no Brasil cai no dia seguinte.",
+                    },
+                    {
+                        frente: "Que regra prática a aula dá para instante e data pura?",
+                        verso: "Instante em timestamptz; competência sem hora, em date.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que diferença separa chave natural de artificial?",
+                        verso: "A natural vem do negócio; a artificial só existe no banco.",
+                    },
+                    {
+                        frente: "Que estrago a linha órfã causa numa junção interna?",
+                        verso: "Ela é descartada, e o total por categoria fica menor.",
+                    },
+                    {
+                        frente: "Por que o ambiente analítico costuma dispensar a estrangeira?",
+                        verso: "Pelo custo de carga, o que joga a checagem para o analista.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Como o colunar guarda cada coluna da tabela?",
+                        verso: "Num arquivo separado, lido só quando a coluna é pedida.",
+                    },
+                    {
+                        frente: "Que operação fica cara no armazenamento colunar?",
+                        verso: "Buscar ou atualizar a linha inteira de um registro.",
+                    },
+                    {
+                        frente: "Que expectativa de tempo separa os dois mundos?",
+                        verso: "Dois segundos é grave no transacional e ótimo no analítico.",
+                    },
+                ],
+            },
+        },
+        2: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que propriedade do resultado permite encaixar consultas?",
+                        verso: "Ele também é uma tabela, só que temporária.",
+                    },
+                    {
+                        frente: "Que três custos o asterisco cobra numa consulta?",
+                        verso: "Leitura a mais, saída instável e menos comunicação.",
+                    },
+                    {
+                        frente: "Que uso legítimo o asterisco ainda tem?",
+                        verso: "Explorar tabela desconhecida, sempre com LIMIT.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que três atalhos de filtro aparecem em quase toda análise?",
+                        verso: "O IN de lista, o BETWEEN de intervalo e o LIKE de padrão.",
+                    },
+                    {
+                        frente: "Que armadilha o NOT IN esconde com nulo na lista?",
+                        verso: "O resultado inteiro vem vazio, sem nenhum erro.",
+                    },
+                    {
+                        frente: "Por que filtrar a coluna crua vence extrair função dela?",
+                        verso: "A função sobre a coluna atrapalha o uso do índice.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que cláusulas decidem onde o nulo cai na ordenação?",
+                        verso: "O NULLS LAST e o NULLS FIRST, ditos na consulta.",
+                    },
+                    {
+                        frente: "De que duas formas o topo engana quem analisa?",
+                        verso: "Na representatividade e na estabilidade do ranking.",
+                    },
+                    {
+                        frente: "Que número de contexto deve acompanhar todo topo?",
+                        verso: "Quanto ele pesa no total, com a mediana ao lado.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que três formas o count assume numa consulta?",
+                        verso: "Com asterisco, com coluna e com distinct da coluna.",
+                    },
+                    {
+                        frente: "O que count e sum devolvem quando não há linha alguma?",
+                        verso: "O count devolve zero e o sum devolve nulo.",
+                    },
+                    {
+                        frente: "Que função protege um painel do sum nulo?",
+                        verso: "O coalesce, trocando o nulo por zero quando cabe.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que ordem lógica o banco segue ao executar a consulta?",
+                        verso: "FROM, WHERE, GROUP BY, HAVING, SELECT, ORDER BY e LIMIT.",
+                    },
+                    {
+                        frente: "Onde o apelido do SELECT funciona, e onde não?",
+                        verso: "Funciona no ORDER BY; no WHERE, ainda não existe.",
+                    },
+                    {
+                        frente: "Que efeito filtrar no WHERE ou no HAVING tem no número?",
+                        verso: "São perguntas diferentes: uma corta vendas, outra corta grupos.",
+                    },
+                ],
+            },
+        },
+    },
+};


### PR DESCRIPTION
Abre a terceira trilha pendente do roadmap de Ciência de Dados.

## O que entra
- Módulo 1, fundamentos: os três ganhos da tabela sobre a planilha, a consulta em texto que versiona no Git, o domínio de uma coluna, o perfil das dimensões, timestamp contra timestamptz e o relatório que vira o dia depois das 21h, chave natural contra artificial, o estrago da linha órfã e por que o colunar guarda cada coluna num arquivo.
- Módulo 2, consulta básica: a propriedade que permite encaixar consultas, os três custos do asterisco, os atalhos IN, BETWEEN e LIKE, a cilada do NOT IN com nulo, as cláusulas que decidem onde o nulo cai na ordenação, as duas formas de o topo enganar, as três formas do count, o sum nulo sem linhas e a ordem lógica de execução.

30 cartas, 3 por aula. A trilha tem 35 aulas, os módulos 3 a 7 vêm em seguida.

A trilha aparece nos roadmaps de Ciência de Dados e de Engenharia de Dados, então o fechamento dela não vai cravar roadmap nem trilha seguinte.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, nenhuma já existia. Arquivo registrado no index.

Empilhado sobre #467.
