### PR TITLE
feat: cartões dos módulos 1 e 2 de PHP

### DIFF
--- a/backend/scripts/data/flashcards/index.ts
+++ b/backend/scripts/data/flashcards/index.ts
@@ -81,6 +81,7 @@ import { isc2Cc } from "./isc2-cc.ts";
 import { css } from "./css.ts";
 import { typescript } from "./typescript.ts";
 import { react } from "./react.ts";
+import { php } from "./php.ts";
 
 export const TRILHAS: CartasDaTrilha[] = [
     logicaDeProgramacao,
@@ -164,4 +165,5 @@ export const TRILHAS: CartasDaTrilha[] = [
     css,
     typescript,
     react,
+    php,
 ];

--- a/backend/scripts/data/flashcards/php.ts
+++ b/backend/scripts/data/flashcards/php.ts
@@ -1,0 +1,178 @@
+import type { CartasDaTrilha } from "../../seed-flashcards.ts";
+
+/**
+ * Cartões de PHP, trilha sem roadmap.
+ *
+ * Sem trilhos de linguagem: tudo em "neutra". O quiz cobra a decisão de
+ * código; as cartas guardam as regras da linguagem, os operadores e as
+ * armadilhas de segurança que a aula enuncia de passagem.
+ */
+export const php: CartasDaTrilha = {
+    trilha: "PHP",
+    modulos: {
+        1: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Onde o PHP roda?",
+                        verso: "No servidor.",
+                    },
+                    {
+                        frente: "O que quem acessa o site recebe?",
+                        verso: "O resultado pronto, nunca o código.",
+                    },
+                    {
+                        frente: "Que saída o PHP costuma devolver?",
+                        verso: "HTML já montado.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Como um script PHP é executado no terminal?",
+                        verso: "Pelo próprio interpretador, apontando para o arquivo.",
+                    },
+                    {
+                        frente: "Que servidor o PHP oferece para desenvolver?",
+                        verso: "Um servidor embutido, iniciado por comando.",
+                    },
+                    {
+                        frente: "Que extensão o arquivo usa?",
+                        verso: "A extensão php.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Com que símbolo toda variável começa?",
+                        verso: "Com cifrão.",
+                    },
+                    {
+                        frente: "O que a saída simples faz com o valor?",
+                        verso: "Imprime direto na resposta.",
+                    },
+                    {
+                        frente: "O que o tipo de uma variável pode fazer ao longo do tempo?",
+                        verso: "Mudar, porque a tipagem é dinâmica.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Por onde todo dado externo passa antes de virar HTML?",
+                        verso: "Pelo escape de caracteres especiais.",
+                    },
+                    {
+                        frente: "Existe exceção a essa regra?",
+                        verso: "Nenhuma.",
+                    },
+                    {
+                        frente: "Que ataque esse escape previne?",
+                        verso: "A injeção de script na página.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a instalação pelo Composer respeita?",
+                        verso: "O arquivo de trava, com as versões fixadas.",
+                    },
+                    {
+                        frente: "O que a atualização faz com esse arquivo?",
+                        verso: "Ignora e busca versões novas.",
+                    },
+                    {
+                        frente: "O que o Composer gerencia num projeto?",
+                        verso: "As dependências e o carregamento automático.",
+                    },
+                ],
+            },
+        },
+        2: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que tipos escalares o PHP tem?",
+                        verso: "Inteiro, decimal, string e booleano.",
+                    },
+                    {
+                        frente: "O que a conversão implícita faz?",
+                        verso: "Muda o tipo do valor conforme o contexto.",
+                    },
+                    {
+                        frente: "Que risco a conversão implícita traz?",
+                        verso: "Comparações com resultado inesperado.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que aspas fazem interpolação de variável?",
+                        verso: "As aspas duplas.",
+                    },
+                    {
+                        frente: "O que as aspas simples fazem?",
+                        verso: "Tratam o conteúdo como texto literal.",
+                    },
+                    {
+                        frente: "Para que serve o heredoc?",
+                        verso: "Escrever blocos longos, com interpolação.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que a comparação simples faz antes de comparar?",
+                        verso: "Converte os tipos.",
+                    },
+                    {
+                        frente: "O que a comparação estrita exige?",
+                        verso: "Mesmo valor e mesmo tipo.",
+                    },
+                    {
+                        frente: "Qual das duas é a recomendada?",
+                        verso: "A estrita, por evitar surpresa.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que o operador de coalescência trata?",
+                        verso: "Valor ausente.",
+                    },
+                    {
+                        frente: "O que o operador seguro para nulo trata?",
+                        verso: "Objeto ausente.",
+                    },
+                    {
+                        frente: "O que os dois juntos cobrem?",
+                        verso: "Quase todo caso de nulo do dia a dia.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "Como o match compara os braços?",
+                        verso: "De forma estrita, sem conversão de tipo.",
+                    },
+                    {
+                        frente: "O que o match devolve?",
+                        verso: "Uma expressão, que pode ser atribuída.",
+                    },
+                    {
+                        frente: "O que acontece se nenhum braço casar?",
+                        verso: "Um erro é lançado.",
+                    },
+                ],
+            },
+        },
+    },
+};


### PR DESCRIPTION
Abre a trilha de PHP.

## O que entra
- Módulo 1, primeiros passos: o código que fica no servidor, o servidor embutido para desenvolver, a variável com cifrão e a tipagem dinâmica, o escape obrigatório de todo dado externo, e a diferença entre instalar e atualizar pelo Composer.
- Módulo 2, tipos e operadores: os quatro escalares e o risco da conversão implícita, as aspas que interpolam contra as que não interpolam, a comparação estrita como padrão, os operadores de valor e objeto ausentes, e o match sem conversão de tipo.

30 cartas para as 10 aulas dos dois módulos.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, nenhuma aula dos módulos 1 e 2 sem carta.

Empilhado sobre #597.
