### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Cálculo 1

### DIFF
--- a/backend/scripts/data/flashcards/calculo-1.ts
+++ b/backend/scripts/data/flashcards/calculo-1.ts
@@ -341,5 +341,251 @@ export const calculo1: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Onde todo extremo de uma função mora?",
+                        verso: "Num ponto crítico, embora nem todo crítico seja extremo.",
+                    },
+                    {
+                        frente: "O que define um ponto crítico?",
+                        verso: "A derivada zerar ali, ou não existir naquele ponto.",
+                    },
+                    {
+                        frente: "Que diferença separa extremo local do global?",
+                        verso: "O local vence a vizinhança; o global, todo o intervalo.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que igualdade o teorema do valor médio garante?",
+                        verso: "A velocidade média é atingida em algum instante do trajeto.",
+                    },
+                    {
+                        frente: "Que hipóteses o teorema do valor médio exige?",
+                        verso: "Continuidade no intervalo fechado e derivada no aberto.",
+                    },
+                    {
+                        frente: "Que retas o teorema do valor médio compara?",
+                        verso: "A secante dos extremos e uma tangente interna paralela a ela.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o sinal da primeira derivada conta?",
+                        verso: "Se a função sobe ou desce naquele trecho.",
+                    },
+                    {
+                        frente: "O que a troca de sinal da derivada marca?",
+                        verso: "Um pico ou um vale no gráfico da função.",
+                    },
+                    {
+                        frente: "Que teste usa apenas a primeira derivada?",
+                        verso: "O do sinal antes e depois do ponto crítico.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que a segunda derivada informa sobre a curva?",
+                        verso: "Como ela se curva ao subir ou descer, a concavidade.",
+                    },
+                    {
+                        frente: "O que caracteriza um ponto de inflexão?",
+                        verso: "A troca de concavidade, com a segunda derivada mudando de sinal.",
+                    },
+                    {
+                        frente: "Que concavidade a segunda derivada positiva indica?",
+                        verso: "A voltada para cima, com a curva abrindo em concha.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que peças cada derivada entrega no esboço?",
+                        verso: "A primeira dá subida e descida; a segunda, a curvatura.",
+                    },
+                    {
+                        frente: "Que informações precedem as derivadas no esboço?",
+                        verso: "Domínio, interseções com os eixos e assíntotas.",
+                    },
+                    {
+                        frente: "Que descuido deixa o esboço incompleto?",
+                        verso: "Ignorar as assíntotas e o comportamento no infinito.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que otimizar busca, segundo a aula?",
+                        verso: "A melhor escolha dentro das restrições que o problema impõe.",
+                    },
+                    {
+                        frente: "Que passo abre um problema de otimização?",
+                        verso: "Escrever a grandeza a otimizar em função de uma variável só.",
+                    },
+                    {
+                        frente: "Que verificação fecha o problema de otimização?",
+                        verso: "Conferir os extremos do intervalo, além dos pontos críticos.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que taxas relacionadas exploram numa equação?",
+                        verso: "Mexer numa grandeza faz as outras responderem no mesmo instante.",
+                    },
+                    {
+                        frente: "Em relação a que se deriva nas taxas relacionadas?",
+                        verso: "Ao tempo, nos dois lados da equação que liga as grandezas.",
+                    },
+                    {
+                        frente: "Quando substituir os valores numéricos do problema?",
+                        verso: "Só depois de derivar, nunca antes.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que situação autoriza a regra de L'Hôpital?",
+                        verso: "A forma indeterminada, como zero sobre zero ou infinito sobre infinito.",
+                    },
+                    {
+                        frente: "O que a regra de L'Hôpital deriva?",
+                        verso: "Numerador e denominador separados, nunca o quociente inteiro.",
+                    },
+                    {
+                        frente: "Que formas precisam de ajuste antes da regra?",
+                        verso: "As de produto ou potência, reescritas como quociente.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que palpite a reta tangente oferece?",
+                        verso: "O melhor valor linear para o que acontece logo ali ao lado.",
+                    },
+                    {
+                        frente: "Como o erro da aproximação linear se comporta?",
+                        verso: "Cresce conforme a distância até o ponto de tangência.",
+                    },
+                    {
+                        frente: "O que o diferencial estima na prática?",
+                        verso: "A variação da função a partir de uma variação pequena na entrada.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que cada passo do método de Newton faz?",
+                        verso: "Corrige o anterior, aproximando a raiz por tangentes.",
+                    },
+                    {
+                        frente: "Que dado o método de Newton exige para começar?",
+                        verso: "Um chute inicial razoavelmente perto da raiz.",
+                    },
+                    {
+                        frente: "Que situação faz o método de Newton falhar?",
+                        verso: "Derivada perto de zero, ou chute inicial muito distante.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que pergunta integrar inverte?",
+                        verso: "Deixa de ser qual a taxa e passa a ser de qual função ela veio.",
+                    },
+                    {
+                        frente: "Por que a integral indefinida carrega uma constante?",
+                        verso: "Infinitas funções têm a mesma derivada, diferindo por constante.",
+                    },
+                    {
+                        frente: "Que teste confirma uma antiderivada?",
+                        verso: "Derivar o resultado e reencontrar a função original.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "De que ideia simples a integral definida nasceu?",
+                        verso: "Aproximar uma área por fatias cada vez mais finas.",
+                    },
+                    {
+                        frente: "Que soma antecede a integral definida?",
+                        verso: "A de retângulos sob a curva, refinada até o limite.",
+                    },
+                    {
+                        frente: "O que a integral definida devolve?",
+                        verso: "Um número, a área acumulada naquele intervalo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que dois problemas o teorema fundamental liga?",
+                        verso: "O da tangente e o da área, as questões que originaram o cálculo.",
+                    },
+                    {
+                        frente: "Como o teorema fundamental calcula a área?",
+                        verso: "Pela diferença da antiderivada nos extremos do intervalo.",
+                    },
+                    {
+                        frente: "Que trabalho o teorema fundamental dispensa?",
+                        verso: "Somar infinitos retângulos a cada área nova.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que uma boa substituição faz com a integral?",
+                        verso: "Transforma a assustadora em outra que você já sabe resolver.",
+                    },
+                    {
+                        frente: "O que a substituição desfaz, na prática?",
+                        verso: "A regra da cadeia, lida de trás para frente.",
+                    },
+                    {
+                        frente: "Que cuidado a integral definida pede na substituição?",
+                        verso: "Trocar também os limites, ou voltar à variável antiga no fim.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que três escolhas a área entre curvas exige?",
+                        verso: "Quem está por cima, quem está por baixo e onde elas se cruzam.",
+                    },
+                    {
+                        frente: "Que integral dá a área entre duas curvas?",
+                        verso: "A da diferença entre a de cima e a de baixo.",
+                    },
+                    {
+                        frente: "Que cuidado a curva que troca de posição pede?",
+                        verso: "Quebrar a área em pedaços no ponto de cruzamento.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de Cálculo 1.

## O que entra
- Módulo 5, aplicações da derivada: o ponto crítico que nem sempre é extremo, as hipóteses do teorema do valor médio, o sinal da primeira derivada, a concavidade que a segunda revela e a ordem do esboço de gráficos.
- Módulo 6, otimização e aproximação: a restrição que define o ótimo, a derivação em relação ao tempo nas taxas relacionadas, quando a regra de L'Hôpital vale, o erro da aproximação linear e os limites do método de Newton.
- Módulo 7, integral: a constante da indefinida, a soma de retângulos que virou integral definida, a ponte do teorema fundamental, a substituição como cadeia ao contrário e a área entre curvas.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 60 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #508.
