### PR TITLE
feat: cartões dos módulos 3 e 4 de ISTQB CTFL

### DIFF
--- a/backend/scripts/data/flashcards/istqb-ctfl.ts
+++ b/backend/scripts/data/flashcards/istqb-ctfl.ts
@@ -174,5 +174,169 @@ export const istqbCtfl: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que ganha importância em modelos iterativos?",
+                        verso: "O teste de regressão.",
+                    },
+                    {
+                        frente: "Por que ele ganha importância ali?",
+                        verso: "Cada incremento pode quebrar o que já funcionava.",
+                    },
+                    {
+                        frente: "O que o modelo de ciclo de vida influencia no teste?",
+                        verso: "Quando e como cada nível acontece.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que evita a redundância entre níveis?",
+                        verso: "Objetivos específicos para cada nível.",
+                    },
+                    {
+                        frente: "Que exemplo a aula usa dessa redundância?",
+                        verso: "Repetir no sistema uma regra já exaustiva no componente.",
+                    },
+                    {
+                        frente: "Quando o teste deve começar, nas boas práticas?",
+                        verso: "O mais cedo possível no ciclo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que as três abordagens dirigidas por teste têm em comum?",
+                        verso: "Os testes são escritos antes do código.",
+                    },
+                    {
+                        frente: "Que outro papel esses testes cumprem?",
+                        verso: "Servem também como forma de especificação.",
+                    },
+                    {
+                        frente: "Onde está a diferença entre elas?",
+                        verso: "No nível do teste e em quem o escreve.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o DevOps não elimina?",
+                        verso: "O teste manual.",
+                    },
+                    {
+                        frente: "O que ele reduz?",
+                        verso: "A necessidade do teste manual repetitivo.",
+                    },
+                    {
+                        frente: "O que o shift left propõe?",
+                        verso: "Antecipar as atividades de teste no ciclo.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que artefatos as retrospectivas melhoram?",
+                        verso: "O testware e a base de teste.",
+                    },
+                    {
+                        frente: "Que outro benefício elas trazem?",
+                        verso: "A colaboração entre as pessoas do time.",
+                    },
+                    {
+                        frente: "Quando uma retrospectiva acontece?",
+                        verso: "Ao fim de um marco, de uma iteração ou do projeto.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Quantos níveis de teste o syllabus lista?",
+                        verso: "Cinco.",
+                    },
+                    {
+                        frente: "Qual é o objeto do teste de componente?",
+                        verso: "O componente isolado.",
+                    },
+                    {
+                        frente: "Qual é o objeto do teste de integração de componentes?",
+                        verso: "As interfaces entre eles.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Em que níveis o teste não funcional pode ser feito?",
+                        verso: "Em todos, inclusive no de componente.",
+                    },
+                    {
+                        frente: "Quando ele deve começar?",
+                        verso: "O mais cedo possível.",
+                    },
+                    {
+                        frente: "O que o teste funcional verifica?",
+                        verso: "O que o sistema faz.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Em que a caixa-preta é baseada?",
+                        verso: "Na especificação.",
+                    },
+                    {
+                        frente: "Em que a caixa-branca é baseada?",
+                        verso: "Na estrutura.",
+                    },
+                    {
+                        frente: "Que erro comum a prova explora nessa dupla?",
+                        verso: "Trocar a base do teste por quem o executa.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o teste de confirmação verifica?",
+                        verso: "Se o defeito corrigido realmente sumiu.",
+                    },
+                    {
+                        frente: "O que o teste de regressão verifica?",
+                        verso: "Se a mudança quebrou o que já funcionava.",
+                    },
+                    {
+                        frente: "Por que a regressão é forte candidata à automação?",
+                        verso: "Roda muitas vezes e evolui devagar.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Que evento pouco lembrado também exige teste?",
+                        verso: "A aposentadoria do sistema.",
+                    },
+                    {
+                        frente: "O que testar nessa aposentadoria?",
+                        verso: "O arquivamento e a restauração dos dados.",
+                    },
+                    {
+                        frente: "O que dispara o teste de manutenção?",
+                        verso: "Correção, melhoria, migração ou mudança de ambiente.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de ISTQB CTFL.

## O que entra
- Módulo 3, teste no ciclo de vida: a regressão que cresce em modelos iterativos, os objetivos por nível que evitam redundância, o que TDD, ATDD e BDD têm em comum, o teste manual que o DevOps não elimina e o que as retrospectivas melhoram.
- Módulo 4, níveis e tipos: os cinco níveis com seu objeto de teste, o teste não funcional cabendo em todos os níveis, caixa-preta baseada em especificação contra caixa-branca baseada em estrutura, confirmação contra regressão, e a aposentadoria de sistema que também exige teste.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #584.
