### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Segurança em Nuvem e Identidade

### DIFF
--- a/backend/scripts/data/flashcards/seguranca-em-nuvem-e-identidade.ts
+++ b/backend/scripts/data/flashcards/seguranca-em-nuvem-e-identidade.ts
@@ -339,5 +339,251 @@ export const segurancaEmNuvemEIdentidade: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que pergunta fazer a um fornecedor de zero trust?",
+                        verso: "Qual princípio o produto implementa e o que fica descoberto.",
+                    },
+                    {
+                        frente: "Quem responde essa pergunta sem desconforto?",
+                        verso: "Quem vende arquitetura, e não produto isolado.",
+                    },
+                    {
+                        frente: "O que zero trust não é?",
+                        verso: "Um produto que se compra pronto.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "No que a política vira sem o estado do dispositivo?",
+                        verso: "Em identidade mais localização, e nada além.",
+                    },
+                    {
+                        frente: "O que verificar explicitamente exige?",
+                        verso: "Checar identidade, dispositivo e contexto a cada acesso.",
+                    },
+                    {
+                        frente: "O que a palavra zero trust anuncia?",
+                        verso: "Bem mais do que identidade e localização entregam.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que escolha sobra a quem só tem permitir e bloquear?",
+                        verso: "Travar o trabalho ou aceitar a exportação.",
+                    },
+                    {
+                        frente: "Onde mora o risco real, nesse espectro?",
+                        verso: "No meio, entre o permitir e o bloquear.",
+                    },
+                    {
+                        frente: "O que o acesso adaptativo acrescenta?",
+                        verso: "Resposta proporcional ao risco daquele acesso.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que detectar rápido sem poder agir garante?",
+                        verso: "Uma poltrona na primeira fila do próprio incidente.",
+                    },
+                    {
+                        frente: "O que assumir a violação muda no projeto?",
+                        verso: "Presume o invasor dentro e limita o estrago.",
+                    },
+                    {
+                        frente: "Que controles nascem dessa premissa?",
+                        verso: "Segmentação, sessão curta e capacidade de revogar.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que cada passo da adoção deveria remover?",
+                        verso: "Uma dor visível de alguém.",
+                    },
+                    {
+                        frente: "O que o programa que só acrescenta fricção consome?",
+                        verso: "O capital político, até parar.",
+                    },
+                    {
+                        frente: "Que ordem a adoção realista segue?",
+                        verso: "Começar por onde já dói, e não pelo mais elegante.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Em que o invasor que age por credencial nunca encosta?",
+                        verso: "Num servidor.",
+                    },
+                    {
+                        frente: "Quem fica cego no ataque mais comum de nuvem?",
+                        verso: "Quem só coleta registro de sistema operacional.",
+                    },
+                    {
+                        frente: "Que registro é indispensável em nuvem?",
+                        verso: "O do plano de controle.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que não vaza no golpe de consentimento?",
+                        verso: "A senha.",
+                    },
+                    {
+                        frente: "Por que trocar a senha não resolve nesse golpe?",
+                        verso: "A autorização concedida não depende dela.",
+                    },
+                    {
+                        frente: "O que precisa ser revogado nesse caso?",
+                        verso: "O consentimento dado à aplicação.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que recriar a frota inteira não resolve?",
+                        verso: "O invasor segue dentro, pelo que deixou no diretório.",
+                    },
+                    {
+                        frente: "Onde a persistência em nuvem costuma morar?",
+                        verso: "Na confiança que o invasor acrescentou no diretório.",
+                    },
+                    {
+                        frente: "Que rastro essa persistência não deixa?",
+                        verso: "Nenhum em máquina, porque não vive em máquina.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Qual é o reflexo certo diante de máquina suspeita?",
+                        verso: "Isolar e preservar, antes de qualquer outra coisa.",
+                    },
+                    {
+                        frente: "O que suspender antes de agir no ambiente elástico?",
+                        verso: "A escala automática.",
+                    },
+                    {
+                        frente: "Por que não encerrar a máquina suspeita?",
+                        verso: "Encerrar apaga a evidência junto.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que acontece detectando em semanas e retendo por dias?",
+                        verso: "Você acha a ponta do fio e nunca a origem.",
+                    },
+                    {
+                        frente: "O que a retenção não é?",
+                        verso: "Um número administrativo.",
+                    },
+                    {
+                        frente: "Com o que a retenção precisa conversar?",
+                        verso: "Com o tempo real até a detecção.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Qual é o achado mais comum e mais difícil de defender?",
+                        verso: "Dado de produção em ambiente de teste.",
+                    },
+                    {
+                        frente: "Que parte desse problema é a fácil?",
+                        verso: "A solução técnica.",
+                    },
+                    {
+                        frente: "O que costuma faltar nesse caso?",
+                        verso: "Alguém chamar o problema pelo nome.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que a conformidade prova?",
+                        verso: "Que você fez o que foi combinado.",
+                    },
+                    {
+                        frente: "O que é segurança, nessa distinção?",
+                        verso: "Ter escolhido bem o que combinar.",
+                    },
+                    {
+                        frente: "Os dois importam igualmente?",
+                        verso: "Importam, mas não são a mesma coisa.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "No que a auditoria vira quando o controle produz evidência?",
+                        verso: "Numa consulta.",
+                    },
+                    {
+                        frente: "No que ela vira quando o controle não produz?",
+                        verso: "Num projeto de três semanas, todo ano.",
+                    },
+                    {
+                        frente: "Que qualidade um bom controle tem?",
+                        verso: "Gera evidência ao funcionar, sem esforço extra.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Quantas ferramentas novas aparecem nos primeiros passos?",
+                        verso: "Nenhuma.",
+                    },
+                    {
+                        frente: "Do que quase tudo ali é feito?",
+                        verso: "De organização e disciplina.",
+                    },
+                    {
+                        frente: "Por que isso assusta?",
+                        verso: "Porque não dá para comprar pronto.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Como é o trabalho que mais reduz risco em nuvem?",
+                        verso: "O menos glamouroso que existe.",
+                    },
+                    {
+                        frente: "O que esse trabalho não rende?",
+                        verso: "Demonstração.",
+                    },
+                    {
+                        frente: "O que ele separa, no fim?",
+                        verso: "Um dia ruim de um trimestre ruim.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de Segurança em Nuvem e Identidade e, com ela, o roadmap de Segurança.

## O que entra
- Módulo 5, zero trust: a pergunta que se faz a quem vende, a política que sem estado do dispositivo vira identidade mais localização, o meio do espectro onde mora o risco, a detecção que sem poder agir só assiste ao incidente e a adoção que remove uma dor a cada passo.
- Módulo 6, detecção e resposta em nuvem: o registro do plano de controle, o golpe de consentimento em que trocar a senha não resolve, a persistência que sobrevive a recriar a frota inteira, o isolamento com escala automática suspensa e a retenção medida contra o tempo até detectar.
- Módulo 7, governança: o dado de produção em ambiente de teste, a diferença entre conformidade e segurança, o controle que produz evidência ao funcionar, os primeiros passos sem nenhuma ferramenta nova e o trabalho pouco glamouroso que separa um dia ruim de um trimestre ruim.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência

| Trilha | Aulas | Cartas | Sem carta |
| --- | --- | --- | --- |
| Redes | 35 | 105 | 0 |
| Linux e Linha de Comando | 35 | 105 | 0 |
| Fundamentos de Cibersegurança | 35 | 105 | 0 |
| Ameaças e Ataques na Prática | 35 | 105 | 0 |
| Defesa e o SOC | 35 | 105 | 0 |
| Segurança de Aplicações Web | 35 | 85 | 0 |
| Pentest com Método | 35 | 105 | 0 |
| Segurança em Nuvem e Identidade | 35 | 105 | 0 |

Seeder rodado num Postgres efêmero com a estrutura de produção. As oito trilhas do roadmap de Segurança ficam com cobertura completa. Redes, Linux e Segurança de Aplicações Web já vinham de PRs anteriores.

Empilhado sobre #538.
