### PR TITLE
fix: trilha sem carga horária deixa de barrar o certificado em silêncio

### DIFF
--- a/backend/scripts/backfill-carga-horaria.ts
+++ b/backend/scripts/backfill-carga-horaria.ts
@@ -1,0 +1,97 @@
+// Preenche a carga horária das trilhas que estão sem ela.
+//
+// Trilha sem workload_hours não emite certificado: statusCertificado devolve o
+// motivo "carga_horaria" e a emissão responde 409. O aluno conclui as 35 aulas,
+// passa em todos os quizzes e não recebe nada, sem entender por quê. Foi o que
+// aconteceu com quem terminou Redes.
+//
+// A carga não é derivada do tempo de leitura das aulas, que mede outra coisa. Ela
+// segue a régua que o catálogo já usa, de cerca de quatro sétimos de hora por aula:
+//
+//   10 aulas ->  6h      28 aulas -> 16h      38 aulas -> 22h
+//   14 aulas ->  8h      34 aulas -> 20h      46 aulas -> 26h
+//   21 aulas -> 12h      35 aulas -> 20h      58 aulas -> 32h
+//   27 aulas -> 15h      37 aulas -> 20h
+//
+// Em trilha multi-linguagem conta o melhor track (neutras mais uma linguagem), e não
+// a soma de todas, senão a mesma aula em dois trilhos dobraria a carga. É a mesma
+// régua da conclusão no roadmap e no certificado.
+//
+// Não sobrescreve quem já tem carga definida: quatro trilhas usam 24h para 35 aulas
+// por decisão editorial, e o script não tem opinião sobre isso.
+//
+// Confere sem gravar:  node scripts/backfill-carga-horaria.ts
+// Aplica:              node scripts/backfill-carga-horaria.ts --aplicar
+import { db } from "../db.ts";
+import { lessons, trails } from "../schema.ts";
+import { and, eq, isNull } from "drizzle-orm";
+
+const HORAS_POR_AULA = 4 / 7;
+
+export function cargaPara(aulas: number) {
+    return Math.max(1, Math.round(aulas * HORAS_POR_AULA));
+}
+
+/** Quantas aulas a trilha cobra de quem a conclui: neutras mais o maior track. */
+function aulasQueContam(aulas: { language: string | null }[]) {
+    const neutras = aulas.filter((a) => a.language === null).length;
+    const porLinguagem = new Map<string, number>();
+    for (const a of aulas) {
+        if (a.language) porLinguagem.set(a.language, (porLinguagem.get(a.language) ?? 0) + 1);
+    }
+    const maiorTrack = porLinguagem.size ? Math.max(...porLinguagem.values()) : 0;
+    return neutras + maiorTrack;
+}
+
+async function backfill() {
+    const aplicar = process.argv.includes("--aplicar");
+
+    const semCarga = await db.select().from(trails).where(isNull(trails.workloadHours));
+    if (semCarga.length === 0) {
+        console.log("Nenhuma trilha sem carga horaria. Nada a fazer.");
+        return;
+    }
+
+    const planejadas: { id: string; nome: string; aulas: number; horas: number }[] = [];
+    const vazias: string[] = [];
+    for (const t of semCarga) {
+        const aulas = await db
+            .select({ language: lessons.language })
+            .from(lessons)
+            .where(and(eq(lessons.trailId, t.id), eq(lessons.published, true)));
+        const contam = aulasQueContam(aulas);
+        // Trilha sem aula publicada nao emite certificado de qualquer jeito, e chutar
+        // uma carga para ela seria inventar numero.
+        if (contam === 0) {
+            vazias.push(t.name);
+            continue;
+        }
+        planejadas.push({ id: t.id, nome: t.name, aulas: contam, horas: cargaPara(contam) });
+    }
+
+    planejadas.sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+    console.log(`${planejadas.length} trilha(s) sem carga horaria:\n`);
+    for (const p of planejadas) {
+        console.log(`  ${p.nome.padEnd(32)} ${String(p.aulas).padStart(3)} aulas -> ${p.horas}h`);
+    }
+    if (vazias.length) {
+        console.log(`\nPuladas por nao terem aula publicada: ${vazias.join(", ")}`);
+    }
+
+    if (!aplicar) {
+        console.log("\nNada gravado. Rode com --aplicar para gravar.");
+        return;
+    }
+
+    for (const p of planejadas) {
+        await db.update(trails).set({ workloadHours: p.horas }).where(eq(trails.id, p.id));
+    }
+    console.log(`\n${planejadas.length} trilha(s) atualizada(s).`);
+}
+
+backfill()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no backfill da carga horaria:", e);
+        process.exit(1);
+    });

