### PR TITLE
feat: cartões dos módulos 1 e 2 de Pentest com Método

### DIFF
--- a/backend/scripts/data/flashcards/index.ts
+++ b/backend/scripts/data/flashcards/index.ts
@@ -57,6 +57,7 @@ import { estatisticaMatematica } from "./estatistica-matematica.ts";
 import { fundamentosDeCiberseguranca } from "./fundamentos-de-ciberseguranca.ts";
 import { ameacasEAtaquesNaPratica } from "./ameacas-e-ataques-na-pratica.ts";
 import { defesaEOSoc } from "./defesa-e-o-soc.ts";
+import { pentestComMetodo } from "./pentest-com-metodo.ts";
 
 export const TRILHAS: CartasDaTrilha[] = [
     logicaDeProgramacao,
@@ -116,4 +117,5 @@ export const TRILHAS: CartasDaTrilha[] = [
     fundamentosDeCiberseguranca,
     ameacasEAtaquesNaPratica,
     defesaEOSoc,
+    pentestComMetodo,
 ];

--- a/backend/scripts/data/flashcards/pentest-com-metodo.ts
+++ b/backend/scripts/data/flashcards/pentest-com-metodo.ts
@@ -1,0 +1,178 @@
+import type { CartasDaTrilha } from "../../seed-flashcards.ts";
+
+/**
+ * Cartões de Pentest com Método, quarta trilha do roadmap de Segurança.
+ *
+ * Sem trilhos de linguagem: tudo em "neutra". O quiz cobra o julgamento de
+ * cenário; as cartas guardam as regras de conduta, os limites contratuais e
+ * as frases-chave que a aula usa para fixar o método.
+ */
+export const pentestComMetodo: CartasDaTrilha = {
+    trilha: "Pentest com Método",
+    modulos: {
+        1: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que a ferramenta encontra, e o que o profissional encontra?",
+                        verso: "A ferramenta acha padrão conhecido; o profissional, consequência.",
+                    },
+                    {
+                        frente: "O que dizer do relatório que só lista o que a ferramenta viu?",
+                        verso: "Que poderia ter sido entregue sem você.",
+                    },
+                    {
+                        frente: "Que diferença separa varredura de teste de intrusão?",
+                        verso: "A varredura aponta indício; o teste confirma e mostra impacto.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "A caixa preta é mais realista?",
+                        verso: "Não: ela é apenas menos informada.",
+                    },
+                    {
+                        frente: "Que escolha a caixa preta representa?",
+                        verso: "Uma escolha de método, e não de realismo.",
+                    },
+                    {
+                        frente: "O que a caixa branca entrega ao testador?",
+                        verso: "Código, credenciais e documentação desde o início.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que regra vale na dúvida sobre escopo?",
+                        verso: "Na dúvida, está fora do escopo.",
+                    },
+                    {
+                        frente: "Quem a ampliação combinada por telefone protege?",
+                        verso: "Ninguém, se não for registrada por escrito.",
+                    },
+                    {
+                        frente: "De que lado o custo do escopo mal registrado cai?",
+                        verso: "Sempre do seu lado.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que separa profissão de crime nessa área?",
+                        verso: "A assinatura de quem é dono do sistema.",
+                    },
+                    {
+                        frente: "Que papel a intenção cumpre nessa diferença?",
+                        verso: "Nenhum: a técnica é idêntica dos dois lados.",
+                    },
+                    {
+                        frente: "Que documento precisa existir antes de qualquer teste?",
+                        verso: "A autorização assinada por quem pode autorizar.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que uma metodologia pública garante?",
+                        verso: "O piso da cobertura e a chance de repetir o trabalho.",
+                    },
+                    {
+                        frente: "O que continua sendo o teto do teste?",
+                        verso: "O julgamento de quem está olhando aquele sistema.",
+                    },
+                    {
+                        frente: "O que a metodologia não substitui?",
+                        verso: "A análise de quem conhece aquele ambiente.",
+                    },
+                ],
+            },
+        },
+        2: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que o cliente descreve ao pedir um teste?",
+                        verso: "A solução que ele mesmo imaginou.",
+                    },
+                    {
+                        frente: "Que descoberta vale metade do valor entregue?",
+                        verso: "Qual problema ele tentava resolver com aquilo.",
+                    },
+                    {
+                        frente: "Que pergunta abre o levantamento com o cliente?",
+                        verso: "O que preocupa a empresa hoje.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Quanto vale a lista do que fica de fora?",
+                        verso: "Tanto quanto a lista do que fica dentro.",
+                    },
+                    {
+                        frente: "O que vira decisão sua no pior momento possível?",
+                        verso: "O que não foi escrito como excluído.",
+                    },
+                    {
+                        frente: "Que dados o escopo precisa registrar por escrito?",
+                        verso: "Alvos, endereços, janelas e o que está proibido.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Onde o canal de comunicação precisa existir?",
+                        verso: "Fora do ambiente que está sendo testado.",
+                    },
+                    {
+                        frente: "O que revela que não havia plano de contingência?",
+                        verso: "O único caminho até o cliente ser o sistema derrubado.",
+                    },
+                    {
+                        frente: "O que a janela de teste define?",
+                        verso: "Quando o teste pode acontecer, e quando não pode.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que vira prioridade ao achar sinal de invasor anterior?",
+                        verso: "Deixa de ser o teste: você passa a ser testemunha.",
+                    },
+                    {
+                        frente: "O que uma testemunha faz com a cena?",
+                        verso: "Preserva, em vez de continuar andando nela.",
+                    },
+                    {
+                        frente: "Que critérios de parada o contrato precisa trazer?",
+                        verso: "Os sinais que suspendem o teste na hora.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que acontece com achado que o cliente não reproduz?",
+                        verso: "Não é corrigido.",
+                    },
+                    {
+                        frente: "O que transforma observação em conserto?",
+                        verso: "O caminho escrito enquanto a coisa está fresca.",
+                    },
+                    {
+                        frente: "Quando a documentação do teste começa?",
+                        verso: "No primeiro minuto do trabalho.",
+                    },
+                ],
+            },
+        },
+    },
+};


### PR DESCRIPTION
Abre a trilha de Pentest com Método, a quarta do roadmap de Segurança.

## O que entra
- Módulo 1, o que é e o que não é: a ferramenta que acha padrão contra o profissional que acha consequência, a caixa preta como escolha de método, a regra do na dúvida está fora, a assinatura do dono como única diferença legal e o piso que a metodologia garante.
- Módulo 2, antes de começar: o problema por trás do pedido do cliente, a lista de exclusões que vale tanto quanto a de alvos, o canal de comunicação fora do ambiente testado, o que fazer ao encontrar sinal de invasor anterior e a documentação desde o primeiro minuto.

30 cartas para as 10 aulas dos dois módulos.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, nenhuma aula dos módulos 1 e 2 sem carta.

Empilhado sobre #533.
