### PR TITLE
feat: cartões dos módulos 1 e 2 de Machine Learning

### DIFF
--- a/backend/scripts/data/flashcards/index.ts
+++ b/backend/scripts/data/flashcards/index.ts
@@ -37,6 +37,7 @@ import { estatisticaEProbabilidade } from "./estatistica-e-probabilidade.ts";
 import { analiseDeDados } from "./analise-de-dados.ts";
 import { sqlParaDados } from "./sql-para-dados.ts";
 import { visualizacaoDeDados } from "./visualizacao-de-dados.ts";
+import { machineLearning } from "./machine-learning.ts";
 
 export const TRILHAS: CartasDaTrilha[] = [
     logicaDeProgramacao,
@@ -76,4 +77,5 @@ export const TRILHAS: CartasDaTrilha[] = [
     analiseDeDados,
     sqlParaDados,
     visualizacaoDeDados,
+    machineLearning,
 ];

--- a/backend/scripts/data/flashcards/machine-learning.ts
+++ b/backend/scripts/data/flashcards/machine-learning.ts
@@ -1,0 +1,178 @@
+import type { CartasDaTrilha } from "../../seed-flashcards.ts";
+
+/**
+ * Cartões de Machine Learning, sexta trilha do roadmap de Ciência de Dados.
+ *
+ * Sem trilhos de linguagem: tudo em "neutra". O quiz cobra o julgamento do
+ * cenário e a leitura do código; as cartas guardam o vocabulário fechado,
+ * os nomes de método e as regras que a aula enuncia de passagem.
+ */
+export const machineLearning: CartasDaTrilha = {
+    trilha: "Machine Learning",
+    modulos: {
+        1: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Por que a lista de regras do filtro de spam não se sustenta?",
+                        verso: "Quem envia adapta a mensagem e cada truque pede regra nova.",
+                    },
+                    {
+                        frente: "Que exemplo da trilha de estatística já era aprendizado?",
+                        verso: "A regressão linear, que achou os coeficientes sozinha.",
+                    },
+                    {
+                        frente: "O que o algoritmo recebe no lugar das regras prontas?",
+                        verso: "Milhares de exemplos já classificados por pessoas.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que verbo resume cada um dos três tipos de aprendizado?",
+                        verso: "Prever no supervisionado, agrupar no não-supervisionado, agir no reforço.",
+                    },
+                    {
+                        frente: "Que peças o aprendizado por reforço coloca em jogo?",
+                        verso: "Um agente, um ambiente e recompensas por cada decisão.",
+                    },
+                    {
+                        frente: "Que tipo de problema o scikit-learn não atende?",
+                        verso: "O aprendizado por reforço, que tem bibliotecas próprias.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que seis termos formam o vocabulário básico de ML?",
+                        verso: "Feature, alvo, amostra, modelo, treino e previsão.",
+                    },
+                    {
+                        frente: "Que estruturas do pandas o X e o y assumem?",
+                        verso: "O X vira DataFrame e o y vira Series de um valor por linha.",
+                    },
+                    {
+                        frente: "Que sinônimos o alvo recebe na documentação?",
+                        verso: "Target, rótulo e variável dependente do problema.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que cadeia de etapas antecede o modelo no fluxo?",
+                        verso: "Buscar com SQL, limpar com pandas, explorar e visualizar.",
+                    },
+                    {
+                        frente: "Que foco separa a estatística do aprendizado de máquina?",
+                        verso: "A estatística explica e testa; o modelo quer prever bem.",
+                    },
+                    {
+                        frente: "O que o algoritmo faz com dado mal preparado?",
+                        verso: "Aprende o problema junto, sem consertar nada sozinho.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que comparação a aula faz entre algoritmo e dado?",
+                        verso: "Algoritmo simples com dado bom vence sofisticado com dado ruim.",
+                    },
+                    {
+                        frente: "Que pergunta precede confiar numa previsão?",
+                        verso: "Que dados treinaram isso e quem eles representam de fato.",
+                    },
+                    {
+                        frente: "Por que um modelo não é neutro só por ser matemática?",
+                        verso: "Ele reproduz o viés que estava nos dados de treino.",
+                    },
+                ],
+            },
+        },
+        2: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que sete etapas o pipeline de ML percorre?",
+                        verso: "Definir, obter, preparar, dividir, treinar, avaliar e usar.",
+                    },
+                    {
+                        frente: "Por que o fluxo é um mapa, e não uma esteira?",
+                        verso: "Avaliar costuma mandar você voltar para limpar de novo.",
+                    },
+                    {
+                        frente: "Que etapas do pipeline vêm antes de qualquer algoritmo?",
+                        verso: "Obter e preparar os dados, o grosso do trabalho.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que faixa de teste costuma ser reservada na divisão?",
+                        verso: "Algo entre vinte e trinta por cento dos dados.",
+                    },
+                    {
+                        frente: "O que o random_state garante entre duas execuções?",
+                        verso: "A mesma divisão, para comparar experimentos de forma justa.",
+                    },
+                    {
+                        frente: "Em que momento o conjunto de teste entra em cena?",
+                        verso: "Só na avaliação, intocado durante todo o treino.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que três métodos todo estimador do scikit-learn expõe?",
+                        verso: "O fit que aprende, o predict que aplica e o score que resume.",
+                    },
+                    {
+                        frente: "Que métrica o score devolve em cada tipo de modelo?",
+                        verso: "Acurácia na classificação e R quadrado na regressão.",
+                    },
+                    {
+                        frente: "Que vantagem a API igual entre algoritmos traz?",
+                        verso: "Trocar de algoritmo sem reescrever o resto do código.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que dataset de exemplo vem junto do scikit-learn?",
+                        verso: "O iris, com 150 linhas de medidas de flores.",
+                    },
+                    {
+                        frente: "Que alinhamento X e y precisam manter entre si?",
+                        verso: "A linha de X corresponde à mesma posição em y.",
+                    },
+                    {
+                        frente: "Por que a métrica quase perfeita do iris engana?",
+                        verso: "Ele é pequeno e bem separável; dado real é mais barulhento.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que três conjuntos a divisão completa produz?",
+                        verso: "Treino, validação e o teste guardado para o fim.",
+                    },
+                    {
+                        frente: "Quantas vezes cada conjunto é consultado no projeto?",
+                        verso: "Treino e validação, várias; o teste, uma só vez.",
+                    },
+                    {
+                        frente: "Que técnica o módulo 5 traz para conjunto pequeno?",
+                        verso: "A validação cruzada, que aproveita melhor os dados.",
+                    },
+                ],
+            },
+        },
+    },
+};


### PR DESCRIPTION
Abre a quinta trilha pendente do roadmap de Ciência de Dados.

## O que entra
- Módulo 1, o que é ML: por que a lista de regras do filtro de spam não se sustenta, o exemplo de aprendizado que já apareceu em estatística, o verbo de cada um dos três tipos, as peças do aprendizado por reforço, os seis termos do vocabulário, as estruturas que X e y assumem no pandas, o foco que separa estatística de modelo e por que um modelo não é neutro só por ser matemática.
- Módulo 2, o fluxo: as sete etapas do pipeline, por que ele é mapa e não esteira, a faixa reservada para teste, o que o random_state garante, os três métodos de todo estimador, a métrica que o score devolve em cada caso, o alinhamento entre X e y e quantas vezes cada conjunto é consultado.

30 cartas, 3 por aula. A trilha tem 35 aulas, os módulos 3 a 7 vêm em seguida.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, nenhuma já existia. Arquivo registrado no index.

Empilhado sobre #473.
