### PR TITLE
feat: cartões dos módulos 1 a 3 de AWS DVA-C02

### DIFF
--- a/backend/scripts/data/flashcards/aws-dva-c02.ts
+++ b/backend/scripts/data/flashcards/aws-dva-c02.ts
@@ -1,0 +1,244 @@
+import type { CartasDaTrilha } from "../../seed-flashcards.ts";
+
+/**
+ * Cartões de AWS DVA-C02, trilha de certificação sem roadmap.
+ *
+ * Sem trilhos de linguagem: tudo em "neutra". O quiz cobra o cenário e a
+ * escolha do serviço; as cartas guardam os números que a prova exige de
+ * cor, os nomes dos serviços e as separações entre conceitos parecidos.
+ */
+export const awsDvaC02: CartasDaTrilha = {
+    trilha: "AWS DVA-C02",
+    modulos: {
+        1: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que toda ação na AWS é, por baixo?",
+                        verso: "Uma chamada de API por HTTPS.",
+                    },
+                    {
+                        frente: "O que SDK e CLI fazem com o request?",
+                        verso: "Montam e assinam a chamada para a API da AWS.",
+                    },
+                    {
+                        frente: "Que par de credenciais o acesso programático usa?",
+                        verso: "Access Key ID, público, e Secret Access Key, secreta.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que processo assina cada request para a AWS?",
+                        verso: "O Signature Version 4.",
+                    },
+                    {
+                        frente: "Quando se implementa essa assinatura à mão?",
+                        verso: "Só ao chamar a API por HTTP puro, sem SDK.",
+                    },
+                    {
+                        frente: "Que serviços têm endpoint global, e não regional?",
+                        verso: "IAM e CloudFront.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que erros o SDK re-tenta sozinho?",
+                        verso: "Os 429, de throttling, e os 5xx.",
+                    },
+                    {
+                        frente: "Que estratégia responde a muitos clientes re-tentando juntos?",
+                        verso: "Backoff exponencial com jitter.",
+                    },
+                    {
+                        frente: "O que o jitter evita no backoff?",
+                        verso: "Que todos os clientes tentem de novo no mesmo instante.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Do que a AWS cuida no modelo compartilhado?",
+                        verso: "Da segurança da nuvem: hardware, rede física e virtualização.",
+                    },
+                    {
+                        frente: "Do que o cliente cuida?",
+                        verso: "Da segurança na nuvem: código, acesso, dados e configuração.",
+                    },
+                    {
+                        frente: "Que serviço entrega rotação automática de senha?",
+                        verso: "O Secrets Manager.",
+                    },
+                ],
+            },
+        },
+        2: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que você entrega ao Lambda?",
+                        verso: "Só o código da função.",
+                    },
+                    {
+                        frente: "Que faixa de memória uma função Lambda aceita?",
+                        verso: "De 128 MB a 10 GB.",
+                    },
+                    {
+                        frente: "Qual é o tempo máximo de execução de uma função?",
+                        verso: "Quinze minutos.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Como o modelo push funciona?",
+                        verso: "O serviço de origem chama o Lambda quando algo acontece.",
+                    },
+                    {
+                        frente: "Como o modelo poll funciona?",
+                        verso: "O Lambda lê a origem pelo event source mapping.",
+                    },
+                    {
+                        frente: "Que permissão o modelo push exige?",
+                        verso: "Uma resource-based policy na função.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Qual é o pool padrão de concorrência por região?",
+                        verso: "Mil execuções simultâneas, compartilhadas pela conta.",
+                    },
+                    {
+                        frente: "Que tipo de concorrência elimina o cold start?",
+                        verso: "A provisionada, pré-aquecida e com custo.",
+                    },
+                    {
+                        frente: "O que a concorrência reservada faz?",
+                        verso: "Garante um piso e impõe um teto à função.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que é uma versão de função Lambda?",
+                        verso: "Um snapshot imutável do código e da configuração.",
+                    },
+                    {
+                        frente: "O que é um alias?",
+                        verso: "Um ponteiro móvel para uma versão.",
+                    },
+                    {
+                        frente: "O que um layer guarda?",
+                        verso: "Dependências reaproveitáveis, fora do pacote da função.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o Lambda cria ao ser conectado a uma VPC?",
+                        verso: "Uma interface de rede elástica.",
+                    },
+                    {
+                        frente: "O que a função perde ao entrar na VPC?",
+                        verso: "A saída para a internet, se não houver NAT.",
+                    },
+                    {
+                        frente: "Quantas novas tentativas a invocação assíncrona faz?",
+                        verso: "Duas, além da original.",
+                    },
+                ],
+            },
+        },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Qual é o tamanho máximo de um item no DynamoDB?",
+                        verso: "400 KB.",
+                    },
+                    {
+                        frente: "Que dois tipos de chave primária existem?",
+                        verso: "Simples, só partition, ou composta, com sort key.",
+                    },
+                    {
+                        frente: "O que causa throttling numa tabela com capacidade sobrando?",
+                        verso: "A partição quente, com acesso concentrado numa chave.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Quanto uma RCU entrega?",
+                        verso: "Uma leitura forte, ou duas eventuais, de item até 4 KB.",
+                    },
+                    {
+                        frente: "Quanto uma WCU entrega?",
+                        verso: "Uma escrita de item até 1 KB.",
+                    },
+                    {
+                        frente: "Que ordem seguir no cálculo de capacidade?",
+                        verso: "Arredondar o tamanho primeiro, aplicar a regra depois.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o LSI mantém igual ao da tabela?",
+                        verso: "A partition key.",
+                    },
+                    {
+                        frente: "Quando um LSI pode ser criado?",
+                        verso: "Só junto com a tabela.",
+                    },
+                    {
+                        frente: "Que tipo de leitura o GSI oferece?",
+                        verso: "Só a eventual, com capacidade própria.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que recurso reage a alterações na tabela?",
+                        verso: "O DynamoDB Streams, acionando Lambda.",
+                    },
+                    {
+                        frente: "Por quanto tempo o Streams guarda os registros?",
+                        verso: "Vinte e quatro horas.",
+                    },
+                    {
+                        frente: "O que o TTL faz, e a que custo?",
+                        verso: "Apaga o item expirado sem consumir WCU.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que serviço resolve conexões esgotadas de Lambda para RDS?",
+                        verso: "O RDS Proxy.",
+                    },
+                    {
+                        frente: "Quando escolher Redis no ElastiCache?",
+                        verso: "Quando precisa de persistência, réplica, pub/sub ou estrutura rica.",
+                    },
+                    {
+                        frente: "Onde criar o pool de conexões numa função Lambda?",
+                        verso: "Fora do handler, para ser reaproveitado.",
+                    },
+                ],
+            },
+        },
+    },
+};

