### PR TITLE
feat: cartões dos módulos 3 e 4 de ETL e Ingestão de Dados

### DIFF
--- a/backend/scripts/data/flashcards/etl-e-ingestao-de-dados.ts
+++ b/backend/scripts/data/flashcards/etl-e-ingestao-de-dados.ts
@@ -174,5 +174,169 @@ export const etlEIngestaoDeDados: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que pergunta define a estratégia de extração?",
+                        verso: "Qual o volume de mudança e qual chave confiável existe.",
+                    },
+                    {
+                        frente: "O que a extração completa faz a cada execução?",
+                        verso: "Traz a tabela inteira, de novo.",
+                    },
+                    {
+                        frente: "O que a extração incremental exige da origem?",
+                        verso: "Uma chave confiável para identificar o que mudou.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Como tratar o erro 429 numa extração de API?",
+                        verso: "Como instrução: o servidor diz exatamente quanto esperar.",
+                    },
+                    {
+                        frente: "O que o erro 429 não é?",
+                        verso: "Uma falha do seu pipeline.",
+                    },
+                    {
+                        frente: "Que mecanismo a API usa para entregar muitos registros?",
+                        verso: "A paginação, página por página.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que organizar por prefixo de data torna possível?",
+                        verso: "A extração incremental no object storage.",
+                    },
+                    {
+                        frente: "O que o prefixo de data não é?",
+                        verso: "Apenas uma questão de arrumação.",
+                    },
+                    {
+                        frente: "Que informação o object storage dá sobre cada objeto?",
+                        verso: "O caminho, o tamanho e a data de modificação.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "No que um watermark que nunca olha para trás confia?",
+                        verso: "Que nada chegou atrasado.",
+                    },
+                    {
+                        frente: "Com que frequência essa confiança se justifica?",
+                        verso: "Quase nunca.",
+                    },
+                    {
+                        frente: "O que o watermark guarda entre execuções?",
+                        verso: "A marca de até onde já foi lido.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o CDC não precisa perguntar?",
+                        verso: "O que mudou: ele já sabia no instante da mudança.",
+                    },
+                    {
+                        frente: "O que separa CDC de watermark?",
+                        verso: "A diferença entre escutar e perguntar.",
+                    },
+                    {
+                        frente: "De onde o CDC costuma ler as mudanças?",
+                        verso: "Do log de transações do banco.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Para que CSV e JSON são ótimos?",
+                        verso: "Para trocar dados entre sistemas heterogêneos.",
+                    },
+                    {
+                        frente: "Para que eles não foram pensados?",
+                        verso: "Para leitura analítica eficiente em grande volume.",
+                    },
+                    {
+                        frente: "Que vantagem o JSON tem sobre o CSV?",
+                        verso: "Representa estrutura aninhada.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que problema o Parquet resolve no ambiente analítico?",
+                        verso: "Menos bytes lidos por consulta e menos espaço ocupado.",
+                    },
+                    {
+                        frente: "Que organização o Parquet usa?",
+                        verso: "Organização colunar.",
+                    },
+                    {
+                        frente: "Onde o Parquet virou padrão?",
+                        verso: "Em data lake e data warehouse.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o Avro carrega junto com o dado?",
+                        verso: "O schema.",
+                    },
+                    {
+                        frente: "Para que tipo de escrita o Avro foi desenhado?",
+                        verso: "Um registro de cada vez, sem atrito.",
+                    },
+                    {
+                        frente: "Onde o Avro é a escolha natural?",
+                        verso: "No meio do caminho, com dado em movimento.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que a compressão troca?",
+                        verso: "CPU por espaço.",
+                    },
+                    {
+                        frente: "O que o particionamento troca?",
+                        verso: "Organização por velocidade de leitura.",
+                    },
+                    {
+                        frente: "Para que as duas decisões existem?",
+                        verso: "Para o pipeline ler só o que precisa.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o schema é, além de detalhe do formato?",
+                        verso: "O contrato entre quem grava e quem lê o dado.",
+                    },
+                    {
+                        frente: "O que o schema separa na prática?",
+                        verso: "A mudança tranquila do pipeline quebrado.",
+                    },
+                    {
+                        frente: "Que mudança de schema costuma ser segura?",
+                        verso: "Acrescentar um campo opcional no fim.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de ETL e Ingestão de Dados.

## O que entra
- Módulo 3, extração: a pergunta que define full contra incremental, o erro 429 lido como instrução, o prefixo de data que viabiliza a extração incremental, o watermark que confia que nada chegou atrasado e o CDC que escuta em vez de perguntar.
- Módulo 4, formatos: para que servem CSV e JSON e para que não servem, o Parquet colunar reduzindo bytes lidos, o Avro carregando o schema junto, as trocas da compressão e do particionamento e o schema como contrato entre quem grava e quem lê.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #543.
