### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Orquestração de Pipelines

### DIFF
--- a/backend/scripts/data/flashcards/orquestracao-de-pipelines.ts
+++ b/backend/scripts/data/flashcards/orquestracao-de-pipelines.ts
@@ -338,5 +338,251 @@ export const orquestracaoDePipelines: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que tipo de falha o retry resolve?",
+                        verso: "A transitória, que depende do momento em que rodou.",
+                    },
+                    {
+                        frente: "Que falha o retry não resolve?",
+                        verso: "A determinística, que falha sempre pelo mesmo motivo.",
+                    },
+                    {
+                        frente: "O que o intervalo entre tentativas evita?",
+                        verso: "Bater na origem que ainda não se recuperou.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Quando uma task é idempotente?",
+                        verso: "Quando rodar uma ou dez vezes deixa o destino igual.",
+                    },
+                    {
+                        frente: "O que o retry sem idempotência produz?",
+                        verso: "Duplicata, a cada nova tentativa.",
+                    },
+                    {
+                        frente: "Que prática a idempotência viabiliza?",
+                        verso: "Reprocessar sem medo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o tempo limite de execução faz?",
+                        verso: "Mata a task que passou do tempo permitido.",
+                    },
+                    {
+                        frente: "O que o SLA faz?",
+                        verso: "Avisa que a execução está mais lenta que o esperado.",
+                    },
+                    {
+                        frente: "O que o SLA não faz?",
+                        verso: "Matar a task.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "No que vira o alerta que dispara toda hora?",
+                        verso: "Em ruído, que a equipe aprende a ignorar.",
+                    },
+                    {
+                        frente: "Quando a falha importante passa despercebida?",
+                        verso: "Exatamente quando o alerta já virou ruído.",
+                    },
+                    {
+                        frente: "Que critério um bom alerta cumpre?",
+                        verso: "Exigir uma ação de quem o recebe.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Sobre o que o backfill só é seguro?",
+                        verso: "Sobre uma task idempotente.",
+                    },
+                    {
+                        frente: "Que teste simples confirma a segurança do backfill?",
+                        verso: "Rodar um único dia dez vezes e comparar o resultado.",
+                    },
+                    {
+                        frente: "Que cuidado o backfill grande pede?",
+                        verso: "Limitar quantas runs acontecem ao mesmo tempo.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que um sensor bem configurado não faz?",
+                        verso: "Segurar um worker refém da condição externa.",
+                    },
+                    {
+                        frente: "Como um sensor espera de forma barata?",
+                        verso: "Liberando o worker entre uma checagem e outra.",
+                    },
+                    {
+                        frente: "Que limites todo sensor precisa ter?",
+                        verso: "Tempo máximo de espera e uma saída clara.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Quando dividir um pipeline em várias DAGs compensa?",
+                        verso: "Quando o ganho em clareza supera o custo de coordenar.",
+                    },
+                    {
+                        frente: "Que custo essa divisão traz?",
+                        verso: "Coordenar a execução entre as DAGs.",
+                    },
+                    {
+                        frente: "Que ganho ela pode trazer?",
+                        verso: "Isolamento e clareza.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Para que o mapeamento dinâmico existe?",
+                        verso: "Para descrever o formato do trabalho uma vez só.",
+                    },
+                    {
+                        frente: "Quem decide quantas instâncias criar?",
+                        verso: "O próprio orquestrador, em tempo de execução.",
+                    },
+                    {
+                        frente: "O que o mapeamento dinâmico substitui?",
+                        verso: "Escrever manualmente uma task para cada item.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Onde senha, token e chave não podem ficar?",
+                        verso: "No código da DAG nem em variável de texto puro.",
+                    },
+                    {
+                        frente: "Onde essas credenciais moram em produção?",
+                        verso: "Num backend de segredos dedicado.",
+                    },
+                    {
+                        frente: "O que a parametrização evita?",
+                        verso: "Valor fixo espalhado pelo código do pipeline.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Se a task está lenta processando dados, qual é o problema?",
+                        verso: "O lugar onde o processamento foi colocado.",
+                    },
+                    {
+                        frente: "O que o orquestrador deve fazer?",
+                        verso: "Coordenar, e não processar.",
+                    },
+                    {
+                        frente: "Para onde o processamento pesado deve ir?",
+                        verso: "Para o motor de dados, fora do orquestrador.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que é um DAG que nunca foi importado na integração?",
+                        verso: "Um incidente esperando a próxima janela de implantação.",
+                    },
+                    {
+                        frente: "Que teste mínimo todo DAG merece?",
+                        verso: "A importação sem erro, feita automaticamente.",
+                    },
+                    {
+                        frente: "Que outra checagem um teste de DAG costuma fazer?",
+                        verso: "Conferir que não há ciclo e que as dependências existem.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Quando uma DAG está de fato pronta?",
+                        verso: "Quando o caminho do commit até o scheduler é automático.",
+                    },
+                    {
+                        frente: "Que qualidade esse caminho precisa ter?",
+                        verso: "Ser testado e igual em todo ambiente.",
+                    },
+                    {
+                        frente: "Que risco a implantação manual traz?",
+                        verso: "Ambientes que divergem sem ninguém notar.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que é um pipeline sem observabilidade?",
+                        verso: "Sortudo, e não confiável.",
+                    },
+                    {
+                        frente: "Quando essa sorte acaba?",
+                        verso: "No dia em que perguntam por que o número está errado.",
+                    },
+                    {
+                        frente: "Que sinais a observabilidade acompanha?",
+                        verso: "Duração, volume, falhas e atraso das execuções.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Sobre o que o desempenho em orquestração raramente é?",
+                        verso: "Sobre a task individual.",
+                    },
+                    {
+                        frente: "Sobre o que ele é, então?",
+                        verso: "Sobre quantas coisas o ambiente deixa acontecer juntas.",
+                    },
+                    {
+                        frente: "Que ajuste costuma destravar o ambiente?",
+                        verso: "Rever os limites de paralelismo e as filas.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que orquestrar não é?",
+                        verso: "Apenas rodar tarefas na hora certa.",
+                    },
+                    {
+                        frente: "O que orquestrar é, então?",
+                        verso: "Dar ao time confiança no comportamento do pipeline.",
+                    },
+                    {
+                        frente: "Que três garantias essa confiança inclui?",
+                        verso: "Repetir igual, falhar de forma previsível e se recuperar.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de Orquestração de Pipelines.

## O que entra
- Módulo 5, confiabilidade: a falha transitória que o retry resolve e a determinística que ele não resolve, a idempotência que evita duplicata a cada tentativa, o tempo limite que mata contra o SLA que só avisa, o alerta que vira ruído e o backfill sobre task idempotente.
- Módulo 6, padrões avançados: o sensor que espera sem segurar worker, quando dividir o pipeline em várias DAGs, o mapeamento dinâmico que descreve o trabalho uma vez, os segredos fora do código e o orquestrador que coordena em vez de processar.
- Módulo 7, operação: o DAG que nunca passou pela integração contínua, o caminho automático do commit até o scheduler, o pipeline sem observabilidade que é só sortudo, o desempenho que é sobre paralelismo e a confiança como objetivo final.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 60 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #547.
