### PR TITLE
feat: cartões dos módulos 3 e 4 de Spring Boot

### DIFF
--- a/backend/scripts/data/flashcards/spring-boot.ts
+++ b/backend/scripts/data/flashcards/spring-boot.ts
@@ -174,5 +174,169 @@ export const springBoot: CartasDaTrilha = {
                 ],
             },
         },
+        3: {
+            1: {
+                neutra: [
+                    {
+                        frente: "Por que gravar enum pela posição é perigoso?",
+                        verso: "Quebra quando alguém acrescenta um valor no meio da lista.",
+                    },
+                    {
+                        frente: "Como gravar o enum com segurança?",
+                        verso: "Pelo nome, e não pela posição.",
+                    },
+                    {
+                        frente: "O que uma entidade representa?",
+                        verso: "Uma tabela, mapeada para uma classe.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "O que um repository entrega sem código?",
+                        verso: "As operações básicas de acesso ao banco.",
+                    },
+                    {
+                        frente: "O que um método de consulta derivado usa?",
+                        verso: "O próprio nome do método para montar a consulta.",
+                    },
+                    {
+                        frente: "Quando escrever a consulta à mão?",
+                        verso: "Quando o nome derivado ficaria ilegível.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "Que ajuste torna a consulta em cascata visível?",
+                        verso: "Ligar a exibição do SQL em desenvolvimento.",
+                    },
+                    {
+                        frente: "Como o problema aparece no console?",
+                        verso: "Cem consultas iguais, em sequência.",
+                    },
+                    {
+                        frente: "O que resolve o problema na consulta?",
+                        verso: "Trazer a associação junto, numa consulta só.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "O que uma transação garante?",
+                        verso: "Tudo ou nada nas operações do bloco.",
+                    },
+                    {
+                        frente: "Onde a fronteira da transação costuma ficar?",
+                        verso: "No serviço, e não no repositório.",
+                    },
+                    {
+                        frente: "O que provoca o desfazimento por padrão?",
+                        verso: "Uma exceção não verificada.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que o Flyway versiona?",
+                        verso: "As mudanças de schema, em arquivos numerados.",
+                    },
+                    {
+                        frente: "O que ele faz ao subir a aplicação?",
+                        verso: "Aplica o que ainda falta, na ordem.",
+                    },
+                    {
+                        frente: "O que nunca fazer com uma migration já aplicada?",
+                        verso: "Alterar o arquivo, porque o resumo deixa de bater.",
+                    },
+                ],
+            },
+        },
+        4: {
+            1: {
+                neutra: [
+                    {
+                        frente: "O que a segurança do Spring é, por dentro?",
+                        verso: "Uma cadeia de filtros na frente da aplicação.",
+                    },
+                    {
+                        frente: "O que cada filtro decide?",
+                        verso: "Se a requisição segue, e com qual identidade.",
+                    },
+                    {
+                        frente: "Onde a configuração dessa cadeia é declarada?",
+                        verso: "Numa classe de configuração da aplicação.",
+                    },
+                ],
+            },
+            2: {
+                neutra: [
+                    {
+                        frente: "Que mensagem de erro de login usar?",
+                        verso: "Apenas que o email ou a senha estão incorretos.",
+                    },
+                    {
+                        frente: "O que dizer qual dos dois falhou entrega?",
+                        verso: "A lista de emails cadastrados.",
+                    },
+                    {
+                        frente: "Como a senha precisa ser guardada?",
+                        verso: "Com hash de algoritmo próprio para senha.",
+                    },
+                ],
+            },
+            3: {
+                neutra: [
+                    {
+                        frente: "O que torna a autenticação sem estado possível?",
+                        verso: "O token carregar a identidade assinada.",
+                    },
+                    {
+                        frente: "O que o servidor deixa de guardar?",
+                        verso: "A sessão do usuário.",
+                    },
+                    {
+                        frente: "Que problema o token sem estado cria?",
+                        verso: "Revogar antes do vencimento fica difícil.",
+                    },
+                ],
+            },
+            4: {
+                neutra: [
+                    {
+                        frente: "Que pergunta a autorização responde?",
+                        verso: "O que aquela identidade pode fazer.",
+                    },
+                    {
+                        frente: "Onde a regra pode ser declarada?",
+                        verso: "Na cadeia de filtros ou por anotação no método.",
+                    },
+                    {
+                        frente: "O que testar em cada permissão?",
+                        verso: "O acesso de quem pode e a negação de quem não pode.",
+                    },
+                ],
+            },
+            5: {
+                neutra: [
+                    {
+                        frente: "O que a política de origem cruzada controla?",
+                        verso: "Quais sites do navegador podem chamar a sua API.",
+                    },
+                    {
+                        frente: "Onde os segredos nunca devem ficar?",
+                        verso: "No código nem no repositório.",
+                    },
+                    {
+                        frente: "Que funcionalidade é candidata a requisição forjada?",
+                        verso: "Aquela em que o usuário informa uma URL para o servidor buscar.",
+                    },
+                ],
+            },
+        },
     },
 };


### PR DESCRIPTION
Continua a trilha de Spring Boot.

## O que entra
- Módulo 3, persistência: o enum gravado pela posição como bomba-relógio, os métodos de consulta derivados do nome, a consulta em cascata visível ao ligar o SQL, a fronteira da transação no serviço, e o Flyway com arquivos que não se alteram depois de aplicados.
- Módulo 4, segurança: a cadeia de filtros por dentro, a mensagem de login que não entrega a lista de emails, o token sem estado com a dificuldade de revogar, os dois testes por permissão, e a política de origem cruzada com o candidato clássico a requisição forjada.

30 cartas novas, 60 na trilha.

## Conferência
Seeder rodado num Postgres efêmero com a estrutura de produção: 30 criadas, 30 já existiam, nenhuma aula dos módulos 1 a 4 sem carta.

Empilhado sobre #610.
