### PR TITLE
feat: cartões dos módulos 4 a 6 fecham AZURE AI-901

### DIFF
--- a/backend/scripts/data/flashcards/azure-ai-901.ts
+++ b/backend/scripts/data/flashcards/azure-ai-901.ts
@@ -240,5 +240,235 @@ export const azureAi901: CartasDaTrilha = {
                 ],
             },
         },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que a mensagem de sistema define?",
+                        verso: "Quem o modelo é e como deve agir, uma vez só.",
+                    },
+                    {
+                        frente: "O que a mensagem de usuário traz?",
+                        verso: "O pedido concreto de cada rodada.",
+                    },
+                    {
+                        frente: "Qual das duas se repete a cada interação?",
+                        verso: "A do usuário.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "No que o deploy transforma um modelo do catálogo?",
+                        verso: "Num endpoint pronto para uso.",
+                    },
+                    {
+                        frente: "O que o código referencia depois do deploy?",
+                        verso: "O nome do deployment.",
+                    },
+                    {
+                        frente: "Onde os parâmetros de geração podem ser ajustados?",
+                        verso: "No portal e também na própria chamada.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que o cliente de projeto faz no SDK do Foundry?",
+                        verso: "Conecta a aplicação ao projeto.",
+                    },
+                    {
+                        frente: "Quem envia as mensagens ao modelo?",
+                        verso: "O cliente de inferência.",
+                    },
+                    {
+                        frente: "Onde a resposta do modelo chega?",
+                        verso: "Na primeira escolha devolvida, dentro da mensagem.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Do que um agente é feito?",
+                        verso: "De modelo mais instruções.",
+                    },
+                    {
+                        frente: "O que ele pode ganhar além disso?",
+                        verso: "Ferramentas e conhecimento.",
+                    },
+                    {
+                        frente: "Onde a conversa do agente vive?",
+                        verso: "Numa thread.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a thread guarda?",
+                        verso: "A conversa com o agente.",
+                    },
+                    {
+                        frente: "O que a chamada de execução faz?",
+                        verso: "Roda o agente e aguarda a conclusão.",
+                    },
+                    {
+                        frente: "Como a resposta é recuperada?",
+                        verso: "Listando as mensagens da thread.",
+                    },
+                ],
+            },
+        },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que serviço faz o trabalho num app de análise de texto?",
+                        verso: "O Azure AI Language.",
+                    },
+                    {
+                        frente: "O que é preciso para conectar o recurso?",
+                        verso: "Endpoint e chave, com o recurso ligado ao projeto.",
+                    },
+                    {
+                        frente: "O que o app entrega, no fim?",
+                        verso: "Uma camada fina sobre a chamada do serviço.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que o reconhecedor de fala faz?",
+                        verso: "Transforma fala em texto.",
+                    },
+                    {
+                        frente: "O que o sintetizador faz?",
+                        verso: "Transforma texto em fala.",
+                    },
+                    {
+                        frente: "Que serviço cobre os dois sentidos da voz?",
+                        verso: "O Azure AI Speech.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que três peças respondem a um prompt falado?",
+                        verso: "Transcrição, modelo multimodal e síntese de voz.",
+                    },
+                    {
+                        frente: "Quem transcreve a fala?",
+                        verso: "O Azure AI Speech.",
+                    },
+                    {
+                        frente: "Quem gera a resposta?",
+                        verso: "O modelo multimodal publicado no Foundry.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que um modelo multimodal recebe?",
+                        verso: "Imagem e texto no mesmo prompt.",
+                    },
+                    {
+                        frente: "Como ele responde?",
+                        verso: "De forma aberta, ao que foi perguntado.",
+                    },
+                    {
+                        frente: "Como o serviço de visão clássico responde?",
+                        verso: "Com saídas fixas e previsíveis.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que gerar imagem faz?",
+                        verso: "Cria um resultado visual novo a partir de um texto.",
+                    },
+                    {
+                        frente: "Que duas etapas um app leve de visão encadeia?",
+                        verso: "Interpretação e geração.",
+                    },
+                    {
+                        frente: "Quem interpreta nessa dupla?",
+                        verso: "O modelo multimodal.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "No que o Content Understanding transforma documentos?",
+                        verso: "Em JSON estruturado.",
+                    },
+                    {
+                        frente: "O que você define antes de usar?",
+                        verso: "Um analisador, com os campos desejados.",
+                    },
+                    {
+                        frente: "O que vem junto de cada campo extraído?",
+                        verso: "O valor e a confiança dele.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que ele faz em imagens, além de ler o texto?",
+                        verso: "Devolve campos nomeados, descrição e classificação.",
+                    },
+                    {
+                        frente: "Em quantas passadas isso acontece?",
+                        verso: "Numa passada só.",
+                    },
+                    {
+                        frente: "O que a leitura de texto sozinha entrega?",
+                        verso: "Apenas o texto lido.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que ele faz com áudio e vídeo?",
+                        verso: "Transcreve e extrai campos no mesmo passo.",
+                    },
+                    {
+                        frente: "Que campos costumam sair daí?",
+                        verso: "Resumo, sentimento e os que você definir.",
+                    },
+                    {
+                        frente: "Que ganho isso traz sobre transcrever e analisar depois?",
+                        verso: "Uma chamada só, no lugar de duas etapas.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que é um app de extração de informação?",
+                        verso: "Uma camada fina sobre o Content Understanding.",
+                    },
+                    {
+                        frente: "Quantas vezes o analisador é definido?",
+                        verso: "Uma vez só.",
+                    },
+                    {
+                        frente: "Para que serve a confiança devolvida?",
+                        verso: "Para decidir o que segue automático e o que vai a revisão.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de AZURE AI-901.

## O que entra
- Módulo 4, do prompt ao agente: o papel de cada mensagem, o deploy que vira endpoint com nome próprio, as peças do SDK, o agente como modelo mais instruções e a thread que guarda a conversa.
- Módulo 5, apps no Foundry: o Azure AI Language por trás da análise de texto, os dois sentidos da voz, o encadeamento que responde a um prompt falado, a resposta aberta do modelo multimodal contra a saída fixa do serviço clássico, e a geração de imagem.
- Módulo 6, Content Understanding: o analisador que devolve JSON com confiança por campo, o que ele acrescenta à leitura de texto em imagens, a transcrição com extração no mesmo passo e o app como camada fina.

42 cartas novas, trilha fechada em 84 para 28 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 42 criadas, 42 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #576.
