### PR TITLE
feat: cartões dos módulos 3 e 4 de Pentest com Método

### DIFF
--- a/backend/scripts/data/flashcards/pentest-com-metodo.ts
+++ b/backend/scripts/data/flashcards/pentest-com-metodo.ts
@@ -174,5 +174,169 @@ export const pentestComMetodo: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que nenhuma informação de fonte aberta é sozinha?",
+                        verso: "Secreta.",
+                    },
+                    {
+                        frente: "Onde está o valor do reconhecimento passivo?",
+                        verso: "Na montagem das peças soltas em um caminho.",
+                    },
+                    {
+                        frente: "Que peças a aula cita nessa montagem?",
+                        verso: "Nome, padrão de conta, versão e subdomínio esquecido.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que a varredura sem nenhum alerta já revelou?",
+                        verso: "Que o monitoramento do cliente não está olhando ali.",
+                    },
+                    {
+                        frente: "Quando esse achado aparece?",
+                        verso: "Antes de qualquer vulnerabilidade encontrada.",
+                    },
+                    {
+                        frente: "Que rastro o reconhecimento ativo deixa?",
+                        verso: "Conexões registradas nos logs do alvo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o serviço declara no banner?",
+                        verso: "A versão que ele quiser.",
+                    },
+                    {
+                        frente: "O que é achado baseado só no banner?",
+                        verso: "Palpite documentado.",
+                    },
+                    {
+                        frente: "Quem percebe esse palpite na primeira leitura?",
+                        verso: "O time técnico do cliente.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que mapear é, e o que não é?",
+                        verso: "É fazer inventário; não é atacar.",
+                    },
+                    {
+                        frente: "Como termina quem testa o primeiro formulário que encontra?",
+                        verso: "Sem ter visto metade da aplicação.",
+                    },
+                    {
+                        frente: "Que ordem o mapeamento web impõe?",
+                        verso: "Inventariar tudo antes de testar qualquer coisa.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a taxa de clique mede?",
+                        verso: "Pouca coisa.",
+                    },
+                    {
+                        frente: "Que medida diz mais que a taxa de clique?",
+                        verso: "O tempo até a primeira denúncia.",
+                    },
+                    {
+                        frente: "O que revela se existe processo ou só treinamento?",
+                        verso: "O que a empresa fez com a primeira denúncia.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Por que critério o scanner responde?",
+                        verso: "Por semelhança, que não é confirmação.",
+                    },
+                    {
+                        frente: "O que a varredura entrega, afinal?",
+                        verso: "Uma lista de hipóteses.",
+                    },
+                    {
+                        frente: "Que trabalho justifica o valor cobrado?",
+                        verso: "A validação dessas hipóteses.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que é achado que você não consegue refazer?",
+                        verso: "Lembrança, e não achado.",
+                    },
+                    {
+                        frente: "Que dois destinos o achado não reproduzido tem?",
+                        verso: "Virar observação declarada, ou ficar de fora da lista.",
+                    },
+                    {
+                        frente: "Que teste um achado precisa passar?",
+                        verso: "Ser reproduzido do zero, com o caminho escrito.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que a nota base descreve?",
+                        verso: "A falha, sem nunca ter conhecido o seu cliente.",
+                    },
+                    {
+                        frente: "O que entregar a nota do catálogo sem ajuste faz?",
+                        verso: "Terceiriza ao cliente a parte mais difícil do trabalho.",
+                    },
+                    {
+                        frente: "Que ajuste a severidade precisa receber?",
+                        verso: "O do contexto: exposição, dado afetado e negócio.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que muda a conversa dentro da empresa?",
+                        verso: "A fronteira atravessada, e não a nota isolada.",
+                    },
+                    {
+                        frente: "No que três médios viram quando alguém liga o caminho?",
+                        verso: "Num pedido de orçamento.",
+                    },
+                    {
+                        frente: "O que o encadeamento demonstra?",
+                        verso: "Que falhas pequenas somam um impacto grande.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que pergunta resolve o caso duvidoso?",
+                        verso: "Qual a menor ação que prova o ponto.",
+                    },
+                    {
+                        frente: "O que essa pergunta separa?",
+                        verso: "A demonstração necessária do impulso de ir além.",
+                    },
+                    {
+                        frente: "Que testes ficam de fora por padrão?",
+                        verso: "Os que causariam dano ou parada não autorizada.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de Pentest com Método.

## O que entra
- Módulo 3, reconhecimento: nada em fonte aberta é secreto sozinho, a varredura sem alerta que já é um achado, o banner que declara a versão que quiser, o mapeamento como inventário e o tempo até a primeira denúncia como medida melhor que a taxa de clique.
- Módulo 4, análise: o scanner que responde por semelhança, o achado que não se reproduz e vira lembrança, a nota base que nunca conheceu o cliente, o encadeamento que transforma três médios em pedido de orçamento e a menor ação que prova o ponto.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #534.
