### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Pentest com Método

### DIFF
--- a/backend/scripts/data/flashcards/pentest-com-metodo.ts
+++ b/backend/scripts/data/flashcards/pentest-com-metodo.ts
@@ -338,5 +338,251 @@ export const pentestComMetodo: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que explorar uma falha mostra?",
+                        verso: "Que uma suposição do desenvolvedor não se sustenta.",
+                    },
+                    {
+                        frente: "A que quem procura truque fica preso?",
+                        verso: "Ao alvo padrão.",
+                    },
+                    {
+                        frente: "O que quem procura suposição consegue?",
+                        verso: "Adaptar-se a qualquer alvo.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que caminho oficial entra sem saber a senha?",
+                        verso: "A recuperação de senha.",
+                    },
+                    {
+                        frente: "Que rigor a recuperação de senha merece?",
+                        verso: "O mesmo rigor do login.",
+                    },
+                    {
+                        frente: "Quanta atenção ela costuma receber?",
+                        verso: "Quase nunca metade da que o login recebe.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que esconder o botão é?",
+                        verso: "Experiência de uso, e não segurança.",
+                    },
+                    {
+                        frente: "O que é segurança de verdade nesse ponto?",
+                        verso: "Verificar quem pode agir, do lado do servidor.",
+                    },
+                    {
+                        frente: "Que permissão sistemas confusos acabam tendo?",
+                        verso: "Apenas visual, que cai na primeira requisição direta.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Existe caractere perigoso?",
+                        verso: "Não: existe contexto que interpreta.",
+                    },
+                    {
+                        frente: "Que defesa perde no longo prazo?",
+                        verso: "A que tenta listar tudo o que é ruim.",
+                    },
+                    {
+                        frente: "Por que essa lista perde?",
+                        verso: "Basta ao atacante achar uma variação não prevista.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Para que serve a prova de conceito?",
+                        verso: "Para convencer alguém cético.",
+                    },
+                    {
+                        frente: "Para que ela não serve?",
+                        verso: "Para medir até onde daria para ir.",
+                    },
+                    {
+                        frente: "Que demonstração é sempre a melhor?",
+                        verso: "A menor que faz o cliente concordar.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que o cliente não comprou?",
+                        verso: "Uma coleção de acessos.",
+                    },
+                    {
+                        frente: "O que ele comprou de fato?",
+                        verso: "A resposta sobre o que um acesso custa para ele.",
+                    },
+                    {
+                        frente: "Quando essa resposta nasce?",
+                        verso: "Só depois que você entra.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Alcance técnico é autorização?",
+                        verso: "Não é.",
+                    },
+                    {
+                        frente: "Que duas perguntas diferentes existem aqui?",
+                        verso: "Conseguir chegar, e poder tocar.",
+                    },
+                    {
+                        frente: "Qual das duas está escrita no contrato?",
+                        verso: "Apenas a de poder tocar.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que não informa nada num achado?",
+                        verso: "O adjetivo.",
+                    },
+                    {
+                        frente: "O que informa de verdade?",
+                        verso: "Número, tipo de dado e processo afetado.",
+                    },
+                    {
+                        frente: "Do que quem decide orçamento precisa?",
+                        verso: "Da consequência descrita, não da gravidade adjetivada.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "No que você vira ao guardar evidência?",
+                        verso: "Custodiante de dado que não é seu.",
+                    },
+                    {
+                        frente: "Que forma a rotina de proteção precisa ter?",
+                        verso: "Ser hábito, e não boa intenção declarada.",
+                    },
+                    {
+                        frente: "Que cuidados a evidência exige?",
+                        verso: "Cifrar, restringir acesso e apagar no prazo combinado.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o cliente deve fazer com toda credencial obtida?",
+                        verso: "Trocar, sem exceção.",
+                    },
+                    {
+                        frente: "Por que trocar mesmo com a sua cópia destruída?",
+                        verso: "O segredo saiu do lugar dele e deixou de ser segredo.",
+                    },
+                    {
+                        frente: "O que a devolução do ambiente inclui?",
+                        verso: "Remover contas, arquivos e acessos criados no teste.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que o cliente viu do seu trabalho?",
+                        verso: "Um documento, nunca o seu terminal.",
+                    },
+                    {
+                        frente: "Por onde o trabalho será julgado?",
+                        verso: "Pelo relatório.",
+                    },
+                    {
+                        frente: "Onde bons técnicos costumam perder contrato?",
+                        verso: "No relatório.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que o impacto é, num achado?",
+                        verso: "O que a falha causa, e não o que ela é.",
+                    },
+                    {
+                        frente: "Quando o achado ainda não foi analisado até o fim?",
+                        verso: "Quando não se sabe dizer o que o adversário consegue.",
+                    },
+                    {
+                        frente: "Que partes um achado bem escrito tem?",
+                        verso: "Descrição, evidência, impacto e recomendação.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que frase nenhum teste autoriza?",
+                        verso: "Que a empresa está segura.",
+                    },
+                    {
+                        frente: "O que se afirma no lugar disso?",
+                        verso: "O que foi avaliado, em que período, e o que se encontrou.",
+                    },
+                    {
+                        frente: "Para quem o sumário executivo é escrito?",
+                        verso: "Para quem decide, sem jargão técnico.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Mitigado é o mesmo que corrigido?",
+                        verso: "Não é.",
+                    },
+                    {
+                        frente: "Que risco a barreira externa carrega?",
+                        verso: "Sair numa mudança de arquitetura, sem ninguém lembrar.",
+                    },
+                    {
+                        frente: "O que o reteste confirma?",
+                        verso: "Se a correção resolveu, e não apenas escondeu.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Qual é o ativo dessa profissão?",
+                        verso: "A confiança.",
+                    },
+                    {
+                        frente: "Como a confiança se constrói?",
+                        verso: "Em anos de conduta chata e inegociável.",
+                    },
+                    {
+                        frente: "Como a confiança some?",
+                        verso: "Num episódio só, explicado pelo resto da carreira.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de Pentest com Método.

## O que entra
- Módulo 5, exploração: a suposição do desenvolvedor que não se sustenta, a recuperação de senha como caminho oficial, o botão escondido que é interface e não controle, o contexto que interpreta em vez do caractere perigoso e a prova de conceito mínima.
- Módulo 6, pós-exploração: o que o cliente comprou de verdade, o alcance técnico que não é autorização, a consequência descrita em números, a custódia da evidência e a troca de toda credencial obtida no teste.
- Módulo 7, relatório e carreira: o documento como produto, o impacto como o que a falha causa, o sumário executivo que não declara a empresa segura, o mitigado que não é corrigido e a confiança como ativo da profissão.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 60 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #535.
