### PR TITLE
feat: revisão liberada para qualquer área, sem exigir a trilha feita

### DIFF
--- a/backend/src/controllers/FlashcardController.ts
+++ b/backend/src/controllers/FlashcardController.ts
@@ -76,7 +76,7 @@ export const getPontosFracos = async (req: Request, res: Response, next: NextFun
 
 export const getRevisaoTrilha = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        res.json(await revisaoDaTrilha(req.userId!, String(req.params.trailId)));
+        res.json(await revisaoDaTrilha(String(req.params.trailId)));
     } catch (err) {
         next(err);
     }
@@ -84,7 +84,7 @@ export const getRevisaoTrilha = async (req: Request, res: Response, next: NextFu
 
 export const getContagemTrilha = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        res.json(await contarRevisaoDaTrilha(req.userId!, String(req.params.trailId)));
+        res.json(await contarRevisaoDaTrilha(String(req.params.trailId)));
     } catch (err) {
         next(err);
     }

--- a/backend/src/services/flashcard.service.ts
+++ b/backend/src/services/flashcard.service.ts
@@ -5,12 +5,11 @@ import {
     cardReviews,
     cardReports,
     lessons,
-    lessonProgress,
     modules,
     trails,
     glossary,
 } from "../../schema.ts";
-import { and, asc, count, desc, eq, inArray, isNotNull, lte, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, isNotNull, lte, notInArray, sql } from "drizzle-orm";
 import { AppError } from "../errors/AppError.ts";
 
 /**
@@ -301,21 +300,70 @@ interface CartaoNaFila {
     aulaId: string | null;
 }
 
+/** O mínimo que a fila precisa saber de cada carta: quem ela é e quando vence. */
+interface NaFila {
+    origem: "flashcard" | "glossario";
+    origemId: string;
+    proximaRevisao: Date;
+    // Carta que ainda não existe no baralho, vinda direto do catálogo. Só serve de
+    // desempate na ordenação, para a carta com histórico ganhar da gêmea sem estado.
+    novo?: boolean;
+}
+
 /**
- * A fila do dia: cartões vencidos, do mais atrasado para o mais recente.
+ * As cartas do catálogo das trilhas escolhidas que ainda não estão no baralho.
+ *
+ * É o que permite revisar uma área inteira sem ter feito a trilha. Elas entram
+ * vencendo agora, que é o mesmo que o baralho faz com carta recém-aberta, e só
+ * viram linha em user_cards quando o aluno responde a primeira vez.
+ */
+async function novasDoCatalogo(
+    userId: string,
+    trilhas: string[],
+    limite: number,
+): Promise<NaFila[]> {
+    const jaNoBaralho = db
+        .select({ id: userCards.origemId })
+        .from(userCards)
+        .where(and(eq(userCards.userId, userId), eq(userCards.origem, "flashcard")));
+
+    const linhas = await db
+        .select({ id: flashcards.id })
+        .from(flashcards)
+        .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
+        .where(
+            and(
+                inArray(lessons.trailId, trilhas),
+                eq(lessons.published, true),
+                notInArray(flashcards.id, jaNoBaralho),
+            ),
+        )
+        .limit(limite);
+
+    const agora = new Date();
+    return linhas.map((l) => ({
+        origem: "flashcard" as const,
+        origemId: l.id,
+        proximaRevisao: agora,
+        novo: true,
+    }));
+}
+
+/**
+ * A fila de revisão do conteúdo escolhido.
+ *
+ * Serve TUDO do conteúdo escolhido, e não só o que venceu hoje. A tela da trilha
+ * sempre funcionou assim, e ver "4 cartas" na sala de revisão e "116" no botão da
+ * trilha, para o mesmo conteúdo, é diferença que ninguém consegue explicar para
+ * quem está estudando. As duas fazem a mesma coisa, então entregam o mesmo número.
+ *
+ * Escolher uma trilha não exige tê-la estudado: o que o aluno ainda não tem no
+ * baralho entra do catálogo, como carta nova. Sem escolha, a fila continua sendo o
+ * baralho dele e nada mais, porque ali o pedido é "o meu", não "aquela área".
  *
  * Sem teto de sessão de propósito: quem quiser vara o baralho de uma vez, e quem não
  * quiser para na hora que cansar, que dá no mesmo. O limite alto que sobra é só uma
  * trava de payload, para um baralho gigante não virar uma resposta de megabytes.
- */
-/**
- * A fila de revisão do conteúdo escolhido.
- *
- * Serve TUDO que o aluno já estudou naquele conteúdo, e não só o que venceu hoje.
- * A tela da trilha sempre funcionou assim, e ver "4 cartas" na sala de revisão e
- * "116" no botão da trilha, para o mesmo conteúdo, é diferença que ninguém
- * consegue explicar para quem está estudando. As duas fazem a mesma coisa, então
- * entregam o mesmo número.
  *
  * O agendador não sai de cena, muda de papel: ele deixa de trancar o que aparece e
  * passa a mandar na PRIORIDADE. A ordem é do mais atrasado para o mais adiantado,
@@ -330,24 +378,29 @@ export async function filaDoDia(
     filtro?: { trilhas?: string[]; glossario?: boolean },
 ): Promise<CartaoNaFila[]> {
     const meus = eq(userCards.userId, userId);
+    const doBaralho = {
+        origem: userCards.origem,
+        origemId: userCards.origemId,
+        proximaRevisao: userCards.proximaRevisao,
+    };
 
     // Sem filtro a fila é o baralho inteiro. Com filtro, a seleção de trilhas e o
     // glossário são somados: dá para revisar duas trilhas juntas, ou só o glossário.
     const escolheu = filtro && (filtro.trilhas?.length || filtro.glossario);
-    let linhas;
+    let linhas: NaFila[];
     if (!escolheu) {
         linhas = await db
-            .select()
+            .select(doBaralho)
             .from(userCards)
             .where(meus)
             .orderBy(asc(userCards.proximaRevisao))
             .limit(limite);
     } else {
-        const partes = [];
+        const partes: Promise<NaFila[]>[] = [];
         if (filtro.trilhas?.length) {
             partes.push(
                 db
-                    .select({ uc: userCards })
+                    .select(doBaralho)
                     .from(userCards)
                     .innerJoin(
                         flashcards,
@@ -359,14 +412,14 @@ export async function filaDoDia(
                     .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
                     .where(and(meus, inArray(lessons.trailId, filtro.trilhas)))
                     .orderBy(asc(userCards.proximaRevisao))
-                    .limit(limite)
-                    .then((r) => r.map((x) => x.uc)),
+                    .limit(limite),
             );
+            partes.push(novasDoCatalogo(userId, filtro.trilhas, limite));
         }
         if (filtro.glossario) {
             partes.push(
                 db
-                    .select()
+                    .select(doBaralho)
                     .from(userCards)
                     .where(and(meus, eq(userCards.origem, "glossario")))
                     .orderBy(asc(userCards.proximaRevisao))
@@ -375,7 +428,11 @@ export async function filaDoDia(
         }
         linhas = (await Promise.all(partes))
             .flat()
-            .sort((a, b) => a.proximaRevisao.getTime() - b.proximaRevisao.getTime())
+            .sort(
+                (a, b) =>
+                    a.proximaRevisao.getTime() - b.proximaRevisao.getTime() ||
+                    Number(a.novo ?? false) - Number(b.novo ?? false),
+            )
             .slice(0, limite);
     }
     if (!linhas.length) return [];
@@ -497,9 +554,9 @@ export async function responder(
             ),
         );
 
-    // Sem estado o cartão pode ser novo de verdade (autorado depois de o aluno
-    // concluir a aula) ou de aula que ele nunca fez. O primeiro caso entra agora; o
-    // segundo é recusado, senão daria para pescar resposta de aula não estudada.
+    // Sem estado, o cartão entra no baralho agora. É por aqui que a revisão livre
+    // materializa a carta: ela é servida do catálogo e só vira linha de user_cards
+    // quando o aluno se avalia pela primeira vez.
     const estado = atual ?? (await abrirCartaoAvulso(userId, origem, origemId));
 
     const dias = diasDesde(estado.ultimaRevisao);
@@ -536,9 +593,12 @@ export async function responder(
 }
 
 /**
- * Abre um cartão solto no baralho, para o caso de ele ter sido autorado depois de o
- * aluno concluir a aula. Só vale para aula concluída, e termo de glossário nunca
- * passa por aqui porque não tem aula a conferir.
+ * Abre um cartão solto no baralho, na primeira vez que o aluno responde a ele.
+ *
+ * Cobre os dois caminhos que chegam sem linha em user_cards: o cartão autorado
+ * depois de a aula ter sido concluída, e a carta de área que o aluno escolheu
+ * revisar sem ter feito a trilha. Basta a aula estar publicada; termo de glossário
+ * nunca passa por aqui porque só nasce junto da aula que o cita.
  */
 async function abrirCartaoAvulso(
     userId: string,
@@ -551,12 +611,8 @@ async function abrirCartaoAvulso(
         .select({ frente: flashcards.frente, trailId: lessons.trailId })
         .from(flashcards)
         .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
-        .innerJoin(
-            lessonProgress,
-            and(eq(lessonProgress.lessonId, lessons.id), eq(lessonProgress.userId, userId)),
-        )
-        .where(eq(flashcards.id, origemId));
-    if (!permitido) throw new AppError(404, "Cartão não encontrado no seu baralho.");
+        .where(and(eq(flashcards.id, origemId), eq(lessons.published, true)));
+    if (!permitido) throw new AppError(404, "Cartão não encontrado.");
 
     // Se a mesma pergunta já está aberta pelo outro trilho de linguagem, responder
     // aqui mexe naquele cartão em vez de abrir um segundo. Sem isso a gêmea
@@ -588,11 +644,16 @@ async function abrirCartaoAvulso(
 }
 
 /**
- * Revisão de uma trilha inteira, oferecida ao concluí-la. Diferente da fila do dia,
- * aqui não importa a data: o objetivo é passar pelo conteúdo todo de uma vez, e por
- * isso a ordem é a das aulas, não a do agendador.
+ * Revisão de uma trilha inteira, oferecida ao concluí-la e disponível a qualquer
+ * momento. Diferente da fila do dia, aqui não importa a data: o objetivo é passar
+ * pelo conteúdo todo de uma vez, e por isso a ordem é a das aulas, não a do
+ * agendador.
+ *
+ * Não exige progresso na trilha. Quem quiser revisar uma área que nunca estudou
+ * recebe o baralho inteiro dela, e cada carta entra no baralho pessoal quando for
+ * respondida.
  */
-export async function revisaoDaTrilha(userId: string, trailId: string) {
+export async function revisaoDaTrilha(trailId: string) {
     const cartoes = await db
         .select({
             id: flashcards.id,
@@ -604,15 +665,9 @@ export async function revisaoDaTrilha(userId: string, trailId: string) {
             trilhaId: trails.id,
         })
         .from(flashcards)
-        // O join com o progresso é o que garante a regra: só entra cartão de aula
-        // concluída, senão a revisão entregaria a resposta de aula não estudada.
         .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
         .innerJoin(modules, eq(modules.id, lessons.moduleId))
         .innerJoin(trails, eq(trails.id, lessons.trailId))
-        .innerJoin(
-            lessonProgress,
-            and(eq(lessonProgress.lessonId, lessons.id), eq(lessonProgress.userId, userId)),
-        )
         .where(and(eq(lessons.trailId, trailId), eq(lessons.published, true)))
         .orderBy(asc(modules.position), asc(lessons.position), asc(flashcards.position));
 
@@ -631,60 +686,96 @@ export async function revisaoDaTrilha(userId: string, trailId: string) {
     return embaralhar(unicos).map((c) => ({ ...c, origem: "flashcard" as const }));
 }
 
-/** Quantos cartões a trilha já liberou para este aluno. Alimenta a chamada de revisão. */
-export async function contarRevisaoDaTrilha(userId: string, trailId: string) {
+/** Quantos cartões a trilha tem para revisar. Alimenta a chamada de revisão. */
+export async function contarRevisaoDaTrilha(trailId: string) {
     const [linha] = await db
         // Conta pergunta distinta, e não linha, pelo mesmo motivo do dedup em
         // revisaoDaTrilha: senão o botão promete mais cartas do que vai mostrar.
         .select({ n: sql<number>`count(distinct ${flashcards.frente})` })
         .from(flashcards)
         .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
-        .innerJoin(
-            lessonProgress,
-            and(eq(lessonProgress.lessonId, lessons.id), eq(lessonProgress.userId, userId)),
-        )
         .where(and(eq(lessons.trailId, trailId), eq(lessons.published, true)));
     return { total: Number(linha?.n ?? 0) };
 }
 
 /**
- * Os baralhos do aluno: uma linha por trilha que tem cartão dele, mais o glossário.
- * É a lista que a aba mostra para ele escolher o que revisar, sozinho ou misturado.
+ * As áreas que o aluno pode revisar: toda trilha publicada que tem carta, mais o
+ * glossário. É a lista que a aba mostra para ele escolher o que revisar, sozinho ou
+ * misturado.
+ *
+ * Vem o catálogo inteiro, e não só o que ele já estudou, porque escolher a área não
+ * depende mais de ter feito a trilha. Cada linha diz as duas coisas: `total` é o que
+ * ele já tem no baralho daquela trilha e `disponiveis` é o tamanho da área. Quem
+ * nunca abriu a trilha aparece com total zero e o baralho cheio esperando.
  */
 export async function baralhos(userId: string) {
     const agora = new Date();
     const vencido = sql<number>`count(*) filter (where ${userCards.proximaRevisao} <= ${agora})`;
 
-    const porTrilha = await db
-        .select({
-            trilhaId: trails.id,
-            nome: trails.name,
-            vencidos: vencido,
-            total: count(),
-        })
-        .from(userCards)
-        .innerJoin(
-            flashcards,
-            and(eq(userCards.origem, "flashcard"), eq(flashcards.id, userCards.origemId)),
-        )
-        .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
-        .innerJoin(trails, eq(trails.id, lessons.trailId))
-        .where(eq(userCards.userId, userId))
-        .groupBy(trails.id, trails.name)
-        .orderBy(trails.name);
+    const [porTrilha, catalogo, [gloss]] = await Promise.all([
+        db
+            .select({
+                trilhaId: trails.id,
+                nome: trails.name,
+                vencidos: vencido,
+                total: count(),
+            })
+            .from(userCards)
+            .innerJoin(
+                flashcards,
+                and(eq(userCards.origem, "flashcard"), eq(flashcards.id, userCards.origemId)),
+            )
+            .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
+            .innerJoin(trails, eq(trails.id, lessons.trailId))
+            .where(eq(userCards.userId, userId))
+            .groupBy(trails.id, trails.name)
+            .orderBy(trails.name),
+        // Pergunta distinta, e não linha, pelo mesmo motivo de contarRevisaoDaTrilha:
+        // trilha com trilho de linguagem tem a mesma carta duas vezes.
+        db
+            .select({
+                trilhaId: trails.id,
+                nome: trails.name,
+                disponiveis: sql<number>`count(distinct ${flashcards.frente})`,
+            })
+            .from(flashcards)
+            .innerJoin(lessons, eq(lessons.id, flashcards.lessonId))
+            .innerJoin(trails, eq(trails.id, lessons.trailId))
+            .where(eq(lessons.published, true))
+            .groupBy(trails.id, trails.name)
+            .orderBy(trails.name),
+        db
+            .select({ vencidos: vencido, total: count() })
+            .from(userCards)
+            .where(and(eq(userCards.userId, userId), eq(userCards.origem, "glossario"))),
+    ]);
 
-    const [gloss] = await db
-        .select({ vencidos: vencido, total: count() })
-        .from(userCards)
-        .where(and(eq(userCards.userId, userId), eq(userCards.origem, "glossario")));
+    const meus = new Map(porTrilha.map((t) => [t.trilhaId, t]));
+    const trilhas = catalogo.map((c) => ({
+        id: c.trilhaId,
+        nome: c.nome,
+        vencidos: Number(meus.get(c.trilhaId)?.vencidos ?? 0),
+        total: Number(meus.get(c.trilhaId)?.total ?? 0),
+        disponiveis: Number(c.disponiveis),
+    }));
 
-    return {
-        trilhas: porTrilha.map((t) => ({
+    // Trilha despublicada some do catálogo mas pode ter deixado carta no baralho de
+    // alguém. Some no fim para o aluno ainda conseguir revisar o que já é dele.
+    const noCatalogo = new Set(trilhas.map((t) => t.id));
+    for (const t of porTrilha) {
+        if (noCatalogo.has(t.trilhaId)) continue;
+        trilhas.push({
             id: t.trilhaId,
             nome: t.nome,
             vencidos: Number(t.vencidos),
             total: Number(t.total),
-        })),
+            disponiveis: Number(t.total),
+        });
+    }
+    trilhas.sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+
+    return {
+        trilhas,
         glossario: { vencidos: Number(gloss?.vencidos ?? 0), total: Number(gloss?.total ?? 0) },
     };
 }
@@ -923,8 +1014,12 @@ export async function historicoSessoes(userId: string, limite = 20) {
 }
 
 /**
- * Sinaliza uma carta com problema. Só vale para carta que está no baralho do aluno,
- * senão viraria porta para reportar conteúdo que ele nunca viu.
+ * Sinaliza uma carta com problema.
+ *
+ * Antes exigia a carta no baralho, o que virou trava boba com a revisão livre: na
+ * área que o aluno nunca estudou a carta só entra no baralho quando ele responde, e
+ * o erro que ele quer reportar costuma estar na primeira que aparece. Basta a carta
+ * existir; quem está vendo uma carta pode reportá-la.
  */
 export async function reportarCartao(
     userId: string,
@@ -932,17 +1027,14 @@ export async function reportarCartao(
     origemId: string,
     comentario?: string,
 ) {
-    const [tem] = await db
-        .select({ id: userCards.id })
-        .from(userCards)
-        .where(
-            and(
-                eq(userCards.userId, userId),
-                eq(userCards.origem, origem),
-                eq(userCards.origemId, origemId),
-            ),
-        );
-    if (!tem) throw new AppError(404, "Cartão não encontrado no seu baralho.");
+    const [existe] =
+        origem === "flashcard"
+            ? await db
+                  .select({ id: flashcards.id })
+                  .from(flashcards)
+                  .where(eq(flashcards.id, origemId))
+            : await db.select({ id: glossary.id }).from(glossary).where(eq(glossary.id, origemId));
+    if (!existe) throw new AppError(404, "Cartão não encontrado.");
 
     await db
         .insert(cardReports)

--- a/backend/tests/flashcard.test.ts
+++ b/backend/tests/flashcard.test.ts
@@ -14,8 +14,10 @@ import {
 import { and, eq } from "drizzle-orm";
 import {
     abrirCartoesDaAula,
+    baralhos,
     contarRevisaoDaTrilha,
     filaDoDia,
+    responder,
     revisaoDaTrilha,
 } from "../src/services/flashcard.service.ts";
 
@@ -121,7 +123,7 @@ describe("cartões em trilha com trilhos de linguagem", () => {
         await concluir(aluno.id, js.id);
         await concluir(aluno.id, py.id);
 
-        const cartoes = await revisaoDaTrilha(aluno.id, trilha.id);
+        const cartoes = await revisaoDaTrilha(trilha.id);
         const perguntas = cartoes.map((c) => c.frente);
 
         assert.equal(new Set(perguntas).size, perguntas.length, "pergunta repetida na revisão");
@@ -135,8 +137,8 @@ describe("cartões em trilha com trilhos de linguagem", () => {
         await concluir(aluno.id, js.id);
         await concluir(aluno.id, py.id);
 
-        const { total } = await contarRevisaoDaTrilha(aluno.id, trilha.id);
-        const cartoes = await revisaoDaTrilha(aluno.id, trilha.id);
+        const { total } = await contarRevisaoDaTrilha(trilha.id);
+        const cartoes = await revisaoDaTrilha(trilha.id);
 
         assert.equal(total, cartoes.length);
     });
@@ -216,7 +218,7 @@ describe("a fila serve a trilha inteira, e não só o que venceu", () => {
                 .where(eq(userCards.id, c.id));
 
         const sala = await filaDoDia(aluno.id, 500, { trilhas: [trilha.id] });
-        const daTrilha = await revisaoDaTrilha(aluno.id, trilha.id);
+        const daTrilha = await revisaoDaTrilha(trilha.id);
 
         assert.equal(sala.length, daTrilha.length);
         assert.deepEqual(
@@ -261,6 +263,124 @@ describe("a fila serve a trilha inteira, e não só o que venceu", () => {
     });
 });
 
+/**
+ * Uma trilha publicada com N cartas e ninguém matriculado: nenhum progresso,
+ * nenhuma carta em baralho. É o cenário da revisão livre.
+ */
+async function trilhaCrua(quantas: number, nome = "Área nova") {
+    const [trilha] = await db
+        .insert(trails)
+        .values({ name: nome, trailLevel: "iniciante", description: "x" })
+        .returning();
+    const [modulo] = await db
+        .insert(modules)
+        .values({ trailId: trilha.id, title: "M1", position: 1 })
+        .returning();
+    const [aula] = await db
+        .insert(lessons)
+        .values({
+            trailId: trilha.id,
+            moduleId: modulo.id,
+            title: "Aula",
+            position: 1,
+            published: true,
+        })
+        .returning();
+    await db.insert(flashcards).values(
+        Array.from({ length: quantas }, (_, i) => ({
+            lessonId: aula.id,
+            frente: `Crua ${i}?`,
+            verso: `Resposta ${i}`,
+            position: i,
+        })),
+    );
+    return { trilha, aula };
+}
+
+describe("revisar uma área sem ter feito a trilha", () => {
+    beforeEach(limparBanco);
+
+    test("a revisão da trilha entrega tudo mesmo sem nenhuma aula concluída", async () => {
+        const aluno = await novoAluno();
+        const { trilha } = await trilhaCrua(7);
+
+        const cartoes = await revisaoDaTrilha(trilha.id);
+
+        assert.equal(cartoes.length, 7);
+        assert.equal((await contarRevisaoDaTrilha(trilha.id)).total, 7);
+        // O baralho continua intocado: só responder é que abre carta.
+        const meu = await db.select().from(userCards).where(eq(userCards.userId, aluno.id));
+        assert.equal(meu.length, 0);
+    });
+
+    test("a sala serve a área escolhida mesmo sem progresso nela", async () => {
+        const aluno = await novoAluno();
+        const { trilha } = await trilhaCrua(5);
+
+        const fila = await filaDoDia(aluno.id, 500, { trilhas: [trilha.id] });
+
+        assert.equal(fila.length, 5);
+    });
+
+    test("a área escolhida mistura o que já é do aluno com o que falta", async () => {
+        const aluno = await novoAluno();
+        const { trilha, aula } = await trilhaCrua(6);
+        // Três cartas já no baralho; as outras três continuam só no catálogo.
+        const cartas = await db.select().from(flashcards).where(eq(flashcards.lessonId, aula.id));
+        await db.insert(userCards).values(
+            cartas.slice(0, 3).map((c) => ({
+                userId: aluno.id,
+                origem: "flashcard" as const,
+                origemId: c.id,
+                proximaRevisao: new Date(),
+            })),
+        );
+
+        const fila = await filaDoDia(aluno.id, 500, { trilhas: [trilha.id] });
+        const perguntas = fila.map((c) => c.frente);
+
+        assert.equal(perguntas.length, 6, "a fila tem de somar baralho e catálogo");
+        assert.equal(new Set(perguntas).size, 6, "carta do baralho não pode vir duplicada");
+    });
+
+    test("sem escolher área, a fila continua sendo só o baralho do aluno", async () => {
+        const aluno = await novoAluno();
+        await aulaCom(4, aluno.id);
+        await trilhaCrua(9, "Área que ele nunca viu");
+
+        const fila = await filaDoDia(aluno.id);
+
+        assert.equal(fila.length, 4, "o baralho inteiro não pode virar o catálogo inteiro");
+    });
+
+    test("responder carta de aula nunca estudada abre ela no baralho", async () => {
+        const aluno = await novoAluno();
+        const { aula } = await trilhaCrua(3);
+        const [carta] = await db.select().from(flashcards).where(eq(flashcards.lessonId, aula.id));
+
+        await responder(aluno.id, "flashcard", carta.id, "facil");
+
+        const [aberta] = await db
+            .select()
+            .from(userCards)
+            .where(and(eq(userCards.userId, aluno.id), eq(userCards.origemId, carta.id)));
+        assert.ok(aberta, "a carta tinha de entrar no baralho na primeira resposta");
+        assert.equal(aberta.repeticoes, 1);
+    });
+
+    test("a lista de áreas traz trilha que o aluno nunca abriu", async () => {
+        const aluno = await novoAluno();
+        const { trilha } = await trilhaCrua(11, "Zebra");
+
+        const { trilhas } = await baralhos(aluno.id);
+        const zebra = trilhas.find((t) => t.id === trilha.id);
+
+        assert.ok(zebra, "a área tinha de aparecer para escolher");
+        assert.equal(zebra.total, 0, "ele não tem carta dela no baralho");
+        assert.equal(zebra.disponiveis, 11, "e a área inteira está disponível");
+    });
+});
+
 describe("ordem da fila de revisão", () => {
     beforeEach(limparBanco);
 
@@ -300,7 +420,7 @@ describe("ordem da fila de revisão", () => {
 
         const ordens = new Set<string>();
         for (let i = 0; i < 6; i++) {
-            ordens.add((await revisaoDaTrilha(aluno.id, trilha.id)).map((c) => c.frente).join("|"));
+            ordens.add((await revisaoDaTrilha(trilha.id)).map((c) => c.frente).join("|"));
         }
 
         assert.ok(ordens.size > 1, "a revisão da trilha saiu na mesma ordem nas seis vezes");

--- a/frontend/src/pages/Revisao/index.tsx
+++ b/frontend/src/pages/Revisao/index.tsx
@@ -173,6 +173,9 @@ export function Revisao() {
       // queremos mostrar.
       if (!cartoes.length) {
         setVazio(true);
+        // O aviso mora dentro do painel de escolha. Começando pela sala, com o painel
+        // fechado, ele não seria visto e o clique pareceria não fazer nada.
+        setEscolhendo(true);
         return;
       }
       // A sessão fica guardada para sobreviver a um F5. As cartas não são guardadas:
@@ -300,6 +303,7 @@ export function Revisao() {
   function fecharEscolha() {
     setEscolhendo(false);
     setBusca('');
+    setVazio(false);
   }
 
   function alternarTrilha(id: string) {
@@ -524,8 +528,8 @@ export function Revisao() {
                   >
                     Escolher área
                   </button>
-                  <Link to="/trilhas" className="rev-sala__selecao">
-                    <span>Ou ir para as trilhas</span>
+                  <Link to="/trilhas" className="rev-sala__saida">
+                    Ou ir para as trilhas
                   </Link>
                 </>
               ) : (
@@ -852,12 +856,11 @@ export function Revisao() {
                 </p>
               )}
 
+              {/* O botão não é desabilitado quando a conta dá zero: quem marcou "todo
+                  o seu baralho" sem nunca ter estudado clicaria num botão morto, sem
+                  saber por quê. Clicando, o aviso acima diz o que fazer. */}
               <div className="rev-escolha__rodape">
-                <button
-                  className="btn btn--accent"
-                  onClick={() => void comecar()}
-                  disabled={escolhidos === 0}
-                >
+                <button className="btn btn--accent" onClick={() => void comecar()}>
                   Começar revisão
                 </button>
               </div>

--- a/frontend/src/pages/Revisao/index.tsx
+++ b/frontend/src/pages/Revisao/index.tsx
@@ -104,6 +104,9 @@ export function Revisao() {
   const [selecao, setSelecao] = useState<Set<string>>(new Set());
   const [comGlossario, setComGlossario] = useState(false);
   const [escolhendo, setEscolhendo] = useState(false);
+  // Busca da lista de áreas. Some junto com o painel, para não sobrar filtro
+  // invisível na próxima vez que ele abrir.
+  const [busca, setBusca] = useState('');
   const [vazio, setVazio] = useState(false);
   // Quantas cartas a sessão entrega, como o aluno digitou. Vazio é "vai até acabar".
   const [limiteTexto, setLimiteTexto] = useState('');
@@ -176,7 +179,7 @@ export function Revisao() {
       // no retorno a fila é remontada do servidor e as já respondidas são tiradas
       // pela lista de "feitas".
       localStorage.setItem(SESSAO, JSON.stringify({ ...escolha, feitas: [] }));
-      setEscolhendo(false);
+      fecharEscolha();
       iniciarSessao(cartoes);
     } catch (err) {
       console.error('Falha ao montar a fila de revisão.', err);
@@ -294,6 +297,11 @@ export function Revisao() {
     return () => window.clearInterval(id);
   }, [atual?.id, modalAberto]);
 
+  function fecharEscolha() {
+    setEscolhendo(false);
+    setBusca('');
+  }
+
   function alternarTrilha(id: string) {
     setSelecao((antes) => {
       const nova = new Set(antes);
@@ -406,15 +414,19 @@ export function Revisao() {
         ...(baralhos?.trilhas ?? []).filter((t) => selecao.has(t.id)).map((t) => t.nome),
         ...(comGlossario ? ['Glossário'] : []),
       ].join(' + ');
-  // Quantas cartas a escolha atual tem, e não quantas venceram: a fila serve tudo
-  // que o aluno já estudou naquele conteúdo. Zero aqui significa que ele ainda não
-  // concluiu nenhuma aula do que marcou, e não que está em dia.
+  // Quantas cartas a escolha atual tem, e não quantas venceram: a fila serve o
+  // conteúdo inteiro. Sem escolha o número é o baralho do aluno; com uma área
+  // marcada é o tamanho dela, porque revisar área não depende de ter feito a trilha.
   const escolhidos = tudoMarcado
     ? (resumo?.total ?? 0)
     : (baralhos?.trilhas ?? [])
         .filter((t) => selecao.has(t.id))
-        .reduce((soma, t) => soma + t.total, 0) +
+        .reduce((soma, t) => soma + t.disponiveis, 0) +
       (comGlossario ? (baralhos?.glossario.total ?? 0) : 0);
+  // 87 áreas não cabem numa lista rolável sem busca.
+  const areas = (baralhos?.trilhas ?? []).filter((t) =>
+    busca.trim() ? t.nome.toLowerCase().includes(busca.trim().toLowerCase()) : true,
+  );
 
   return (
     <div className="home-shell">
@@ -455,7 +467,7 @@ export function Revisao() {
             </h1>
             <p className="rev-sala__sub">
               {trilhaId
-                ? 'Todos os cartões das aulas que você concluiu nesta trilha, na ordem em que estudou.'
+                ? 'Todos os cartões desta trilha, embaralhados.'
                 : 'Cartões que voltam hoje. Cada acerto empurra o próximo encontro para mais longe.'}
             </p>
           </div>
@@ -489,9 +501,9 @@ export function Revisao() {
             </div>
           )}
 
-          {/* Fila vazia agora só acontece por falta de aula concluída, e não por
-              estar em dia: a fila serve tudo que o aluno estudou. O texto muda
-              conforme o motivo: baralho inteiro sem carta, ou só a escolha atual. */}
+          {/* Fila vazia não significa mais "está tudo em dia", e nem "você não
+              estudou": a área pode ser escolhida sem ter feito a trilha. Sobrou o
+              caso de o baralho estar vazio e nenhuma área ter sido marcada. */}
           {!trilhaId && baralhos && fila === null && escolhidos === 0 && (
             <div className="rev-sala__aviso">
               <span className="rev-sala__check">
@@ -499,22 +511,27 @@ export function Revisao() {
               </span>
               {baralhoVazio ? (
                 <>
-                  <h3>Seu baralho começa na próxima aula</h3>
+                  <h3>Escolha uma área para começar</h3>
                   <p>
-                    As cartas nascem quando você conclui uma aula. Estude uma e ela já entra aqui
-                    para você rever nos próximos dias.
+                    Seu baralho ainda está vazio, mas você não precisa esperar: dá para revisar
+                    qualquer área agora, mesmo sem ter feito a trilha. Concluir uma aula também
+                    traz as cartas dela para cá sozinho.
                   </p>
-                  <Link to="/trilhas" className="btn btn--accent">
-                    Ir para as trilhas
+                  <button
+                    type="button"
+                    className="btn btn--accent"
+                    onClick={() => setEscolhendo(true)}
+                  >
+                    Escolher área
+                  </button>
+                  <Link to="/trilhas" className="rev-sala__selecao">
+                    <span>Ou ir para as trilhas</span>
                   </Link>
                 </>
               ) : (
                 <>
                   <h3>Nada por aqui ainda</h3>
-                  <p>
-                    Você ainda não concluiu nenhuma aula do que escolheu. Troque o conteúdo ou
-                    estude uma aula dessa trilha para as cartas nascerem.
-                  </p>
+                  <p>Não há cartas no que você escolheu. Marque outra área.</p>
                   <button
                     type="button"
                     className="rev-sala__selecao"
@@ -738,22 +755,28 @@ export function Revisao() {
             role="dialog"
             aria-modal="true"
             aria-label="Escolher o que revisar"
-            onClick={() => setEscolhendo(false)}
+            onClick={fecharEscolha}
           >
             <div className="rev-escolha" onClick={(e) => e.stopPropagation()}>
               <div className="rev-escolha__topo">
                 <h2>O que você quer revisar</h2>
-                <button
-                  className="rev-escolha__x"
-                  onClick={() => setEscolhendo(false)}
-                  aria-label="Fechar"
-                >
+                <button className="rev-escolha__x" onClick={fecharEscolha} aria-label="Fechar">
                   <X size={16} />
                 </button>
               </div>
               <p className="rev-escolha__ajuda">
-                Marque mais de um para embaralhar tudo na mesma sessão.
+                Qualquer área, tenha você feito a trilha ou não. Marque mais de uma para
+                embaralhar tudo na mesma sessão.
               </p>
+
+              <input
+                className="rev-busca"
+                type="search"
+                autoComplete="off"
+                placeholder="Buscar área"
+                value={busca}
+                onChange={(e) => setBusca(e.target.value)}
+              />
 
               <div className="rev-escolha__lista">
                 <button
@@ -765,7 +788,7 @@ export function Revisao() {
                   <span className="rev-item__nome">Todo o seu baralho</span>
                 </button>
 
-                {baralhos.trilhas.map((t) => {
+                {areas.map((t) => {
                   const marcado = selecao.has(t.id);
                   return (
                     <button
@@ -776,9 +799,16 @@ export function Revisao() {
                     >
                       <span className="rev-item__check">{marcado && <Check size={13} />}</span>
                       <span className="rev-item__nome">{t.nome}</span>
+                      {/* O tamanho da área, e quanto dela já é dele. Sem isso não dá
+                          para saber se marcar aquela linha rende 3 cartas ou 105. */}
+                      <span className="rev-item__n">
+                        {t.total ? `${t.total} de ${t.disponiveis}` : t.disponiveis}
+                      </span>
                     </button>
                   );
                 })}
+
+                {!areas.length && <p className="rev-escolha__ajuda">Nenhuma área com esse nome.</p>}
 
                 {baralhos.glossario.total > 0 && (
                   <button
@@ -816,8 +846,8 @@ export function Revisao() {
                   separando "não estudei nada ainda" de "escolhi o baralho errado". */}
               {vazio && (
                 <p className="rev-escolha__vazio">
-                  {baralhoVazio
-                    ? 'Você ainda não tem cartas. Elas nascem quando você conclui uma aula.'
+                  {tudoMarcado
+                    ? 'Seu baralho está vazio. Marque uma área para revisar mesmo sem ter feito a trilha.'
                     : 'Não há cartas no que você escolheu. Marque outro conteúdo.'}
                 </p>
               )}
@@ -826,7 +856,7 @@ export function Revisao() {
                 <button
                   className="btn btn--accent"
                   onClick={() => void comecar()}
-                  disabled={baralhoVazio}
+                  disabled={escolhidos === 0}
                 >
                   Começar revisão
                 </button>

--- a/frontend/src/services/flashcards.ts
+++ b/frontend/src/services/flashcards.ts
@@ -23,7 +23,10 @@ export interface Baralho {
   id: string;
   nome: string;
   vencidos: number;
+  /** Cartas desta trilha que já estão no baralho do aluno. */
   total: number;
+  /** Tamanho da área: tudo que ela tem para revisar, tendo ele estudado ou não. */
+  disponiveis: number;
 }
 
 export interface Baralhos {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -53,6 +53,13 @@
     filter 0.15s ease,
     background 0.15s ease;
 }
+/* Sem isto um botão desabilitado fica idêntico a um habilitado, e clicar nele não
+   faz nada nem explica por quê. */
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: none;
+}
 .btn--block {
   width: 100%;
   height: 50px;

--- a/frontend/src/styles/revisao.css
+++ b/frontend/src/styles/revisao.css
@@ -540,8 +540,33 @@
   color: var(--muted);
 }
 
+.rev-busca {
+  width: 100%;
+  margin-bottom: 10px;
+  padding: 9px 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-strong);
+  background: var(--input);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+}
+.rev-busca::placeholder {
+  color: var(--muted);
+}
+.rev-busca:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+/* flex e min-height zero para a lista encolher dentro do teto do painel: com o
+   catálogo inteiro ela passou de meia dúzia de linhas para dezenas, e sem isso ela
+   empurraria o rodapé para fora em vez de rolar. */
 .rev-escolha__lista {
   display: flex;
+  flex: 1;
+  min-height: 0;
   flex-direction: column;
   gap: 6px;
   overflow-y: auto;
@@ -597,6 +622,15 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* O tamanho da área, discreto: quem escolhe olha o nome, o número é conferência. */
+.rev-item__n {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .rev-escolha__quantas {

--- a/frontend/src/styles/revisao.css
+++ b/frontend/src/styles/revisao.css
@@ -156,6 +156,21 @@
   color: var(--accent);
 }
 
+/* A saída secundária do estado vazio é um link, e não um segundo botão: reusando a
+   pílula do seletor ela colava na de cima e as duas disputavam o clique. */
+.rev-sala__saida {
+  display: block;
+  width: fit-content;
+  margin: 18px auto 0;
+  color: var(--muted);
+  font-size: 13px;
+  border-bottom: 1px solid transparent;
+}
+.rev-sala__saida:hover {
+  color: var(--accent);
+  border-bottom-color: currentColor;
+}
+
 /* ---------- O modal da carta ---------- */
 
 .rev-modal {


### PR DESCRIPTION
Libera a revisão de qualquer área, mesmo sem ter feito a trilha.

Antes a carta só existia para quem concluiu a aula: três pontos do backend faziam junção com o progresso, e quem escolhesse uma área não estudada recebia fila vazia ou 404 ao responder.

## O que muda

- **Revisão da trilha** e **contagem** deixam de exigir progresso e passam a entregar a trilha publicada inteira. As duas perderam o parâmetro de usuário, porque não dependem mais de quem pergunta.
- **Responder** uma carta que não está no baralho passa a abri-la, em vez de recusar. É por aí que a carta de área nova entra no baralho pessoal, na primeira resposta.
- **A sala** passa a listar todas as áreas com carta, não só as que o aluno já tem. Cada linha traz o tamanho da área e quanto dela já é dele.
- **A fila com área escolhida** soma o baralho e o catálogo: o que ele já tem vem com o agendamento, o resto entra como carta nova vencendo agora. Sem área escolhida, a fila continua sendo só o baralho dele.
- **Reportar** deixa de exigir a carta no baralho. Na área nova a carta só entra ao ser respondida, e o erro que se quer reportar costuma estar na primeira que aparece.

## O agendador não muda

A curva continua mandando na prioridade e no reagendamento. Carta nova entra vencendo agora, que é o mesmo que o baralho já fazia com carta recém-aberta, e carta atrasada continua na frente. No empate entre uma carta com histórico e a gêmea sem estado, ganha a que tem histórico.

## Na tela

O seletor ganhou busca, porque passou de meia dúzia de linhas para o catálogo inteiro, e a lista agora rola dentro do painel em vez de empurrar o rodapé. Os textos de estado vazio deixaram de dizer que a carta nasce ao concluir a aula, já que não é mais a única porta.

## Conferência

- 135 testes de integração passando, 6 deles novos: trilha inteira sem progresso, contagem, sala servindo área não estudada, mistura de baralho com catálogo, resposta abrindo a carta e a área nova aparecendo na lista.
- Um teste guarda o caminho de trás: sem área escolhida, a fila continua sendo o baralho do aluno, para "todo o seu baralho" não virar o catálogo inteiro.
- Tipos limpos nos dois lados, build do front passando, lint sem apontar nada nos arquivos tocados.

Em rascunho até você validar local.
