### PR TITLE
feat: cartões dos módulos 3 e 4 de Cálculo 2

### DIFF
--- a/backend/scripts/data/flashcards/calculo-2.ts
+++ b/backend/scripts/data/flashcards/calculo-2.ts
@@ -177,5 +177,169 @@ export const calculo2: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que pergunta integrar até o infinito faz?",
+                        verso: "O que sobra de área quando se avança sem nunca parar.",
+                    },
+                    {
+                        frente: "Que ferramenta define a integral imprópria?",
+                        verso: "O limite, com o extremo indo ao infinito.",
+                    },
+                    {
+                        frente: "O que dois extremos infinitos exigem?",
+                        verso: "Quebrar em duas integrais, cada uma com seu limite.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que segundo tipo de integral imprópria existe?",
+                        verso: "O do integrando que dispara dentro do intervalo.",
+                    },
+                    {
+                        frente: "O que um buraco no gráfico não impede?",
+                        verso: "Que a área seja finita, mesmo com a função disparando.",
+                    },
+                    {
+                        frente: "Onde o limite é tomado nesse segundo tipo?",
+                        verso: "No ponto de descontinuidade, aproximando-se dele.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que pergunta vem antes de calcular o valor?",
+                        verso: "Se a integral converge ou diverge.",
+                    },
+                    {
+                        frente: "O que caracteriza uma integral convergente?",
+                        verso: "O limite existir e dar um número finito.",
+                    },
+                    {
+                        frente: "O que a divergência significa na prática?",
+                        verso: "A área cresce sem limite, sem valor a reportar.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que saída o critério da comparação oferece?",
+                        verso: "Comparar com uma função conhecida, por cima ou por baixo.",
+                    },
+                    {
+                        frente: "O que a maior convergente garante à menor?",
+                        verso: "Que ela também converge.",
+                    },
+                    {
+                        frente: "O que a menor divergente garante à maior?",
+                        verso: "Que ela também diverge.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que curiosidade as impróprias revelam sobre volume?",
+                        verso: "Volume finito acompanhado de superfície infinita.",
+                    },
+                    {
+                        frente: "Que lição a aula tira desses casos?",
+                        verso: "A intuição às vezes precisa se curvar diante da conta.",
+                    },
+                    {
+                        frente: "Onde as impróprias aparecem fora da geometria?",
+                        verso: "Em probabilidade, com distribuições sobre toda a reta.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que passo precede a integral da área entre curvas?",
+                        verso: "Esboçar a região e identificar quem está por cima.",
+                    },
+                    {
+                        frente: "Que erros o esboço rápido evita?",
+                        verso: "Os de sinal e os de limites de integração.",
+                    },
+                    {
+                        frente: "Que integral dá a área entre duas curvas?",
+                        verso: "A da diferença, a de cima menos a de baixo.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que desenho precede a integral por discos?",
+                        verso: "O raio de uma fatia genérica.",
+                    },
+                    {
+                        frente: "O que o raio da fatia mede?",
+                        verso: "A distância da curva até o eixo de rotação.",
+                    },
+                    {
+                        frente: "Quando o disco vira anel?",
+                        verso: "Quando há um buraco, com raio interno e externo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que alternativa ao disco a aula apresenta?",
+                        verso: "A casca cilíndrica, outro caminho para o mesmo volume.",
+                    },
+                    {
+                        frente: "Que critério escolhe entre casca e disco?",
+                        verso: "O que deixa a integral mais simples de montar.",
+                    },
+                    {
+                        frente: "Que medidas a casca cilíndrica combina?",
+                        verso: "O raio multiplicado pela altura da casca.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que contraste o comprimento de arco apresenta?",
+                        verso: "Fórmula elegante e cálculo teimoso.",
+                    },
+                    {
+                        frente: "O que vale mais que forçar a integral do arco?",
+                        verso: "Dominar a montagem correta da fórmula.",
+                    },
+                    {
+                        frente: "Que derivada aparece na fórmula do comprimento de arco?",
+                        verso: "A da função, dentro de uma raiz.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que face da integral trabalho e valor médio mostram?",
+                        verso: "A de fora da geometria, somando contribuições contínuas.",
+                    },
+                    {
+                        frente: "Como o valor médio de uma função é obtido?",
+                        verso: "Pela integral dividida pelo comprimento do intervalo.",
+                    },
+                    {
+                        frente: "Que produto o trabalho integra?",
+                        verso: "O da força pelo deslocamento, ponto a ponto.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de Cálculo 2.

## O que entra
- Módulo 3, integrais impróprias: o limite que define os dois tipos, a área que pode ser finita mesmo com a função disparando, a pergunta sobre convergência antes do cálculo, o que a comparação garante nos dois sentidos e o volume finito de superfície infinita.
- Módulo 4, aplicações da integral: o esboço antes da área entre curvas, o raio da fatia genérica nos discos e anéis, o critério para escolher casca ou disco, a montagem do comprimento de arco e a integral fora da geometria em trabalho e valor médio.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #516.