--- a/backend/tests/certificado.test.ts
+++ b/backend/tests/certificado.test.ts
@@ -245,6 +245,20 @@ describe("Certificado de conclusão", () => {
         assert.equal(tentativa.status, 409);
     });
 
+    // A tela da trilha usa o motivo para explicar ao aluno por que o certificado não
+    // aparece. Sem isso ela mostra um card mudo, que foi o que gerou o relato de
+    // "concluí a trilha e não consigo emitir".
+    test("quem ainda não concluiu recebe o motivo progresso", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token);
+        const aluno = await criarUsuarioLogado();
+        await passarNoQuiz(aluno.token, lessonIds[0]);
+
+        const status = await get(`/trails/${trailId}/certificado`, aluno.token);
+        assert.equal(status.body.elegivel, false);
+        assert.equal(status.body.motivo, "progresso");
+    });
+
     test("trilha sem carga horária não emite", async () => {
         const admin = await criarUsuarioLogado(true);
         const { trailId, lessonIds } = await montarTrilha(admin.token, { horas: null });

--- a/frontend/src/pages/TrilhaDetalhe/index.tsx
+++ b/frontend/src/pages/TrilhaDetalhe/index.tsx
@@ -97,6 +97,20 @@ function Stars({ value, size = 16 }: { value: number; size?: number }) {
   );
 }
 
+// Por que o certificado não está disponível, na linguagem do aluno. O motivo
+// "progresso" só vira aviso depois que ele começou a trilha: antes disso é o óbvio,
+// e poluiria o card de quem está só olhando.
+function avisoDoCert(
+  motivo: NonNullable<CertificadoStatus['motivo']>,
+  comecado: boolean,
+): string | null {
+  if (motivo === 'manual')
+    return 'O certificado sai quando as aulas são concluídas com os quizzes.';
+  if (motivo === 'carga_horaria') return 'Esta trilha ainda não emite certificado.';
+  if (motivo === 'indisponivel') return 'A emissão de certificados está indisponível no momento.';
+  return comecado ? 'Conclua todas as aulas da trilha para liberar o certificado.' : null;
+}
+
 function formatNota(n: number | null | undefined): string {
   return (n ?? 0).toFixed(1).replace('.', ',');
 }
@@ -287,6 +301,7 @@ export function TrilhaDetalhe() {
   }
 
   const alunos = trilha?.studentsCount ?? 0;
+  const avisoCert = cert?.motivo ? avisoDoCert(cert.motivo, stats.comecado) : null;
   const inclui = trilha
     ? [
         { icon: <BookOpen size={15} />, label: `${stats.total} aulas em texto` },
@@ -459,11 +474,10 @@ export function TrilhaDetalhe() {
                         Baixar certificado
                       </button>
                     )}
-                    {cert?.motivo === 'manual' && (
-                      <p className="td-card__cert-hint">
-                        O certificado sai quando as aulas são concluídas com os quizzes.
-                      </p>
-                    )}
+                    {/* Todo motivo de não emitir precisa aparecer. Antes só o "manual"
+                        tinha aviso, e quem concluía uma trilha sem carga horária definida
+                        ficava sem botão e sem explicação nenhuma. */}
+                    {avisoCert && <p className="td-card__cert-hint">{avisoCert}</p>}
                     <hr className="rule" />
                     <div className="td-card__inc-title">Esta trilha inclui</div>
                     <div className="td-card__inc">


### PR DESCRIPTION
Corrige o relato do 0xgio: concluiu a trilha de Redes e não conseguia emitir o certificado, sem nenhuma explicação na tela.

## O diagnóstico

Ele passou em tudo que o backend exige. Conferido no banco de produção:

| Verificação | Resultado |
|---|---|
| Emissor configurado (razão social, CNPJ, responsável) | ok |
| Aulas publicadas concluídas | 35 de 35 |
| Conclusões manuais (que não valem certificado) | 0 |
| Certificado já emitido | não |
| **Carga horária da trilha** | **vazia** |

`workload_hours` está nulo em Redes. O serviço então devolve `motivo: "carga_horaria"` e a emissão responde 409, porque a carga vai impressa no documento. Esse comportamento está correto e **já tinha teste**.

Os defeitos são os outros dois lados.

## Defeito 1: o dado, e não é só Redes

**Catorze trilhas com aula publicada estão sem carga horária em produção.** Quem concluir qualquer uma delas fica sem certificado, do mesmo jeito.

Arquitetura e Escala, C++, Cálculo 1, Cálculo 2, Cálculo 3, Estatística Matemática, Geometria Analítica, Go, Java, Kubernetes, Linux e Linha de Comando, Pré-cálculo, Redes, Álgebra Linear.

O script novo preenche seguindo a régua que o catálogo **já usa**. Nas 74 trilhas que têm o campo, a razão é consistente em cerca de quatro sétimos de hora por aula:

```
10 aulas ->  6h     27 aulas -> 15h     37 aulas -> 20h
14 aulas ->  8h     28 aulas -> 16h     38 aulas -> 22h
21 aulas -> 12h     34 aulas -> 20h     46 aulas -> 26h
                    35 aulas -> 20h     58 aulas -> 32h
```

O que o script propõe:

| Trilha | Aulas | Horas |
|---|---|---|
| Arquitetura e Escala, Cálculo 1, Cálculo 2, Cálculo 3, Estatística Matemática, Geometria Analítica, Kubernetes, Linux e Linha de Comando, Pré-cálculo, Redes, Álgebra Linear | 35 | 20 |
| C++, Go | 27 | 15 |
| Java | 30 | 17 |

Quatro cuidados no script:

- **Conta o melhor track** em trilha multi-linguagem, e não a soma, senão a mesma aula em dois trilhos dobraria a carga. É a mesma régua da conclusão no roadmap e no certificado.
- **Pula trilha sem aula publicada** em vez de inventar número.
- **Não sobrescreve** quem já tem carga: quatro trilhas usam 24h para 35 aulas por decisão editorial, e o script não tem opinião sobre isso.
- **Roda em ensaio por padrão**, e só grava com `--aplicar`.

## Defeito 2: a tela ficava muda

O card da trilha só tinha aviso para o motivo `manual`. Os outros três caíam no silêncio: sem botão, sem frase, sem nada. Foi exatamente o que ele viu.

| Motivo | Antes | Agora |
|---|---|---|
| `manual` | aviso | igual |
| `carga_horaria` | **nada** | "Esta trilha ainda não emite certificado." |
| `indisponivel` | **nada** | "A emissão de certificados está indisponível no momento." |
| `progresso` | **nada** | "Conclua todas as aulas da trilha para liberar o certificado." |

O de `progresso` só aparece depois que o aluno começou a trilha. Antes disso é o óbvio, e poluiria o card de quem está só olhando.

## Conferência

Um teste novo trava o contrato do motivo `progresso`, que a tela passou a usar e nenhum teste afirmava. Suíte em **149 testes**.

O script foi validado num Postgres efêmero com os casos de borda montados de propósito:

```
Multi linguagem     35 aulas -> 20h     (70 aulas no banco, 35 no melhor track)
Sem carga 27        27 aulas -> 15h
Sem carga 35        35 aulas -> 20h
Puladas por nao terem aula publicada: Sem aula publicada
```

Depois de aplicar: a trilha com 24h ficou intacta, a sem aula publicada continuou nula, e a segunda rodada atualizou zero.

## Rodar em produção

Primeiro o ensaio, para conferir a tabela:

```
docker compose -f docker-compose.prod.yml exec -T backend node scripts/backfill-carga-horaria.ts
```

E então:

```
docker compose -f docker-compose.prod.yml exec -T backend node scripts/backfill-carga-horaria.ts --aplicar
```

Depois disso o 0xgio consegue emitir o de Redes sem precisar refazer nada, porque a conclusão dele já está registrada e válida.

## O número é editorial

A regra dos quatro sétimos foi derivada do que o catálogo já pratica, e não inventada. Mas carga horária vai impressa num documento que a pessoa põe no currículo, então se você quiser outro valor para alguma trilha, é só dizer antes de aplicar.
