### PR TITLE
feat: cartões dos módulos 3 e 4 de Sistemas de Tempo Real

### DIFF
--- a/backend/scripts/data/flashcards/sistemas-de-tempo-real.ts
+++ b/backend/scripts/data/flashcards/sistemas-de-tempo-real.ts
@@ -175,5 +175,169 @@ export const sistemasDeTempoReal: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que critério correto atribui prioridade a uma tarefa?",
+                        verso: "A criticidade temporal, não a importância aparente.",
+                    },
+                    {
+                        frente: "Como o kernel trata tarefas prontas de mesma prioridade?",
+                        verso: "Reveza por rodízio a cada tick, com o fatiamento ligado.",
+                    },
+                    {
+                        frente: "Que tarefa vive no porão do sistema, e para quê?",
+                        verso: "A ociosa, de prioridade zero, limpando recurso encerrado.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Quem provou a otimalidade do RMS, e quando?",
+                        verso: "Liu e Layland, em 1973, entre as prioridades fixas.",
+                    },
+                    {
+                        frente: "Que caráter o teste de utilização tem?",
+                        verso: "Suficiente, não necessário: falhar não prova impossível.",
+                    },
+                    {
+                        frente: "Que hipóteses o mundo real costuma violar no RMS?",
+                        verso: "Tarefas independentes e deadline igual ao período.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que diferença de falha separa o EDF do RMS?",
+                        verso: "No RMS a baixa prioridade cai; no EDF, todos podem cair.",
+                    },
+                    {
+                        frente: "Que suporte prático o EDF tem hoje?",
+                        verso: "O Zephyr e o Linux o oferecem; o FreeRTOS não traz nativo.",
+                    },
+                    {
+                        frente: "Que custo extra o EDF cobra do kernel?",
+                        verso: "Manter e comparar deadlines a cada decisão de escalonar.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que sonda e que ano o caso clássico envolve?",
+                        verso: "A Mars Pathfinder, em 1997, com resets diários.",
+                    },
+                    {
+                        frente: "Que dois remédios a inversão de prioridade tem?",
+                        verso: "A herança de prioridade e o teto de prioridade.",
+                    },
+                    {
+                        frente: "Que primitiva do FreeRTOS não tem herança?",
+                        verso: "O semáforo binário; exclusão mútua pede mutex.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que instrumento barato mede latência com precisão?",
+                        verso: "Um pino alternado lido por osciloscópio ou analisador.",
+                    },
+                    {
+                        frente: "Que ferramentas registram cada evento de escalonamento?",
+                        verso: "Os rastreadores de RTOS, com carimbo de microssegundo.",
+                    },
+                    {
+                        frente: "Que valor deve sempre ser registrado numa medição?",
+                        verso: "O pior caso observado, nunca só a média da amostra.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que três pecados capitais o malloc comete?",
+                        verso: "Tempo variável, fragmentação e falha tarde demais.",
+                    },
+                    {
+                        frente: "Que agravante o heap global acrescenta ao problema?",
+                        verso: "Ele é protegido por lock, no meio do caminho crítico.",
+                    },
+                    {
+                        frente: "Que ganho alocar tudo na inicialização traz?",
+                        verso: "A falha aparece na bancada, e não no cliente.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que preço o pool paga por blocos de tamanho fixo?",
+                        verso: "A fragmentação interna, com bytes perdidos por bloco.",
+                    },
+                    {
+                        frente: "Que conta dimensiona a quantidade de blocos?",
+                        verso: "A de pior caso: quantos podem estar em uso ao mesmo tempo.",
+                    },
+                    {
+                        frente: "Que contador revela a folga real do pool no campo?",
+                        verso: "O mínimo de blocos livres já observado na operação.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que ordem de escrita o produtor precisa respeitar?",
+                        verso: "Primeiro o dado, depois o índice publicado ao consumidor.",
+                    },
+                    {
+                        frente: "Que arranjo dispensa trava no ring buffer?",
+                        verso: "Um produtor e um consumidor únicos, o chamado SPSC.",
+                    },
+                    {
+                        frente: "Que sacrifício a convenção de cheio costuma fazer?",
+                        verso: "Um slot, para distinguir cheio de vazio sem contador.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que três vilões consomem stack sem avisar?",
+                        verso: "Buffer local grande, recursão e as funções de formatação.",
+                    },
+                    {
+                        frente: "Que hook detecta o estouro de stack no FreeRTOS?",
+                        verso: "O de overflow, que registra a tarefa culpada.",
+                    },
+                    {
+                        frente: "Que função responde a folga mínima já vista?",
+                        verso: "A do high-water mark do stack daquela tarefa.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que se troca na virada, e o que nunca se copia?",
+                        verso: "Trocam-se os ponteiros; o conteúdo nunca é copiado.",
+                    },
+                    {
+                        frente: "Que par de interrupções o DMA oferece de graça?",
+                        verso: "A de meia transferência e a de transferência completa.",
+                    },
+                    {
+                        frente: "Onde a mesma ideia reaparece além do sensor?",
+                        verso: "Nos displays, desenhando o quadro seguinte enquanto exibe.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Segue a trilha de Sistemas de Tempo Real.

## O que entra
- Módulo 3, escalonamento: o critério correto de prioridade, o rodízio entre iguais, a tarefa ociosa, quem provou a otimalidade do RMS, o caráter suficiente do teste de utilização, a diferença de falha entre EDF e RMS, a sonda do caso clássico de inversão e os dois remédios dela.
- Módulo 4, memória: os três pecados do malloc, o agravante do heap global, o preço do pool de blocos fixos, a conta que dimensiona a quantidade, a ordem de escrita do ring buffer, o arranjo que dispensa trava, os vilões que consomem stack e o par de interrupções que o DMA oferece.

30 cartas novas, trilha em 60.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam.

Empilhado sobre #498.
