### PR TITLE
feat: cartões dos módulos 3 e 4 de Ruby on Rails

### DIFF
--- a/backend/scripts/data/flashcards/ruby-on-rails.ts
+++ b/backend/scripts/data/flashcards/ruby-on-rails.ts
@@ -174,5 +174,169 @@ export const rubyOnRails: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que nunca fazer com uma migration já aplicada?",
+                        verso: "Editar, se ela já rodou em outro ambiente.",
+                    },
+                    {
+                        frente: "Por que a edição não chega lá?",
+                        verso: "Ela consta como executada, e não roda de novo.",
+                    },
+                    {
+                        frente: "O que fazer em vez disso?",
+                        verso: "Criar uma migration nova com a correção.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que a interface de consulta monta antes de executar?",
+                        verso: "A consulta, encadeando condições.",
+                    },
+                    {
+                        frente: "Quando a consulta é realmente executada?",
+                        verso: "Quando o resultado é usado.",
+                    },
+                    {
+                        frente: "O que um model representa?",
+                        verso: "Uma tabela, com cada instância sendo uma linha.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Onde a validação roda?",
+                        verso: "Antes de gravar, no próprio model.",
+                    },
+                    {
+                        frente: "O que um callback permite?",
+                        verso: "Rodar código em pontos do ciclo de vida do registro.",
+                    },
+                    {
+                        frente: "Que risco o callback traz?",
+                        verso: "Efeito escondido, disparado longe de quem salvou.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que a associação de pertencimento guarda?",
+                        verso: "A chave estrangeira, do lado que pertence.",
+                    },
+                    {
+                        frente: "O que a associação de posse declara?",
+                        verso: "Que o registro tem um ou vários do outro lado.",
+                    },
+                    {
+                        frente: "O que a associação através de outra permite?",
+                        verso: "Alcançar registros distantes por um caminho declarado.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que um escopo nomeia?",
+                        verso: "Uma condição de consulta reutilizável.",
+                    },
+                    {
+                        frente: "O que provoca a consulta em cascata?",
+                        verso: "Carregar a associação item a item, dentro da lista.",
+                    },
+                    {
+                        frente: "O que resolve esse problema?",
+                        verso: "Carregar as associações junto, de uma vez.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Que ataque a autenticação de tempo constante evita?",
+                        verso: "Descobrir emails cadastrados pelo tempo de resposta.",
+                    },
+                    {
+                        frente: "O que ela mantém igual nos dois casos?",
+                        verso: "O tempo, com email inexistente ou com senha errada.",
+                    },
+                    {
+                        frente: "O que o gerador de autenticação entrega?",
+                        verso: "As telas, o model e as rotas de login prontos.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que o Rails inclui em todo formulário por padrão?",
+                        verso: "O token contra requisição forjada.",
+                    },
+                    {
+                        frente: "O que o cookie de sessão guarda?",
+                        verso: "O identificador da sessão, assinado.",
+                    },
+                    {
+                        frente: "Que proteção o framework aplica na saída da view?",
+                        verso: "O escape automático do conteúdo.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que pergunta a autorização responde?",
+                        verso: "O que aquele usuário pode fazer.",
+                    },
+                    {
+                        frente: "Onde a verificação precisa ficar?",
+                        verso: "No servidor, antes de executar a ação.",
+                    },
+                    {
+                        frente: "O que esconder o link na tela é?",
+                        verso: "Experiência de uso, e não controle de acesso.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que um mailer é, na estrutura?",
+                        verso: "Uma classe parecida com um controller, para emails.",
+                    },
+                    {
+                        frente: "O que a view do mailer monta?",
+                        verso: "O corpo da mensagem.",
+                    },
+                    {
+                        frente: "Como o envio deve acontecer em produção?",
+                        verso: "Em segundo plano, para não travar a requisição.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que validar sempre no arquivo enviado?",
+                        verso: "O tipo e o tamanho.",
+                    },
+                    {
+                        frente: "Que risco aceitar qualquer arquivo traz?",
+                        verso: "Encher o disco e servir conteúdo perigoso.",
+                    },
+                    {
+                        frente: "O que o Active Storage abstrai?",
+                        verso: "Onde o arquivo fica guardado, local ou na nuvem.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de Ruby on Rails.

## O que entra
- Módulo 3, Active Record: a migration aplicada que não se edita, a consulta montada antes de executar, validações com o risco dos callbacks, os tipos de associação, e a consulta em cascata com o carregamento junto.
- Módulo 4, autenticação e recursos: o tempo constante que impede descobrir emails cadastrados, as proteções que o Rails já liga, a autorização verificada no servidor, o mailer enviando em segundo plano, e a validação obrigatória de tipo e tamanho no upload.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #607.
