### PR TITLE
feat: modo entrevista na tela de revisão

### DIFF
--- a/frontend/src/components/ModoEntrevista.tsx
+++ b/frontend/src/components/ModoEntrevista.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Check } from './Icons';
+import {
+  NIVEIS,
+  filaDeEntrevista,
+  obterResumo,
+  obterTopicos,
+  type Nivel,
+  type ResumoEntrevista,
+  type TopicoEntrevista,
+} from '../services/entrevista';
+import type { Cartao } from '../services/flashcards';
+
+// Quantas perguntas por sessão. Ensaio de entrevista é curto de propósito: passar
+// de vinte perguntas de uma vez não é ensaio, é maratona.
+const OPCOES_QUANTIDADE = [5, 10, 20];
+
+interface Props {
+  /** Entrega a fila pronta para a sala abrir a carta. */
+  onComecar: (cartoes: Cartao[]) => void;
+}
+
+/**
+ * O painel do modo entrevista: escolher o nível, os assuntos e o tamanho da sessão.
+ *
+ * Fica separado da revisão do dia porque são objetivos diferentes. Revisar trilha é
+ * fixar o que se estudou; treinar entrevista é ensaiar resposta. O que continua
+ * compartilhado é o essencial: mesmo baralho, mesmo agendamento e mesmas
+ * estatísticas, porque a carta respondida aqui volta pela fila do dia.
+ */
+export function ModoEntrevista({ onComecar }: Props) {
+  const [nivel, setNivel] = useState<Nivel>('junior');
+  const [topicos, setTopicos] = useState<TopicoEntrevista[]>([]);
+  const [escolhidos, setEscolhidos] = useState<Set<string>>(new Set());
+  const [resumo, setResumo] = useState<ResumoEntrevista | null>(null);
+  const [quantas, setQuantas] = useState(10);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+
+  const carregar = useCallback(async (alvo: Nivel) => {
+    setCarregando(true);
+    setErro('');
+    try {
+      const [lista, r] = await Promise.all([obterTopicos(alvo), obterResumo(alvo)]);
+      setTopicos(lista);
+      setResumo(r);
+    } catch (err) {
+      console.error('Falha ao carregar o modo entrevista.', err);
+      setErro('Não foi possível carregar os assuntos.');
+    } finally {
+      setCarregando(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void carregar(nivel);
+  }, [nivel, carregar]);
+
+  // Trocar de nível não pode carregar assunto que sumiu da lista, porque um tópico
+  // só de sênior deixa de existir ao voltar para estágio. A marcação é derivada em
+  // vez de sincronizada por efeito: assim não existe intervalo em que a contagem já
+  // mudou e a seleção ainda não.
+  const marcados = topicos.filter((t) => escolhidos.has(t.id));
+
+  function alternar(id: string) {
+    setEscolhidos((antes) => {
+      const nova = new Set(antes);
+      if (nova.has(id)) nova.delete(id);
+      else nova.add(id);
+      return nova;
+    });
+  }
+
+  const disponiveis = marcados.length
+    ? marcados.reduce((s, t) => s + t.total, 0)
+    : (resumo?.total ?? 0);
+
+  async function comecar() {
+    setErro('');
+    try {
+      const cartoes = await filaDeEntrevista(
+        nivel,
+        marcados.map((t) => t.id),
+        quantas,
+      );
+      if (!cartoes.length) {
+        setErro('Ainda não há perguntas para essa combinação de nível e assunto.');
+        return;
+      }
+      onComecar(cartoes);
+    } catch (err) {
+      console.error('Falha ao montar a sessão de entrevista.', err);
+      setErro('Não foi possível montar a sessão.');
+    }
+  }
+
+  return (
+    <div className="rev-sala__aviso ent">
+      <h3>Ensaio de entrevista</h3>
+      <p>
+        Perguntas como elas caem numa entrevista de verdade. Vire a carta, compare com o que você
+        teria respondido e se avalie.
+      </p>
+
+      {/* O nível é cumulativo, e o texto diz isso: escolher pleno traz estágio e
+          júnior junto, que é como a entrevista real funciona. */}
+      <div className="ent-niveis" role="group" aria-label="Nível da vaga">
+        {NIVEIS.map((n) => (
+          <button
+            key={n.valor}
+            type="button"
+            className={`ent-nivel${nivel === n.valor ? ' ent-nivel--on' : ''}`}
+            onClick={() => setNivel(n.valor)}
+            aria-pressed={nivel === n.valor}
+          >
+            <b>{n.rotulo}</b>
+            <span>{n.descricao}</span>
+          </button>
+        ))}
+      </div>
+      <p className="ent-cumulativo">
+        Um nível traz também os anteriores, porque entrevista de {nivelAtual(nivel)} cobra o básico
+        do mesmo jeito.
+      </p>
+
+      {carregando && <p className="ent-vazio">Carregando os assuntos...</p>}
+
+      {!carregando && !topicos.length && (
+        <p className="ent-vazio">Nenhum assunto disponível ainda.</p>
+      )}
+
+      {!carregando && topicos.length > 0 && (
+        <>
+          <div className="ent-topicos">
+            {topicos.map((t) => {
+              const marcado = escolhidos.has(t.id);
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  className={`ent-topico${marcado ? ' ent-topico--on' : ''}`}
+                  onClick={() => alternar(t.id)}
+                  aria-pressed={marcado}
+                  disabled={t.total === 0}
+                >
+                  <span className="ent-topico__check">{marcado && <Check size={13} />}</span>
+                  <span className="ent-topico__nome">{t.nome}</span>
+                  {/* Quantas já foram vistas ao menos uma vez, para dar noção de
+                      progresso em vez de só um menu. */}
+                  <span className="ent-topico__n">
+                    {t.vistas ? `${t.vistas} de ${t.total}` : t.total}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          <p className="ent-cumulativo">
+            {marcados.length
+              ? `${disponiveis} perguntas nos assuntos marcados.`
+              : 'Sem marcar nada, vem de todos os assuntos.'}
+          </p>
+
+          <div className="ent-quantas">
+            <span>Quantas perguntas</span>
+            <div className="ent-quantas__opcoes">
+              {OPCOES_QUANTIDADE.map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  className={`ent-quant${quantas === n ? ' ent-quant--on' : ''}`}
+                  onClick={() => setQuantas(n)}
+                  aria-pressed={quantas === n}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {erro && <p className="ent-erro">{erro}</p>}
+
+      <button
+        className="btn btn--accent"
+        onClick={() => void comecar()}
+        disabled={carregando || !topicos.length}
+      >
+        Começar ensaio
+      </button>
+    </div>
+  );
+}
+
+function nivelAtual(nivel: Nivel) {
+  return NIVEIS.find((n) => n.valor === nivel)?.rotulo.toLowerCase() ?? nivel;
+}

--- a/frontend/src/pages/Revisao/index.tsx
+++ b/frontend/src/pages/Revisao/index.tsx
@@ -5,6 +5,7 @@ import { Logo } from '../../components/Logo';
 import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
+import { ModoEntrevista } from '../../components/ModoEntrevista';
 import { Flame, Check, X } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user as userMock } from '../../data/home';
@@ -77,6 +78,29 @@ function segundos(ms: number) {
   return s < 10 ? `${s.toFixed(1)}s` : `${Math.round(s)}s`;
 }
 
+const ROTULO_NIVEL: Record<string, string> = {
+  estagio: 'Estágio',
+  junior: 'Júnior',
+  pleno: 'Pleno',
+  senior: 'Sênior',
+};
+
+// De onde a carta veio, no topo da frente. Cada origem tem uma coisa diferente para
+// dizer: a de aula mostra a trilha, a de entrevista mostra o assunto.
+function tituloDaCarta(c: Cartao) {
+  if (c.origem === 'glossario') return 'Glossário';
+  if (c.origem === 'entrevista') return c.topico ?? 'Entrevista';
+  return c.trilha;
+}
+
+// O rodapé, que situa a carta sem entregar a resposta.
+function origemDaCarta(c: Cartao) {
+  if (c.origem === 'glossario') return 'Termo do glossário';
+  if (c.origem === 'entrevista')
+    return `Entrevista de ${(ROTULO_NIVEL[c.nivel ?? ''] ?? '').toLowerCase() || 'nível não informado'}`;
+  return c.aula;
+}
+
 function duracao(ms: number) {
   if (!ms) return '--';
   const min = Math.round(ms / 60000);
@@ -100,6 +124,9 @@ export function Revisao() {
   const [stats, setStats] = useState<Estatisticas | null>(null);
   const [historico, setHistorico] = useState<SessaoRevisao[]>([]);
   const [fracos, setFracos] = useState<PontoFraco[]>([]);
+  // Qual dos dois modos está aberto. Os dois compartilham baralho, agenda e
+  // estatísticas; o que muda é como o aluno escolhe o que entra na sessão.
+  const [modo, setModo] = useState<'dia' | 'entrevista'>('dia');
   // Trilhas escolhidas. Vazio significa o baralho inteiro, e é como a aba abre.
   const [selecao, setSelecao] = useState<Set<string>>(new Set());
   const [comGlossario, setComGlossario] = useState(false);
@@ -356,7 +383,11 @@ export function Revisao() {
     // que recarregar no meio de uma sessão de 10 traga 10 cartas novas. A lista de
     // respondidas é o que impede a carta que acabou de ser respondida de voltar no
     // F5: a fila não filtra mais por vencimento, então ela continua no baralho.
-    const bruto = localStorage.getItem(SESSAO);
+    //
+    // Só vale para a revisão do dia. A sessão salva descreve uma escolha de trilhas,
+    // e o modo entrevista não cabe nesse formato: escrever ali misturaria as duas e
+    // o F5 remontaria a fila errada. Ensaio interrompido volta para a escolha.
+    const bruto = modo === 'dia' ? localStorage.getItem(SESSAO) : null;
     if (bruto) {
       try {
         const sessao = JSON.parse(bruto);
@@ -467,18 +498,53 @@ export function Revisao() {
         <div className="rev-sala">
           <div className="rev-sala__head">
             <h1 className="rev-sala__titulo">
-              {trilhaId ? 'Revisão da trilha' : 'Revisão do dia'}
+              {trilhaId
+                ? 'Revisão da trilha'
+                : modo === 'entrevista'
+                  ? 'Modo entrevista'
+                  : 'Revisão do dia'}
             </h1>
             <p className="rev-sala__sub">
               {trilhaId
                 ? 'Todos os cartões desta trilha, embaralhados.'
-                : 'Cartões que voltam hoje. Cada acerto empurra o próximo encontro para mais longe.'}
+                : modo === 'entrevista'
+                  ? 'Perguntas de entrevista por nível e assunto. O que você responder aqui volta pela revisão do dia.'
+                  : 'Cartões que voltam hoje. Cada acerto empurra o próximo encontro para mais longe.'}
             </p>
           </div>
 
+          {/* Dois modos, e não duas páginas: eles compartilham baralho, agenda e
+              estatísticas, então trocar de aba não deveria parecer trocar de app. */}
+          {!trilhaId && fila === null && (
+            <div className="rev-modos" role="tablist" aria-label="Modo de revisão">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={modo === 'dia'}
+                className={`rev-modo${modo === 'dia' ? ' rev-modo--on' : ''}`}
+                onClick={() => setModo('dia')}
+              >
+                Revisão do dia
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={modo === 'entrevista'}
+                className={`rev-modo${modo === 'entrevista' ? ' rev-modo--on' : ''}`}
+                onClick={() => setModo('entrevista')}
+              >
+                Entrevista
+              </button>
+            </div>
+          )}
+
           {erro && <div className="rev-sala__erro">{erro}</div>}
 
-          {!trilhaId && baralhos && fila === null && escolhidos > 0 && (
+          {!trilhaId && modo === 'entrevista' && fila === null && (
+            <ModoEntrevista onComecar={iniciarSessao} />
+          )}
+
+          {!trilhaId && modo === 'dia' && baralhos && fila === null && escolhidos > 0 && (
             <div className="rev-sala__aviso">
               <div className="rev-sala__baralho" aria-hidden="true">
                 <span />
@@ -508,7 +574,7 @@ export function Revisao() {
           {/* Fila vazia não significa mais "está tudo em dia", e nem "você não
               estudou": a área pode ser escolhida sem ter feito a trilha. Sobrou o
               caso de o baralho estar vazio e nenhuma área ter sido marcada. */}
-          {!trilhaId && baralhos && fila === null && escolhidos === 0 && (
+          {!trilhaId && modo === 'dia' && baralhos && fila === null && escolhidos === 0 && (
             <div className="rev-sala__aviso">
               <span className="rev-sala__check">
                 <Check size={22} />
@@ -913,13 +979,9 @@ export function Revisao() {
                   aria-label={revelado ? 'Ver a pergunta' : 'Mostrar resposta'}
                 >
                   <div className="rev__face rev__face--frente">
-                    <span className="rev__origem">
-                      {atual.origem === 'glossario' ? 'Glossário' : atual.trilha}
-                    </span>
+                    <span className="rev__origem">{tituloDaCarta(atual)}</span>
                     <p className="rev__texto">{atual.frente}</p>
-                    <span className="rev__rodape">
-                      {atual.origem === 'glossario' ? 'Termo do glossário' : atual.aula}
-                    </span>
+                    <span className="rev__rodape">{origemDaCarta(atual)}</span>
                   </div>
                   <div className="rev__face rev__face--verso">
                     <span className="rev__origem">Resposta</span>
@@ -940,9 +1002,7 @@ export function Revisao() {
                         Reler {atual.aula}
                       </a>
                     ) : (
-                      <span className="rev__rodape">
-                        {atual.origem === 'glossario' ? 'Termo do glossário' : atual.aula}
-                      </span>
+                      <span className="rev__rodape">{origemDaCarta(atual)}</span>
                     )}
                   </div>
                 </div>

--- a/frontend/src/services/entrevista.ts
+++ b/frontend/src/services/entrevista.ts
@@ -1,0 +1,50 @@
+import api from './api';
+import type { Cartao } from './flashcards';
+
+export type Nivel = 'estagio' | 'junior' | 'pleno' | 'senior';
+
+/** Do mais raso ao mais fundo. A ordem é a mesma do backend, e o corte é cumulativo. */
+export const NIVEIS: { valor: Nivel; rotulo: string; descricao: string }[] = [
+  { valor: 'estagio', rotulo: 'Estágio', descricao: 'Fundamentos e vocabulário' },
+  { valor: 'junior', rotulo: 'Júnior', descricao: 'Uso no dia a dia e armadilhas' },
+  { valor: 'pleno', rotulo: 'Pleno', descricao: 'Design, produção e depuração' },
+  { valor: 'senior', rotulo: 'Sênior', descricao: 'Trade-off e decisão técnica' },
+];
+
+export interface TopicoEntrevista {
+  id: string;
+  slug: string;
+  nome: string;
+  /** Perguntas que o tópico tem até o nível escolhido. */
+  total: number;
+  /** Quantas dessas o aluno já respondeu alguma vez. */
+  vistas: number;
+}
+
+export interface ResumoEntrevista {
+  nivel: Nivel;
+  total: number;
+  novas: number;
+  vistas: number;
+}
+
+export async function obterTopicos(nivel: Nivel) {
+  const { data } = await api.get<TopicoEntrevista[]>(`/entrevista/topicos?nivel=${nivel}`);
+  return data;
+}
+
+export async function obterResumo(nivel: Nivel) {
+  const { data } = await api.get<ResumoEntrevista>(`/entrevista/resumo?nivel=${nivel}`);
+  return data;
+}
+
+/**
+ * A sessão. Sem tópico escolhido vem de todos, e a ordem é embaralhada pelo
+ * servidor: numa entrevista as perguntas não vêm na ordem em que você as estudou.
+ */
+export async function filaDeEntrevista(nivel: Nivel, topicos: string[], limite: number) {
+  const q = new URLSearchParams({ nivel, limite: String(limite) });
+  if (topicos.length) q.set('topicos', topicos.join(','));
+  const { data } = await api.get<Cartao[]>(`/entrevista/fila?${q.toString()}`);
+  return data;
+}

--- a/frontend/src/services/flashcards.ts
+++ b/frontend/src/services/flashcards.ts
@@ -6,11 +6,14 @@ export interface Cartao {
   id: string;
   frente: string;
   verso: string;
-  origem: 'flashcard' | 'glossario';
+  origem: 'flashcard' | 'glossario' | 'entrevista';
   trilha: string | null;
   aula: string | null;
   trilhaId: string | null;
   aulaId: string | null;
+  /** Só em carta de entrevista, no lugar da trilha e da aula. */
+  topico?: string | null;
+  nivel?: string | null;
 }
 
 export interface ResumoFlashcards {

--- a/frontend/src/styles/revisao.css
+++ b/frontend/src/styles/revisao.css
@@ -1082,3 +1082,220 @@
   font-size: 12px;
   color: #7fe0b4;
 }
+
+/* ---------- Modo entrevista ---------- */
+
+/* Alternador entre os dois modos. Discreto de propósito: eles compartilham
+   baralho e estatísticas, então trocar de aba não deveria parecer trocar de app. */
+.rev-modos {
+  display: flex;
+  gap: 6px;
+  width: fit-content;
+  margin: 0 auto 18px;
+  padding: 4px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.rev-modo {
+  padding: 7px 16px;
+  border: 0;
+  border-radius: var(--r-md);
+  background: none;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+.rev-modo:hover {
+  color: var(--text);
+}
+.rev-modo--on {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.ent {
+  text-align: left;
+}
+.ent h3,
+.ent > p {
+  text-align: center;
+}
+
+/* Os quatro níveis lado a lado. Cada um mostra o que cobra, porque "pleno" sozinho
+   não diz nada para quem está escolhendo. */
+.ent-niveis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin: 20px 0 8px;
+}
+.ent-nivel {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 11px 10px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+.ent-nivel:hover {
+  border-color: var(--accent);
+}
+.ent-nivel--on {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.ent-nivel b {
+  font-size: 13.5px;
+  font-weight: 700;
+}
+.ent-nivel span {
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
+.ent-cumulativo {
+  margin: 0 0 16px;
+  font-size: 12.5px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.ent-topicos {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 260px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+.ent-topico {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 11px 13px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+.ent-topico:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.ent-topico:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.ent-topico--on {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.ent-topico__check {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  border: 1.5px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--on-accent);
+}
+.ent-topico--on .ent-topico__check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.ent-topico__nome {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ent-topico__n {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.ent-quantas {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 16px 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--muted);
+}
+.ent-quantas__opcoes {
+  display: flex;
+  gap: 6px;
+}
+.ent-quant {
+  min-width: 44px;
+  padding: 7px 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+.ent-quant--on {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.ent-vazio {
+  margin: 16px 0;
+  font-size: 13px;
+  color: var(--muted);
+  text-align: center;
+}
+.ent-erro {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--av-red) 12%, transparent);
+  color: var(--text);
+  font-size: 12.5px;
+  text-align: center;
+}
+
+@media (max-width: 560px) {
+  .ent-niveis {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}


### PR DESCRIPTION
Empilhado em #624, que por sua vez está em #623. Ordem de merge: #623, #624, este.

Traz o modo entrevista para a tela. Com este PR o recurso fica utilizável de ponta a ponta.

## Duas abas, e não duas páginas

Os dois modos compartilham baralho, agenda, ofensiva e estatísticas, então trocar de aba não deveria parecer trocar de aplicativo. O que muda é só como o aluno escolhe o que entra na sessão: a revisão do dia escolhe por área, o ensaio escolhe por nível e assunto.

O alternador só aparece quando não há sessão rodando, para não virar uma saída acidental no meio da revisão.

## O painel do ensaio

Ficou num componente próprio, `ModoEntrevista`, para o diff na página de Revisão continuar pequeno. Ele mostra:

- **Os quatro níveis com o que cada um cobra.** "Pleno" sozinho não diz nada para quem está escolhendo, então cada botão traz a descrição: fundamentos, uso no dia a dia, design e produção, trade-off e decisão.
- **O aviso de que o nível é cumulativo**, que é o comportamento do servidor. Sem esse texto, o aluno estranharia receber pergunta de estágio ao escolher pleno.
- **A lista de assuntos**, com quantas perguntas já foram vistas ao menos uma vez. Sem esse número a lista seria só um menu, e o aluno não saberia por onde continuar.
- **O tamanho da sessão**: 5, 10 ou 20. Ensaio é curto de propósito.

## A carta

Reaproveita o modal existente sem mudança estrutural. Na frente, o assunto entra no lugar da trilha e o nível no lugar da aula, porque pergunta de entrevista não tem aula para onde voltar. O link de reler continua exclusivo das cartas de trilha.

## A trava do localStorage

A sessão salva descreve uma escolha de trilhas, e o ensaio não cabe nesse formato. Responder no modo entrevista deixa de escrever ali; se escrevesse, um F5 remontaria a fila errada, misturando os dois modos. Ensaio interrompido volta para a escolha, que é o comportamento honesto.

## Conferência

O backend foi exercitado por HTTP contra o ambiente local, com as 80 perguntas de Go semeadas:

```
GET /entrevista/topicos?nivel=pleno   [{"nome":"Go","total":60,"vistas":0}]
GET /entrevista/resumo?nivel=estagio  {"total":20,"novas":20,"vistas":0}
GET /entrevista/resumo?nivel=junior   {"total":40,"novas":40,"vistas":0}
GET /entrevista/resumo?nivel=pleno    {"total":60,"novas":60,"vistas":0}
GET /entrevista/resumo?nivel=senior   {"total":80,"novas":80,"vistas":0}
GET /entrevista/resumo?nivel=chefe    400
```

A fila de nível júnior devolve perguntas de estágio e de júnior misturadas, confirmando o corte cumulativo.

Tipos limpos, build de produção passando, e o único aviso do lint no componente novo é o mesmo padrão de busca de dados já usado na página.

**Falta a sua validação visual.** A extensão do navegador não conseguiu abrir o localhost daqui, então não tenho captura da tela montada. O ambiente local está de pé com as perguntas de Go semeadas, em `/revisao`, aba Entrevista.

## O que vem depois

Conteúdo de Docker e comportamental, um PR cada.
