### PR TITLE
feat: cartões dos módulos 4 a 6 de AWS SAA-C03

### DIFF
--- a/backend/scripts/data/flashcards/aws-saa-c03.ts
+++ b/backend/scripts/data/flashcards/aws-saa-c03.ts
@@ -256,5 +256,251 @@ export const awsSaaC03: CartasDaTrilha = {
                 ],
             },
         },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que torna uma subnet pública?",
+                        verso: "A rota da route table dela para um Internet Gateway.",
+                    },
+                    {
+                        frente: "O que não torna a subnet pública?",
+                        verso: "Uma marcação própria nem o fato de ter endereço público.",
+                    },
+                    {
+                        frente: "O que a route table define?",
+                        verso: "Para onde vai o tráfego daquela subnet.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Onde o NAT Gateway fica hospedado?",
+                        verso: "Numa subnet pública.",
+                    },
+                    {
+                        frente: "Onde ele nunca fica?",
+                        verso: "Na própria subnet privada.",
+                    },
+                    {
+                        frente: "O que o NAT permite à subnet privada?",
+                        verso: "Sair para a internet sem receber conexão de fora.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que comportamento o security group tem?",
+                        verso: "É stateful: a resposta volta sem regra de saída.",
+                    },
+                    {
+                        frente: "Que comportamento a network ACL tem?",
+                        verso: "É stateless: precisa de regra nos dois sentidos.",
+                    },
+                    {
+                        frente: "O que a network ACL exige além de liberar a entrada?",
+                        verso: "Liberar a saída na faixa de portas efêmeras.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o PrivateLink permite?",
+                        verso: "Consumir um serviço específico sem expor à internet.",
+                    },
+                    {
+                        frente: "O que o peering conecta?",
+                        verso: "Duas VPCs, sem trânsito para uma terceira.",
+                    },
+                    {
+                        frente: "O que o Transit Gateway resolve?",
+                        verso: "A ligação de muitas VPCs e redes num ponto central.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o Session Manager faz com a porta de entrada?",
+                        verso: "Remove: a conexão parte de dentro da instância.",
+                    },
+                    {
+                        frente: "O que ele substitui na arquitetura?",
+                        verso: "O bastion host.",
+                    },
+                    {
+                        frente: "O que o VPC Flow Logs registra?",
+                        verso: "O tráfego que entra e sai das interfaces de rede.",
+                    },
+                ],
+            },
+        },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que a Site-to-Site VPN conecta?",
+                        verso: "Redes.",
+                    },
+                    {
+                        frente: "O que a Client VPN conecta?",
+                        verso: "Pessoas.",
+                    },
+                    {
+                        frente: "Que pergunta separa os dois casos?",
+                        verso: "Se do outro lado há uma rede inteira ou um usuário.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que o Direct Connect troca?",
+                        verso: "Velocidade de entrega por consistência.",
+                    },
+                    {
+                        frente: "O que ele entrega depois de pronto?",
+                        verso: "Banda e latência previsíveis.",
+                    },
+                    {
+                        frente: "Que desvantagem ele tem no início?",
+                        verso: "Demora mais para ficar disponível.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que problema o registro alias resolve?",
+                        verso: "O mesmo do CNAME, mas funcionando no apex do domínio.",
+                    },
+                    {
+                        frente: "Que custo o alias evita?",
+                        verso: "O da consulta, quando o destino é um recurso da AWS.",
+                    },
+                    {
+                        frente: "O que um health check faz no Route 53?",
+                        verso: "Tira do rodízio o destino que parou de responder.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "De onde nasce a política de roteamento certa?",
+                        verso: "Da pergunta que o requisito faz.",
+                    },
+                    {
+                        frente: "Que política responde a desempenho?",
+                        verso: "A de latência.",
+                    },
+                    {
+                        frente: "Que política responde a sobrevivência?",
+                        verso: "A de failover.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o CloudFront aproxima?",
+                        verso: "O conteúdo, do usuário.",
+                    },
+                    {
+                        frente: "O que o Global Accelerator aproxima?",
+                        verso: "O usuário, da aplicação.",
+                    },
+                    {
+                        frente: "Que pergunta decide entre os dois?",
+                        verso: "Se existe conteúdo para colocar em cache.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "De onde nasce a escolha da família de instância?",
+                        verso: "Do gargalo real: CPU, memória, disco ou rede.",
+                    },
+                    {
+                        frente: "De onde ela não nasce?",
+                        verso: "Do tipo mais familiar nem do menor preço.",
+                    },
+                    {
+                        frente: "O que a família de uso geral equilibra?",
+                        verso: "CPU e memória, sem privilegiar nenhum extremo.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "De que depende o modelo de compra certo?",
+                        verso: "Do padrão de uso da carga.",
+                    },
+                    {
+                        frente: "O que o compromisso de longo prazo exige?",
+                        verso: "Previsibilidade no uso.",
+                    },
+                    {
+                        frente: "Que carga combina com instância spot?",
+                        verso: "A que tolera interrupção a qualquer momento.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que a AMI define?",
+                        verso: "O que a instância já traz pronta.",
+                    },
+                    {
+                        frente: "O que o user data define?",
+                        verso: "O que a instância faz ao nascer.",
+                    },
+                    {
+                        frente: "O que o launch template amarra?",
+                        verso: "Os dois, de forma reprodutível e versionada.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que balanceador o conteúdo HTTP pede?",
+                        verso: "O de aplicação.",
+                    },
+                    {
+                        frente: "Que balanceador a performance bruta em TCP pede?",
+                        verso: "O de rede.",
+                    },
+                    {
+                        frente: "Que balanceador a inspeção transparente pede?",
+                        verso: "O de gateway.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que duas coisas um Auto Scaling Group entrega junto?",
+                        verso: "Escalabilidade e alta disponibilidade.",
+                    },
+                    {
+                        frente: "O que ele faz com a instância que falha no health check?",
+                        verso: "Substitui por uma nova.",
+                    },
+                    {
+                        frente: "O que a capacidade desejada define?",
+                        verso: "Quantas instâncias o grupo tenta manter.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de AWS SAA-C03.

## O que entra
- Módulo 4, VPC: a rota que define se a subnet é pública, o NAT hospedado na subnet pública, security group stateful contra network ACL stateless, o que separa peering, Transit Gateway e PrivateLink, e o Session Manager que apaga a porta de entrada.
- Módulo 5, conectividade e entrega: a VPN que liga redes contra a que liga pessoas, o que o Direct Connect troca, o alias que funciona no apex, a política de roteamento nascida do requisito, e a diferença entre aproximar conteúdo e aproximar usuário.
- Módulo 6, computação: a família escolhida pelo gargalo real, o modelo de compra ditado pelo padrão de uso, o trio AMI, user data e launch template, a camada que decide o balanceador e o Auto Scaling entregando escala com disponibilidade.

45 cartas novas, 90 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 45 já existiam, nenhuma aula dos módulos 1 a 6 sem carta.

Empilhado sobre #569.
