### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Sistemas de Tempo Real

### DIFF
--- a/backend/scripts/data/flashcards/sistemas-de-tempo-real.ts
+++ b/backend/scripts/data/flashcards/sistemas-de-tempo-real.ts
@@ -339,5 +339,251 @@ export const sistemasDeTempoReal: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que quatro regras de estilo tornam o WCET fechável?",
+                        verso: "Laço com teto, sem recursão, poucos caminhos e sem opaco.",
+                    },
+                    {
+                        frente: "Que exigência as regras do JPL fazem sobre o laço?",
+                        verso: "Que uma ferramenta consiga provar o teto de iterações.",
+                    },
+                    {
+                        frente: "Por que microcontrolador simples facilita o WCET?",
+                        verso: "Sem cache, o tempo por instrução fica quase constante.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que qualidade os estímulos de medição precisam ter?",
+                        verso: "Serem adversariais, provocando o pior caminho de propósito.",
+                    },
+                    {
+                        frente: "Que caminho a análise estática de WCET percorre?",
+                        verso: "Enumera caminhos do binário e modela o processador.",
+                    },
+                    {
+                        frente: "Que três testemunhas o número de WCET maduro tem?",
+                        verso: "A medição, a margem de projeto e o monitor em campo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que padrão substitui a alimentação incondicional?",
+                        verso: "As tarefas críticas provam vida antes de alguém alimentar.",
+                    },
+                    {
+                        frente: "Que defeito o watchdog com janela consegue pegar?",
+                        verso: "O laço descontrolado que alimenta cedo demais.",
+                    },
+                    {
+                        frente: "Que registrador vale ler logo na inicialização?",
+                        verso: "O de causa do reset, para registrar o motivo da queda.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que quatro colunas a tabela de modos de falha tem?",
+                        verso: "A falha, a detecção, a reação e o estado alvo.",
+                    },
+                    {
+                        frente: "Que trabalho ativo a detecção de falha exige?",
+                        verso: "Testes de plausibilidade sobre a leitura do sensor.",
+                    },
+                    {
+                        frente: "Que meio-termo existe entre o normal e o desastre?",
+                        verso: "A degradação controlada, com função reduzida.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Quanto durou o voo inaugural do foguete do caso?",
+                        verso: "Quarenta segundos, antes da destruição em voo.",
+                    },
+                    {
+                        frente: "Que detalhe amargo o código do Ariane guardava?",
+                        verso: "A função nem era necessária em voo, herdada ligada.",
+                    },
+                    {
+                        frente: "Que lição de processo o reuso do caso deixa?",
+                        verso: "Suposição herdada precisa de dono e revalidação.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que duas implementações canônicas a FSM tem?",
+                        verso: "O enum com switch e a tabela de transições declarada.",
+                    },
+                    {
+                        frente: "Que quatro hábitos tornam a FSM robusta?",
+                        verso: "Evento inválido tratado, timeout como evento, um escritor e default.",
+                    },
+                    {
+                        frente: "Quantas combinações cinco flags booleanas criam?",
+                        verso: "Trinta e duas, com a maioria inválida por natureza.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que três condições sustentam ficar no superloop?",
+                        verso: "Poucas taxas harmônicas, nada longo bloqueando e prazo folgado.",
+                    },
+                    {
+                        frente: "Que sinal indica a hora de migrar para o RTOS?",
+                        verso: "Pegar-se construindo um escalonador artesanal na mão.",
+                    },
+                    {
+                        frente: "Que erro cada direção da escolha comete?",
+                        verso: "Kernel em termostato e superloop em drone com prazo curto.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que política serve quando só o valor recente vale?",
+                        verso: "Descartar o velho, sobrescrevendo a fila de uma posição.",
+                    },
+                    {
+                        frente: "Que diagnóstico separa fila curta de consumidor lento?",
+                        verso: "Transbordar em rajada contra transbordar sempre.",
+                    },
+                    {
+                        frente: "Onde bloquear o produtor nunca é permitido?",
+                        verso: "Dentro de uma ISR, que não pode esperar por nada.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que quatro degraus a escada de sincronização tem?",
+                        verso: "Seção crítica, mutex, atomics e a estrutura sem trava.",
+                    },
+                    {
+                        frente: "Que par de ordenações o SPSC correto usa?",
+                        verso: "O release na publicação e o acquire na leitura.",
+                    },
+                    {
+                        frente: "Que teste de vaidade o lock-free precisa passar?",
+                        verso: "A medição mostrar o mecanismo simples sofrendo.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que três passos o padrão de log de tempo real segue?",
+                        verso: "Registrar binário, formatar depois e transmitir longe.",
+                    },
+                    {
+                        frente: "Que relógio o carimbo do evento precisa usar?",
+                        verso: "O timer de hardware em microssegundos, não o tick.",
+                    },
+                    {
+                        frente: "Em que prioridade a tarefa de drenagem deve rodar?",
+                        verso: "Baixa por princípio: o log não compete com o controle.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que documento abre o projeto de tempo real?",
+                        verso: "A tabela de requisitos com deadline, classe e origem.",
+                    },
+                    {
+                        frente: "Que justifica os 500 Hz da malha de atitude?",
+                        verso: "A dinâmica rápida do quadricóptero, em dezenas de ms.",
+                    },
+                    {
+                        frente: "Que exercício o projeto do drone propõe?",
+                        verso: "Engenharia no papel, sem placa nem solda envolvidas.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Como se desempata prioridade entre períodos iguais?",
+                        verso: "Pela consequência do atraso, já que o RMS não desempata.",
+                    },
+                    {
+                        frente: "Que limite o teste dá para cinco tarefas?",
+                        verso: "Cerca de 0,743 de utilização somada no conjunto.",
+                    },
+                    {
+                        frente: "Que grandeza em campo mostra a folga real respirando?",
+                        verso: "O tempo da tarefa ociosa, medido durante a operação.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que frase todo tamanho de fila precisa completar?",
+                        verso: "Aguento tanta rajada com o consumidor parado tanto tempo.",
+                    },
+                    {
+                        frente: "Que contraste separa o setpoint do comando de missão?",
+                        verso: "O setpoint é fluxo e o comando é evento que não evapora.",
+                    },
+                    {
+                        frente: "Quem lê os contadores de descarte, e com que ritmo?",
+                        verso: "O housekeeping, uma vez por segundo na ronda.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que prazo o watchdog de hardware do drone usa?",
+                        verso: "Cem milissegundos, alimentado pelo housekeeping.",
+                    },
+                    {
+                        frente: "Que quatro itens a ronda de um hertz confere?",
+                        verso: "Folga de stack, descartes, bateria e vida das tarefas.",
+                    },
+                    {
+                        frente: "Como cada linha da tabela de falhas é ensaiada?",
+                        verso: "Em bancada, com hélice removida e falha injetada.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "De que os sistemas de tempo real confiáveis nascem?",
+                        verso: "De método disciplinado, e não de genialidade isolada.",
+                    },
+                    {
+                        frente: "Que três preferências o critério final fixa?",
+                        verso: "Pior caso, previsibilidade e número com origem e margem.",
+                    },
+                    {
+                        frente: "Que kit de prática o fechamento recomenda?",
+                        verso: "Placa barata, RTOS aberto e um analisador modesto.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de Sistemas de Tempo Real.

## O que entra
- Módulo 5, pior caso e falha: as quatro regras de estilo que tornam o WCET fechável, a exigência do JPL sobre o laço, a qualidade adversarial dos estímulos, o padrão correto de alimentar o watchdog, o defeito que a janela pega, as quatro colunas da tabela de modos de falha e as lições dos desastres.
- Módulo 6, padrões: as duas implementações canônicas da máquina de estados, os quatro hábitos que a tornam robusta, as três condições que sustentam o superloop, o sinal de migrar para o RTOS, a política de descartar o velho, os quatro degraus da escada de sincronização e os três passos do log de tempo real.
- Módulo 7, projeto do drone: o documento que abre o projeto, o desempate entre períodos iguais, o limite do teste para cinco tarefas, a frase que todo tamanho de fila completa, o prazo do watchdog e as três preferências do critério final.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 15 criadas no último bloco, nenhuma aula publicada sem carta.

Empilhado sobre #499.
