### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham Processamento com Spark

### DIFF
--- a/backend/scripts/data/flashcards/processamento-com-spark.ts
+++ b/backend/scripts/data/flashcards/processamento-com-spark.ts
@@ -338,5 +338,251 @@ export const processamentoComSpark: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que torna um job Spark lento, além do volume?",
+                        verso: "Quantas vezes o dado atravessa rede e disco.",
+                    },
+                    {
+                        frente: "O que reduzir para acelerar o job?",
+                        verso: "A quantidade e o tamanho dos shuffles.",
+                    },
+                    {
+                        frente: "O que acontece com os dados num shuffle?",
+                        verso: "São redistribuídos entre os executors por chave.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que uma transformação narrow dispensa?",
+                        verso: "O shuffle: cada partição basta a si mesma.",
+                    },
+                    {
+                        frente: "O que marca uma transformação wide?",
+                        verso: "A necessidade de redistribuir dados entre partições.",
+                    },
+                    {
+                        frente: "Como estimar o custo de um job antes de rodar?",
+                        verso: "Contando os shuffles no plano de execução.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que repartition permite que coalesce não permite?",
+                        verso: "Aumentar o número de partições.",
+                    },
+                    {
+                        frente: "Por que coalesce é mais barato?",
+                        verso: "Ele junta partições sem shuffle completo.",
+                    },
+                    {
+                        frente: "Quando coalesce é a escolha natural?",
+                        verso: "Ao reduzir partições antes de escrever.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que tipo de problema o data skew é?",
+                        verso: "De dados, e não de cluster.",
+                    },
+                    {
+                        frente: "Quando o skew aparece?",
+                        verso: "Na hora do shuffle.",
+                    },
+                    {
+                        frente: "O que aumentar executors faz contra o skew?",
+                        verso: "Quase nada: a chave pesada continua num só lugar.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o broadcast join troca?",
+                        verso: "Custo de rede do shuffle por custo de memória.",
+                    },
+                    {
+                        frente: "O que cada executor passa a guardar?",
+                        verso: "Uma cópia inteira da tabela pequena.",
+                    },
+                    {
+                        frente: "Que limite decide se o broadcast cabe?",
+                        verso: "O tamanho da tabela contra a memória do executor.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Quando o cache compensa?",
+                        verso: "Quando o mesmo resultado é reaproveitado mais de uma vez.",
+                    },
+                    {
+                        frente: "O que o cache faz num DataFrame de uso único?",
+                        verso: "Só acrescenta custo, sem nunca ser aproveitado.",
+                    },
+                    {
+                        frente: "O que persist permite escolher?",
+                        verso: "O nível de armazenamento, entre memória e disco.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Para que serve ler o plano físico?",
+                        verso: "Para confirmar o que o Spark realmente vai executar.",
+                    },
+                    {
+                        frente: "Que confirmação a leitura do plano dá?",
+                        verso: "Se o filtro escrito chegou até a fonte de dados.",
+                    },
+                    {
+                        frente: "O que ler o plano não é?",
+                        verso: "Curiosidade acadêmica.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o AQE faz com o plano?",
+                        verso: "Ajusta depois, já com o tamanho real dos dados.",
+                    },
+                    {
+                        frente: "O que o AQE não faz?",
+                        verso: "Substituir o Catalyst.",
+                    },
+                    {
+                        frente: "Quando o Spark sabe o tamanho real dos dados?",
+                        verso: "Só durante a execução.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que mais memória resolve?",
+                        verso: "O sintoma.",
+                    },
+                    {
+                        frente: "O que menos dado por partição resolve?",
+                        verso: "A causa.",
+                    },
+                    {
+                        frente: "Que pergunta antecede aumentar a memória do executor?",
+                        verso: "Se o problema não é a partição grande demais.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Para que o Spark UI existe?",
+                        verso: "Para trocar o palpite pelo diagnóstico.",
+                    },
+                    {
+                        frente: "O que confirmar antes de mexer em memória ou partições?",
+                        verso: "Onde está o gargalo, com número na tela.",
+                    },
+                    {
+                        frente: "Que informação o Spark UI mostra por stage?",
+                        verso: "Duração, dados lidos e distribuição das tasks.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Quando um job de batch está pronto?",
+                        verso: "Quando dá para rodar de novo, para qualquer data.",
+                    },
+                    {
+                        frente: "Que garantia esse rodar de novo exige?",
+                        verso: "O resultado não mudar por acidente.",
+                    },
+                    {
+                        frente: "Que nome essa garantia tem?",
+                        verso: "Idempotência.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que milhares de arquivos pequenos causam?",
+                        verso: "Escrita rápida e leitura lenta para sempre.",
+                    },
+                    {
+                        frente: "Quem paga a conta dos arquivos pequenos?",
+                        verso: "Todo mundo que precisar ler aquele dado depois.",
+                    },
+                    {
+                        frente: "O que o particionamento na escrita organiza?",
+                        verso: "Os arquivos pela coluna de filtro mais comum.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que escolha decidir onde o Spark roda envolve?",
+                        verso: "Pagar por ociosidade ou por latência de inicialização.",
+                    },
+                    {
+                        frente: "O que o cluster sempre ligado cobra?",
+                        verso: "Ociosidade entre as execuções.",
+                    },
+                    {
+                        frente: "O que o cluster sob demanda cobra?",
+                        verso: "Tempo de subir a cada execução.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o Structured Streaming é?",
+                        verso: "A mesma API de DataFrame para dado que não termina.",
+                    },
+                    {
+                        frente: "O que ele não exige aprender?",
+                        verso: "Uma API totalmente nova.",
+                    },
+                    {
+                        frente: "Que diferença o dado de streaming traz?",
+                        verso: "Ele nunca termina de chegar.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o Spark não decide por quem escreve o job?",
+                        verso: "Filtrar cedo, particionar e cachear com critério.",
+                    },
+                    {
+                        frente: "Que antipadrão traz risco para o driver?",
+                        verso: "Trazer dado grande para ele.",
+                    },
+                    {
+                        frente: "O que o Spark otimiza sozinho?",
+                        verso: "Muita coisa, mas não as decisões de projeto.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de Processamento com Spark.

## O que entra
- Módulo 5, shuffle e desempenho: o custo de atravessar rede e disco, a contagem de shuffles como estimativa de custo, o que separa repartition de coalesce, o data skew como problema de dados e a troca que o broadcast join faz.
- Módulo 6, otimização: quando o cache compensa e quando só custa, a leitura do plano físico como confirmação, o AQE ajustando depois sem substituir o Catalyst, memória que resolve sintoma contra partição que resolve causa, e o Spark UI no lugar do palpite.
- Módulo 7, na prática: o job de batch que roda de novo sem surpresa, os arquivos pequenos que são lentos para sempre, a escolha entre ociosidade e latência de inicialização, o Structured Streaming como a mesma API e as decisões que o Spark não toma por você.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 60 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #550.
