### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Cálculo 3

### DIFF
--- a/backend/scripts/data/flashcards/calculo-3.ts
+++ b/backend/scripts/data/flashcards/calculo-3.ts
@@ -341,5 +341,251 @@ export const calculo3: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que ideia transforma uma superfície num número?",
+                        verso: "Somar infinitos pedacinhos de volume.",
+                    },
+                    {
+                        frente: "Que soma antecede a integral dupla?",
+                        verso: "A de Riemann, com pequenos retângulos da região.",
+                    },
+                    {
+                        frente: "O que a integral dupla de uma função positiva mede?",
+                        verso: "O volume sob a superfície, acima da região.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que o teorema de Fubini permite?",
+                        verso: "Integrar uma vez e depois integrar o resultado.",
+                    },
+                    {
+                        frente: "Que liberdade Fubini dá sobre a ordem?",
+                        verso: "Trocar a ordem das integrações, cumpridas as condições.",
+                    },
+                    {
+                        frente: "Que integral interna aparece na iterada?",
+                        verso: "A que trata a outra variável como constante.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que passo evita a maioria dos erros de limite?",
+                        verso: "Desenhar a região antes de montar a integral.",
+                    },
+                    {
+                        frente: "Que limites a integral interna recebe numa região geral?",
+                        verso: "Funções da outra variável, e não números fixos.",
+                    },
+                    {
+                        frente: "Que limites a integral externa precisa ter?",
+                        verso: "Números constantes.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que simetria pede coordenadas polares?",
+                        verso: "A circular, que costuma encurtar bastante a conta.",
+                    },
+                    {
+                        frente: "Que fator extra as polares acrescentam?",
+                        verso: "O raio, multiplicando o integrando.",
+                    },
+                    {
+                        frente: "Que regiões as polares descrevem com facilidade?",
+                        verso: "Discos, anéis e setores.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que separa área, volume e massa na integral dupla?",
+                        verso: "Só o integrando: a integral é a mesma.",
+                    },
+                    {
+                        frente: "Que integrando calcula a área da região?",
+                        verso: "A função constante igual a um.",
+                    },
+                    {
+                        frente: "Que integrando calcula a massa de uma lâmina?",
+                        verso: "A densidade, ponto a ponto.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Em que a integral tripla transforma medir um sólido?",
+                        verso: "Em três integrações simples encaixadas.",
+                    },
+                    {
+                        frente: "Que região a integral tripla percorre?",
+                        verso: "Um sólido no espaço.",
+                    },
+                    {
+                        frente: "Que integrando devolve o volume do sólido?",
+                        verso: "A função constante igual a um.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que leitura as regiões gerais exigem?",
+                        verso: "De dentro para fora, começando pela variável presa.",
+                    },
+                    {
+                        frente: "O que a sombra do sólido determina?",
+                        verso: "A região do plano que recebe as duas integrais externas.",
+                    },
+                    {
+                        frente: "Entre o que a variável interna fica presa?",
+                        verso: "Entre duas superfícies.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Quando as coordenadas cilíndricas valem a pena?",
+                        verso: "Quando a sombra no chão é um círculo ou um setor.",
+                    },
+                    {
+                        frente: "Que coordenadas as cilíndricas combinam?",
+                        verso: "As polares no plano com a altura de sempre.",
+                    },
+                    {
+                        frente: "Que fator extra as cilíndricas trazem?",
+                        verso: "O raio, multiplicando o integrando.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Diante de que sólidos trocar para esféricas?",
+                        verso: "Esferas e cones que saem da origem.",
+                    },
+                    {
+                        frente: "Que três coordenadas as esféricas usam?",
+                        verso: "A distância à origem e dois ângulos.",
+                    },
+                    {
+                        frente: "Que fator as esféricas acrescentam ao integrando?",
+                        verso: "O quadrado da distância vezes o seno de um dos ângulos.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a massa representa na integral tripla?",
+                        verso: "A densidade somada por todo o sólido.",
+                    },
+                    {
+                        frente: "O que o centro de massa calcula?",
+                        verso: "A média das posições, ponderada pela densidade.",
+                    },
+                    {
+                        frente: "Que integrando dá massa em vez de volume?",
+                        verso: "A densidade, no lugar da constante um.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que um campo vetorial associa a cada lugar?",
+                        verso: "Uma direção e uma intensidade.",
+                    },
+                    {
+                        frente: "Como o cálculo enxerga o mundo em movimento?",
+                        verso: "Por campos vetoriais, seta a seta.",
+                    },
+                    {
+                        frente: "Que exemplos físicos são campos vetoriais?",
+                        verso: "Velocidade de um fluido, força e campo elétrico.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que a integral de linha mede?",
+                        verso: "O efeito acumulado do campo ao longo do caminho.",
+                    },
+                    {
+                        frente: "O que a integral de linha não olha apenas?",
+                        verso: "Os extremos: o caminho inteiro conta.",
+                    },
+                    {
+                        frente: "Que dado a integral de linha exige antes?",
+                        verso: "A parametrização da curva.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que importa num campo conservativo?",
+                        verso: "De onde se partiu e aonde se chegou.",
+                    },
+                    {
+                        frente: "Que função todo campo conservativo tem?",
+                        verso: "Uma função potencial, cujo gradiente é o campo.",
+                    },
+                    {
+                        frente: "Que valor a integral fechada tem num campo conservativo?",
+                        verso: "Zero.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que ponte o teorema de Green oferece?",
+                        verso: "Entre o que acontece na borda e o que acontece dentro.",
+                    },
+                    {
+                        frente: "Que tipo de curva o teorema de Green exige?",
+                        verso: "Fechada, simples e percorrida no sentido positivo.",
+                    },
+                    {
+                        frente: "Em que integral Green transforma a de linha?",
+                        verso: "Numa integral dupla sobre a região interna.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que leituras divergente e rotacional fazem?",
+                        verso: "Um enxerga o espalhar, o outro enxerga o girar.",
+                    },
+                    {
+                        frente: "O que o divergente mede num ponto?",
+                        verso: "O quanto o campo sai ou entra dali.",
+                    },
+                    {
+                        frente: "Que rotacional um campo conservativo tem?",
+                        verso: "Rotacional nulo.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de Cálculo 3.

## O que entra
- Módulo 5, integrais duplas: a soma de pedacinhos que vira número, a ordem que Fubini libera, o desenho da região antes dos limites, o fator raio das polares e o integrando que separa área, volume e massa.
- Módulo 6, integrais triplas: as três integrações encaixadas, a leitura de dentro para fora nas regiões gerais, a sombra circular que pede cilíndricas, a esfera que pede esféricas e a densidade que leva à massa e ao centro de massa.
- Módulo 7, campos vetoriais: a direção com intensidade em cada ponto, o efeito acumulado da integral de linha, a função potencial do campo conservativo, a ponte entre borda e interior no teorema de Green e as duas leituras do divergente e do rotacional.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 60 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #520.
