### PR TITLE
feat: cartões dos módulos 5, 6 e 7 fecham ISTQB CTFL

### DIFF
--- a/backend/scripts/data/flashcards/istqb-ctfl.ts
+++ b/backend/scripts/data/flashcards/istqb-ctfl.ts
@@ -338,5 +338,251 @@ export const istqbCtfl: CartasDaTrilha = {
                 ],
             },
         },
+        5: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que artefatos podem ser examinados no teste estático?",
+                        verso: "Só os legíveis e compreensíveis.",
+                    },
+                    {
+                        frente: "O que a análise estática por ferramenta procura?",
+                        verso: "Desvios de padrão e problemas no código, sem executar.",
+                    },
+                    {
+                        frente: "O que o teste estático alcança que o dinâmico não alcança?",
+                        verso: "Defeitos antes de qualquer execução.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que problemas só o teste estático revela?",
+                        verso: "Código inalcançável e código duplicado.",
+                    },
+                    {
+                        frente: "Por que o dinâmico não revela código morto?",
+                        verso: "Ele simplesmente nunca executa aquele trecho.",
+                    },
+                    {
+                        frente: "O que o teste dinâmico revela melhor?",
+                        verso: "As falhas de comportamento durante a execução.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que benefícios de negócio o feedback antecipado traz?",
+                        verso: "Focar no mais valioso e entregar valor antes.",
+                    },
+                    {
+                        frente: "Que benefício de qualidade ele traz?",
+                        verso: "Corrigir mais cedo, com custo menor.",
+                    },
+                    {
+                        frente: "Por que a frequência importa nesse feedback?",
+                        verso: "Reduz o tempo entre criar e descobrir o problema.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Toda anomalia encontrada é um defeito?",
+                        verso: "Não necessariamente.",
+                    },
+                    {
+                        frente: "Que atividade existe por causa disso?",
+                        verso: "A de comunicar e analisar antes de classificar.",
+                    },
+                    {
+                        frente: "Que papéis a revisão tem?",
+                        verso: "Autor, moderador, revisor, escriba e gerente.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a revisão técnica exige e o que ela dispensa?",
+                        verso: "Exige preparação individual; a reunião é opcional.",
+                    },
+                    {
+                        frente: "O que o walkthrough inverte nisso?",
+                        verso: "A reunião é o centro; a preparação é opcional.",
+                    },
+                    {
+                        frente: "Que tipo de revisão é o mais formal?",
+                        verso: "A inspeção.",
+                    },
+                ],
+            },
+        },
+        6: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Quantas técnicas de caixa-preta existem?",
+                        verso: "Quatro.",
+                    },
+                    {
+                        frente: "Quantas técnicas de caixa-branca existem?",
+                        verso: "Duas.",
+                    },
+                    {
+                        frente: "Quantas técnicas baseadas em experiência existem?",
+                        verso: "Três.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Como as partições inválidas devem ser testadas?",
+                        verso: "Individualmente, sem combinar umas com as outras.",
+                    },
+                    {
+                        frente: "Por que essa regra existe?",
+                        verso: "Para evitar que um defeito mascare o outro.",
+                    },
+                    {
+                        frente: "O que uma partição de equivalência agrupa?",
+                        verso: "Valores que o sistema deve tratar do mesmo jeito.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que vizinho a variante de dois valores escolhe?",
+                        verso: "O da partição adjacente, ou seja, o de fora.",
+                    },
+                    {
+                        frente: "O que a variante de três valores acrescenta?",
+                        verso: "Também o vizinho de dentro do limite.",
+                    },
+                    {
+                        frente: "Onde os defeitos se concentram, segundo a técnica?",
+                        verso: "Nas bordas das partições.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Quantas colunas a tabela completa tem com N condições binárias?",
+                        verso: "Dois elevado a N.",
+                    },
+                    {
+                        frente: "Quantas colunas ela tem com três condições?",
+                        verso: "Oito.",
+                    },
+                    {
+                        frente: "O que a transição de estados modela?",
+                        verso: "Os estados e os eventos que levam de um a outro.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que contar para a cobertura de comando?",
+                        verso: "Os comandos executáveis.",
+                    },
+                    {
+                        frente: "O que contar para a cobertura de decisão?",
+                        verso: "Os resultados possíveis de cada decisão.",
+                    },
+                    {
+                        frente: "Qual das duas coberturas é mais forte?",
+                        verso: "A de decisão: ela inclui a de comando.",
+                    },
+                ],
+            },
+        },
+        7: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que acontece com os checklists ao longo do tempo?",
+                        verso: "Crescem, e podem virar listas grandes demais.",
+                    },
+                    {
+                        frente: "O que essa lista grande provoca?",
+                        verso: "Itens redundantes e revisões mais lentas.",
+                    },
+                    {
+                        frente: "Que cuidado o syllabus recomenda?",
+                        verso: "Revisar e podar o checklist periodicamente.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Acabar o tempo alocado é critério de saída válido?",
+                        verso: "É, desde que as partes interessadas aceitem.",
+                    },
+                    {
+                        frente: "Que outro critério do mesmo tipo vale?",
+                        verso: "Acabar o orçamento.",
+                    },
+                    {
+                        frente: "O que a priorização de teste decide?",
+                        verso: "O que executar primeiro, quando o tempo é limitado.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que caracteriza um risco de produto?",
+                        verso: "Algo que o software faz de errado.",
+                    },
+                    {
+                        frente: "O que caracteriza um risco de projeto?",
+                        verso: "Algo que o projeto faz de errado.",
+                    },
+                    {
+                        frente: "O que o risco combina, na definição?",
+                        verso: "Probabilidade e impacto.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o relatório de progresso apoia?",
+                        verso: "O controle contínuo.",
+                    },
+                    {
+                        frente: "O que o relatório de conclusão faz?",
+                        verso: "Resume um ciclo já encerrado.",
+                    },
+                    {
+                        frente: "Para que serve a gestão de configuração no teste?",
+                        verso: "Manter o testware versionado e rastreável.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a automação não substitui?",
+                        verso: "O raciocínio humano.",
+                    },
+                    {
+                        frente: "O que a automação não conserta?",
+                        verso: "Um processo ruim.",
+                    },
+                    {
+                        frente: "Como as afirmações contrárias aparecem na prova?",
+                        verso: "Como distratores.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Fecha a trilha de ISTQB CTFL.

## O que entra
- Módulo 5, teste estático: quais artefatos podem ser examinados, o código morto que só o estático revela, os benefícios de negócio do feedback antecipado, a anomalia que nem sempre é defeito, e o que revisão técnica e walkthrough invertem entre si.
- Módulo 6, técnicas: a contagem de quatro, duas e três por categoria, as partições inválidas testadas uma a uma, o vizinho escolhido em cada variante de valor limite, o número de colunas da tabela de decisão e o que contar em cada cobertura.
- Módulo 7, gestão: o checklist que cresce demais, o tempo e o orçamento como critérios de saída válidos, a âncora entre risco de produto e de projeto, o relatório de progresso contra o de conclusão, e o que a automação não substitui nem conserta.

45 cartas novas, trilha fechada em 105 para 35 aulas.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 45 criadas, 60 já existiam, nenhuma aula publicada sem carta.

Empilhado sobre #585.