--- a/backend/scripts/data/flashcards/index.ts
+++ b/backend/scripts/data/flashcards/index.ts
@@ -68,6 +68,7 @@ import { streamingDeDados } from "./streaming-de-dados.ts";
 import { modernDataStack } from "./modern-data-stack.ts";
 import { qualidadeEGovernancaDeDados } from "./qualidade-e-governanca-de-dados.ts";
 import { awsAiPractitioner } from "./aws-ai-practitioner.ts";
+import { awsDvaC02 } from "./aws-dva-c02.ts";
 
 export const TRILHAS: CartasDaTrilha[] = [
     logicaDeProgramacao,
@@ -138,4 +139,5 @@ export const TRILHAS: CartasDaTrilha[] = [
     modernDataStack,
     qualidadeEGovernancaDeDados,
     awsAiPractitioner,
+    awsDvaC02,
 ];


### PR DESCRIPTION
Abre a trilha de AWS DVA-C02.

## O que entra
- Módulo 1, chamando a AWS: a API HTTPS por trás de tudo, o par de credenciais, a assinatura SigV4 feita pelo SDK, os endpoints globais de IAM e CloudFront, os erros que o SDK re-tenta e o backoff com jitter.
- Módulo 2, Lambda: os limites de memória e tempo, a diferença entre push e poll no gatilho, a concorrência reservada contra a provisionada, versão e alias, e a interface de rede criada ao entrar numa VPC.
- Módulo 3, dados: o item de 400 KB e a partição quente, a conta de RCU e WCU, o que separa LSI de GSI, o Streams com retenção de 24 horas e o RDS Proxy para conexões esgotadas.

42 cartas para as 14 aulas dos três módulos.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 42 criadas, nenhuma aula dos módulos 1 a 3 sem carta.

Empilhado sobre #565.
