### PR TITLE
feat: cartões dos módulos 1 e 2 de Processamento com Spark

### DIFF
--- a/backend/scripts/data/flashcards/index.ts
+++ b/backend/scripts/data/flashcards/index.ts
@@ -62,6 +62,7 @@ import { segurancaEmNuvemEIdentidade } from "./seguranca-em-nuvem-e-identidade.t
 import { modelagemDeDadosEDataWarehousing } from "./modelagem-de-dados-e-data-warehousing.ts";
 import { etlEIngestaoDeDados } from "./etl-e-ingestao-de-dados.ts";
 import { orquestracaoDePipelines } from "./orquestracao-de-pipelines.ts";
+import { processamentoComSpark } from "./processamento-com-spark.ts";
 
 export const TRILHAS: CartasDaTrilha[] = [
     logicaDeProgramacao,
@@ -126,4 +127,5 @@ export const TRILHAS: CartasDaTrilha[] = [
     modelagemDeDadosEDataWarehousing,
     etlEIngestaoDeDados,
     orquestracaoDePipelines,
+    processamentoComSpark,
 ];

--- a/backend/scripts/data/flashcards/processamento-com-spark.ts
+++ b/backend/scripts/data/flashcards/processamento-com-spark.ts
@@ -1,0 +1,178 @@
+import type { CartasDaTrilha } from "../../seed-flashcards.ts";
+
+/**
+ * Cartões de Processamento com Spark, do roadmap de Engenharia de Dados.
+ *
+ * Sem trilhos de linguagem: tudo em "neutra". O quiz cobra a decisão de
+ * projeto do job; as cartas guardam as definições fechadas, os nomes dos
+ * componentes e as regras de bolso que a aula enuncia de passagem.
+ */
+export const processamentoComSpark: CartasDaTrilha = {
+    trilha: "Processamento com Spark",
+    modulos: {
+        1: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que escalar verticalmente compra?",
+                        verso: "Tempo dentro do teto de uma máquina.",
+                    },
+                    {
+                        frente: "O que escalar horizontalmente muda?",
+                        verso: "Qual é o teto.",
+                    },
+                    {
+                        frente: "Que limite a máquina única impõe?",
+                        verso: "Memória, disco e núcleos de um só equipamento.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Por que a etapa de map roda livre?",
+                        verso: "Cada registro é independente dos demais.",
+                    },
+                    {
+                        frente: "Por que o shuffle custa caro?",
+                        verso: "Junta de novo o que estava espalhado.",
+                    },
+                    {
+                        frente: "Que estratégia o paralelismo de dados usa?",
+                        verso: "Dividir para conquistar, um pedaço por máquina.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o Spark não inventou?",
+                        verso: "O paralelismo de dados.",
+                    },
+                    {
+                        frente: "O que o Spark trocou?",
+                        verso: "Onde os dados ficam entre uma etapa e outra.",
+                    },
+                    {
+                        frente: "Para onde essa troca levou os dados intermediários?",
+                        verso: "Do disco para a memória.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Qual é a pergunta certa entre os motores?",
+                        verso: "Qual deles combina com o tamanho do problema atual.",
+                    },
+                    {
+                        frente: "Qual não é a pergunta certa?",
+                        verso: "Qual motor é o melhor.",
+                    },
+                    {
+                        frente: "Quando o pandas ainda resolve?",
+                        verso: "Quando o dado cabe na memória de uma máquina.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que PySpark, Scala e SQL descrevem?",
+                        verso: "O mesmo plano, para a mesma engine.",
+                    },
+                    {
+                        frente: "Sobre o que é a escolha entre eles?",
+                        verso: "Sobre o time, e não sobre desempenho.",
+                    },
+                    {
+                        frente: "Que módulos o ecossistema Spark reúne?",
+                        verso: "SQL, streaming, aprendizado de máquina e grafos.",
+                    },
+                ],
+            },
+        },
+        2: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que o driver decide?",
+                        verso: "O quê e quando.",
+                    },
+                    {
+                        frente: "O que o cluster manager decide?",
+                        verso: "Onde há espaço.",
+                    },
+                    {
+                        frente: "O que os executors sabem fazer?",
+                        verso: "Executar a task que chegou.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que corta um job em stages?",
+                        verso: "O shuffle.",
+                    },
+                    {
+                        frente: "O que corta um stage em tasks?",
+                        verso: "As partições.",
+                    },
+                    {
+                        frente: "Como a aula descreve esses dois cortes?",
+                        verso: "O shuffle divide na vertical, a partição na horizontal.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que limita o paralelismo de um stage?",
+                        verso: "O menor valor entre partições e núcleos livres.",
+                    },
+                    {
+                        frente: "O que partições demais provocam?",
+                        verso: "Desperdício, com muita tarefa pequena.",
+                    },
+                    {
+                        frente: "O que partições de menos provocam?",
+                        verso: "Núcleos ociosos, sem trabalho para pegar.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que uma transformação faz?",
+                        verso: "Monta o plano.",
+                    },
+                    {
+                        frente: "O que uma ação faz?",
+                        verso: "Executa o plano.",
+                    },
+                    {
+                        frente: "Quando algo acontece de fato?",
+                        verso: "Só quando uma ação é chamada.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o plano lógico diz?",
+                        verso: "O que o Spark deve entregar.",
+                    },
+                    {
+                        frente: "O que o plano físico diz?",
+                        verso: "Como os executors vão entregar.",
+                    },
+                    {
+                        frente: "Quem escolhe o plano físico?",
+                        verso: "O Catalyst.",
+                    },
+                ],
+            },
+        },
+    },
+};


### PR DESCRIPTION
Abre a trilha de Processamento com Spark, do roadmap de Engenharia de Dados.

## O que entra
- Módulo 1, por que distribuir: o teto que a escala vertical não muda, o map livre contra o shuffle caro, o que o Spark trocou em vez de inventar, a pergunta certa na comparação entre motores e as linguagens que descrevem o mesmo plano.
- Módulo 2, arquitetura: a divisão de papéis entre driver, cluster manager e executors, o shuffle que corta jobs em stages e as partições que cortam stages em tasks, o limite do paralelismo, a avaliação lazy e o plano físico escolhido pelo Catalyst.

30 cartas para as 10 aulas dos dois módulos.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, nenhuma aula dos módulos 1 e 2 sem carta.

Empilhado sobre #548.
