### PR TITLE
feat: cartões dos módulos 3, 4 e 5 fecham AWS AI Practitioner

### DIFF
--- a/backend/scripts/data/flashcards/aws-ai-practitioner.ts
+++ b/backend/scripts/data/flashcards/aws-ai-practitioner.ts
@@ -206,5 +206,251 @@ export const awsAiPractitioner: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que é um prompt zero-shot?",
+                        verso: "Pedido feito sem nenhum exemplo junto.",
+                    },
+                    {
+                        frente: "O que o few-shot acrescenta ao prompt?",
+                        verso: "Alguns exemplos do formato esperado.",
+                    },
+                    {
+                        frente: "O que a cadeia de raciocínio pede ao modelo?",
+                        verso: "Mostrar os passos antes da resposta final.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que temperatura e top-p controlam?",
+                        verso: "A diversidade da resposta.",
+                    },
+                    {
+                        frente: "O que o máximo de tokens controla?",
+                        verso: "O tamanho da resposta.",
+                    },
+                    {
+                        frente: "O que nenhum desses parâmetros garante?",
+                        verso: "Que a resposta é verdadeira.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o RAG faz com dados externos?",
+                        verso: "Recupera e injeta no prompt.",
+                    },
+                    {
+                        frente: "Que três ganhos o RAG traz?",
+                        verso: "Menos alucinação, dado atual sem retreino e citação de fonte.",
+                    },
+                    {
+                        frente: "O que o RAG dispensa quando o dado muda?",
+                        verso: "Retreinar o modelo.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que uma Knowledge Base do Bedrock resolve?",
+                        verso: "A montagem do RAG, já gerenciada.",
+                    },
+                    {
+                        frente: "O que um Agent do Bedrock acrescenta?",
+                        verso: "A capacidade de chamar ações e APIs.",
+                    },
+                    {
+                        frente: "O que o Agent decide sozinho?",
+                        verso: "Que passos executar para atender ao pedido.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que dados que mudam sempre pedem?",
+                        verso: "RAG: atualiza a base, sem retreinar.",
+                    },
+                    {
+                        frente: "O que especializar o comportamento pede?",
+                        verso: "Fine-tuning.",
+                    },
+                    {
+                        frente: "Que abordagem tentar primeiro, por ser mais barata?",
+                        verso: "A engenharia de prompt.",
+                    },
+                ],
+            },
+            6: {
+                neutra: [
+                    {
+                        frente: "O que um modelo menor entrega?",
+                        verso: "Mais barato e rápido, porém menos capaz.",
+                    },
+                    {
+                        frente: "O que é injeção de prompt?",
+                        verso: "Entrada que tenta subverter as instruções do sistema.",
+                    },
+                    {
+                        frente: "Que defesa a injeção de prompt exige?",
+                        verso: "Guardrails e desconfiança da entrada do usuário.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que a IA responsável trata?",
+                        verso: "Justiça, transparência, segurança e privacidade no uso da IA.",
+                    },
+                    {
+                        frente: "Que exigência ela faz sobre a decisão do modelo?",
+                        verso: "Que possa ser explicada a quem é afetado por ela.",
+                    },
+                    {
+                        frente: "Quando a IA responsável entra no projeto?",
+                        verso: "Desde o desenho, e não no fim.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que é viés num modelo?",
+                        verso: "Erro sistemático que trata grupos de forma injusta.",
+                    },
+                    {
+                        frente: "De onde o viés costuma ser herdado?",
+                        verso: "De dados desequilibrados.",
+                    },
+                    {
+                        frente: "Que serviço da AWS ajuda a detectar viés?",
+                        verso: "O SageMaker Clarify.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que a explicabilidade responde?",
+                        verso: "Por que o modelo chegou àquela saída.",
+                    },
+                    {
+                        frente: "Que documentação a AWS publica sobre seus serviços de IA?",
+                        verso: "Os AWS AI Service Cards.",
+                    },
+                    {
+                        frente: "Que troca a explicabilidade costuma enfrentar?",
+                        verso: "Modelo mais complexo costuma ser mais difícil de explicar.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que os guardrails limitam?",
+                        verso: "O conteúdo que pode ser gerado.",
+                    },
+                    {
+                        frente: "O que a supervisão humana revisa?",
+                        verso: "As decisões de alto impacto.",
+                    },
+                    {
+                        frente: "Que papel os dois cumprem juntos?",
+                        verso: "São pilares da IA responsável.",
+                    },
+                ],
+            },
+        },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Do que a AWS cuida no modelo compartilhado?",
+                        verso: "Da segurança da nuvem.",
+                    },
+                    {
+                        frente: "Do que o cliente cuida?",
+                        verso: "Da segurança na nuvem, incluindo acesso e dados.",
+                    },
+                    {
+                        frente: "Que princípio aplicar no IAM?",
+                        verso: "O do menor privilégio.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Onde criptografar os dados?",
+                        verso: "Em repouso e em trânsito.",
+                    },
+                    {
+                        frente: "Que serviço gerencia as chaves na AWS?",
+                        verso: "O AWS KMS.",
+                    },
+                    {
+                        frente: "Que serviço descobre e protege dado pessoal no S3?",
+                        verso: "O Amazon Macie.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Os dados do cliente treinam os modelos base no Bedrock?",
+                        verso: "Não treinam.",
+                    },
+                    {
+                        frente: "Que serviço dá conectividade privada à rede da AWS?",
+                        verso: "O AWS PrivateLink.",
+                    },
+                    {
+                        frente: "O que o PrivateLink evita no tráfego?",
+                        verso: "Sair para a internet pública.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que serviço registra as chamadas de API na conta?",
+                        verso: "O AWS CloudTrail.",
+                    },
+                    {
+                        frente: "Que serviço coleta métricas e logs?",
+                        verso: "O Amazon CloudWatch.",
+                    },
+                    {
+                        frente: "Que pergunta o CloudTrail responde numa auditoria?",
+                        verso: "Quem chamou o quê, e quando.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que dois reflexos a prova cobra?",
+                        verso: "Ligar cenário a serviço e separar conceitos parecidos.",
+                    },
+                    {
+                        frente: "Que prática a aula recomenda para fechar?",
+                        verso: "Fazer o simulado e revisar as explicações.",
+                    },
+                    {
+                        frente: "Que armadilha os conceitos parecidos criam?",
+                        verso: "Opções quase certas na mesma questão.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de AWS AI Practitioner.

## O que entra
- Módulo 3, prompt e adaptação: zero-shot, few-shot e cadeia de raciocínio, o que temperatura e máximo de tokens controlam e o que eles não garantem, os ganhos do RAG, o que Knowledge Bases e Agents resolvem, e o critério entre prompt, RAG e fine-tuning.
- Módulo 4, IA responsável: as dimensões que ela cobre, o viés herdado de dados desequilibrados com o SageMaker Clarify, a explicabilidade e os AWS AI Service Cards, e a dupla guardrails mais supervisão humana.
- Módulo 5, segurança e conformidade: a divisão da responsabilidade compartilhada, criptografia com KMS e descoberta de dado pessoal com Macie, a privacidade dos dados no Bedrock com PrivateLink, a auditoria por CloudTrail e CloudWatch, e os dois reflexos que a prova cobra.

45 cartas novas, trilha fechada em 81 para 27 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 36 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #564.
