### PR TITLE
feat: cartões dos módulos 3 e 4 de Defesa e o SOC

### DIFF
--- a/backend/scripts/data/flashcards/defesa-e-o-soc.ts
+++ b/backend/scripts/data/flashcards/defesa-e-o-soc.ts
@@ -174,5 +174,169 @@ export const defesaEOSoc: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que o SIEM descobre sozinho?",
+                        verso: "Nada: ele responde o que alguém escreveu.",
+                    },
+                    {
+                        frente: "O que é comprar a plataforma antes das perguntas?",
+                        verso: "Comprar um cofre sem saber o que guardar.",
+                    },
+                    {
+                        frente: "Que trabalho o SIEM concentra?",
+                        verso: "Juntar os logs e responder consultas sobre eles.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que ordem uma boa consulta segue?",
+                        verso: "Filtrar cedo e juntar tarde.",
+                    },
+                    {
+                        frente: "O que acontece com a consulta que varre meses primeiro?",
+                        verso: "Costuma expirar antes de responder qualquer coisa.",
+                    },
+                    {
+                        frente: "Que filtro costuma reduzir mais rápido o conjunto?",
+                        verso: "O da janela de tempo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que é pior que uma regra que não existe?",
+                        verso: "Uma regra que dispara por coincidência.",
+                    },
+                    {
+                        frente: "Que estrago a regra por coincidência causa no time?",
+                        verso: "Ensina o time a desconfiar de todas as outras.",
+                    },
+                    {
+                        frente: "O que a correlação junta?",
+                        verso: "Eventos de fontes diferentes na mesma história.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que teste diz se um painel é útil?",
+                        verso: "Que decisão ele apoia, e quem toma essa decisão.",
+                    },
+                    {
+                        frente: "Para que serve o painel sem essa resposta?",
+                        verso: "Para impressionar visita.",
+                    },
+                    {
+                        frente: "Que erro comum entulha um painel?",
+                        verso: "Colocar tudo que a ferramenta sabe desenhar.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Existe conjunto universal de boas regras?",
+                        verso: "Não: o conjunto é sempre ajustado àquele ambiente.",
+                    },
+                    {
+                        frente: "O que ajustar regra exige saber?",
+                        verso: "O que é normal naquele ambiente.",
+                    },
+                    {
+                        frente: "Que limite o SIEM tem diante do dado que falta?",
+                        verso: "Não responde o que ninguém coletou.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que acontece com a regra sem explicação?",
+                        verso: "Vira intocável, e ninguém a ajusta.",
+                    },
+                    {
+                        frente: "Que fim a regra intocável tem?",
+                        verso: "Envelhece até parar de servir.",
+                    },
+                    {
+                        frente: "Que informação toda regra deveria carregar?",
+                        verso: "O porquê de cada número e limite escolhido.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Em que língua escrever a regra primeiro?",
+                        verso: "Em português, antes de virar consulta.",
+                    },
+                    {
+                        frente: "O que não conseguir explicar o comportamento revela?",
+                        verso: "Que ainda não se sabe o que se está procurando.",
+                    },
+                    {
+                        frente: "Que ponto de partida uma boa regra tem?",
+                        verso: "O comportamento do atacante, não o indicador solto.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que a regra que nunca disparou pode ser?",
+                        verso: "Uma regra quebrada em silêncio.",
+                    },
+                    {
+                        frente: "Que atitude a regra sem disparos merece?",
+                        verso: "Desconfiança, com teste proposital.",
+                    },
+                    {
+                        frente: "Que teste valida uma detecção?",
+                        verso: "Reproduzir o comportamento e ver se ela dispara.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que problema a regra editada direto na interface cria?",
+                        verso: "O conhecimento fica só na cabeça de quem a escreveu.",
+                    },
+                    {
+                        frente: "O que a detecção como código traz junto?",
+                        verso: "Histórico, revisão e a chance de voltar atrás.",
+                    },
+                    {
+                        frente: "O que acontece com quem escreveu a regra, um dia?",
+                        verso: "Troca de emprego, levando o contexto embora.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a cobertura de detecção é?",
+                        verso: "Bússola, e não destino.",
+                    },
+                    {
+                        frente: "O que a cobertura mede, exatamente?",
+                        verso: "O que já foi observado e catalogado por alguém.",
+                    },
+                    {
+                        frente: "Que obrigação o invasor não tem?",
+                        verso: "A de ficar dentro do catálogo.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de Defesa e o SOC.

## O que entra
- Módulo 3, SIEM: a plataforma que só responde o que alguém escreveu, o filtre cedo e junte tarde, a regra que dispara por coincidência e o estrago que faz no time, o teste do painel útil e a ausência de um conjunto universal de boas regras.
- Módulo 4, engenharia de detecção: a regra sem explicação que vira intocável, escrever em português antes da consulta, a regra que nunca disparou e merece desconfiança, o histórico que a detecção como código preserva e a cobertura como bússola.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #531.
