### PR TITLE
feat: cartões dos módulos 3 e 4 de Streaming de Dados

### DIFF
--- a/backend/scripts/data/flashcards/streaming-de-dados.ts
+++ b/backend/scripts/data/flashcards/streaming-de-dados.ts
@@ -174,5 +174,169 @@ export const streamingDeDados: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que os acks decidem no produtor?",
+                        verso: "Quanto ele espera pela durabilidade.",
+                    },
+                    {
+                        frente: "O que o tempo de espera do lote decide?",
+                        verso: "Quanto o produtor espera para ganhar throughput.",
+                    },
+                    {
+                        frente: "Que problema o produtor idempotente resolve?",
+                        verso: "A duplicata que ele mesmo criaria ao reenviar.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que decisão define a garantia no consumidor?",
+                        verso: "A ordem entre processar e confirmar o offset.",
+                    },
+                    {
+                        frente: "O que confirmar depois de processar dá?",
+                        verso: "At-least-once, que pode reprocessar.",
+                    },
+                    {
+                        frente: "O que confirmar antes de processar dá?",
+                        verso: "At-most-once, que pode perder a mensagem.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que dois papéis a partição acumula?",
+                        verso: "Unidade de paralelismo e unidade de ordem.",
+                    },
+                    {
+                        frente: "Quando aumentar partições aumenta o paralelismo real?",
+                        verso: "Só se a chave distribuir a carga de forma equilibrada.",
+                    },
+                    {
+                        frente: "O que uma chave concentrada provoca?",
+                        verso: "Uma partição sobrecarregada e o resto ocioso.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que serializar assume, além do formato?",
+                        verso: "Um contrato entre quem produz e quem consome.",
+                    },
+                    {
+                        frente: "Para que o Schema Registry existe?",
+                        verso: "Para o contrato só mudar de forma compatível.",
+                    },
+                    {
+                        frente: "O que uma mudança incompatível quebra?",
+                        verso: "Todo consumidor que ainda lê pelo schema antigo.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que pergunta a retenção por tempo faz?",
+                        verso: "Há quanto tempo isso foi gravado.",
+                    },
+                    {
+                        frente: "Que pergunta o log compaction faz?",
+                        verso: "Se existe uma versão mais nova desta chave.",
+                    },
+                    {
+                        frente: "O que escolher a política errada provoca?",
+                        verso: "Perder dado que ainda era necessário.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que o at-most-once troca?",
+                        verso: "Confiabilidade por simplicidade.",
+                    },
+                    {
+                        frente: "O que o at-least-once troca?",
+                        verso: "Duplicidade por segurança contra perda.",
+                    },
+                    {
+                        frente: "Alguma garantia de entrega é gratuita?",
+                        verso: "Nenhuma: todas cobram em algum lugar.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que a idempotência elimina?",
+                        verso: "O efeito da duplicata, e não a duplicata.",
+                    },
+                    {
+                        frente: "O que pode acontecer mesmo assim?",
+                        verso: "A mensagem chegar duas vezes.",
+                    },
+                    {
+                        frente: "O que não pode variar?",
+                        verso: "O estado final do destino.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o produtor idempotente evita?",
+                        verso: "O duplicado gerado pelo reenvio dele mesmo.",
+                    },
+                    {
+                        frente: "O que uma transação no Kafka agrupa?",
+                        verso: "Escritas em vários tópicos, com efeito de tudo ou nada.",
+                    },
+                    {
+                        frente: "O que a transação permite ao consumidor?",
+                        verso: "Ler apenas o que foi confirmado.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o exactly-once não promete?",
+                        verso: "Que nada será reprocessado.",
+                    },
+                    {
+                        frente: "O que ele promete?",
+                        verso: "Que o efeito final é de um processamento só.",
+                    },
+                    {
+                        frente: "Onde essa garantia precisa valer?",
+                        verso: "No destino, de ponta a ponta.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que estrago uma poison message causa?",
+                        verso: "Trava a partição e prende as boas atrás dela.",
+                    },
+                    {
+                        frente: "Para onde a mensagem problemática deve ir?",
+                        verso: "Para uma fila de mensagens mortas.",
+                    },
+                    {
+                        frente: "O que isso libera?",
+                        verso: "O fluxo, que volta a andar sem ela.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de Streaming de Dados.

## O que entra
- Módulo 3, produzir e consumir: o que acks e o tempo de lote decidem, a ordem entre processar e confirmar o offset, a partição como unidade de ordem e de paralelismo, o schema como contrato e a diferença entre retenção por tempo e log compaction.
- Módulo 4, garantias de entrega: o que cada nível troca, a idempotência que elimina o efeito e não a duplicata, o produtor idempotente com transações, o que exactly-once promete de fato e a poison message que trava a partição.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #555.
