### PR TITLE
fix: conta de login social passa a receber link para criar senha

### DIFF
--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -13,7 +13,7 @@ import {
     getDummyHash,
 } from "../services/password.service.ts";
 import { db } from "../../db.ts";
-import { users, tokens } from "../../schema.ts";
+import { users, tokens, oauthAccounts } from "../../schema.ts";
 import { eq, and, isNull } from "drizzle-orm";
 import type { Request, Response, NextFunction } from "express";
 import { env } from "../config/env.ts";
@@ -318,7 +318,8 @@ export const resendVerification = async (req: Request, res: Response, next: Next
 
         // Resposta genérica, para não revelar se o email tem conta ou já foi verificado.
         const resposta = {
-            mensagem: "Se houver uma conta pendente de confirmação com esse email, reenviamos o link.",
+            mensagem:
+                "Se houver uma conta pendente de confirmação com esse email, reenviamos o link.",
         };
 
         const [user] = await db
@@ -338,13 +339,29 @@ export const resendVerification = async (req: Request, res: Response, next: Next
     }
 };
 
+// Por qual provedor a conta entra hoje, só para o email falar a língua de quem lê
+// ("sua conta entra pelo Google"). Devolve nulo quando não há nenhum, e aí o texto
+// cai para a forma genérica.
+const NOME_PROVEDOR: Record<string, string> = { google: "Google", github: "GitHub" };
+
+async function provedorDe(userId: string): Promise<string | null> {
+    const [conta] = await db
+        .select({ provider: oauthAccounts.provider })
+        .from(oauthAccounts)
+        .where(eq(oauthAccounts.userId, userId))
+        .limit(1);
+    if (!conta) return null;
+    return NOME_PROVEDOR[conta.provider] ?? conta.provider;
+}
+
 export const forgotPassword = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const { email } = forgotPasswordSchema.parse(req.body);
 
         // Resposta sempre genérica, para não revelar se o email tem conta.
         const resposta = {
-            mensagem: "Se houver uma conta com esse email, enviamos um link para redefinir a senha.",
+            mensagem:
+                "Se houver uma conta com esse email, enviamos um link para redefinir a senha.",
         };
 
         const [user] = await db
@@ -352,10 +369,17 @@ export const forgotPassword = async (req: Request, res: Response, next: NextFunc
             .from(users)
             .where(eq(users.email, email));
 
-        // Só envia quando a conta existe e tem senha (login social não tem o que redefinir).
-        if (user && user.passwordHash) {
+        // Conta que entrou por login social não tem senha para redefinir, mas tem para
+        // CRIAR. Antes o pedido dela era descartado em silêncio: a pessoa recebia a
+        // mensagem de que o link foi enviado e nada chegava nunca. Agora o link sai
+        // igual, só com o texto certo para o caso dela.
+        if (user) {
             const token = await authService.gerarTokenResetSenha(user.id);
-            await emailService.enviarResetSenha(email, token);
+            if (user.passwordHash) {
+                await emailService.enviarResetSenha(email, token);
+            } else {
+                await emailService.enviarCriarSenha(email, token, await provedorDe(user.id));
+            }
         }
 
         res.json(resposta);
@@ -416,7 +440,8 @@ export const forgotPasswordOtp = async (req: Request, res: Response, next: NextF
 
         // Resposta genérica, para não revelar se o email tem conta.
         const resposta = {
-            mensagem: "Se houver uma conta com esse email, enviamos um código para redefinir a senha.",
+            mensagem:
+                "Se houver uma conta com esse email, enviamos um código para redefinir a senha.",
         };
 
         const [user] = await db
@@ -424,13 +449,17 @@ export const forgotPasswordOtp = async (req: Request, res: Response, next: NextF
             .from(users)
             .where(eq(users.email, email));
 
-        if (user && user.passwordHash) {
+        // Mesma correção do caminho por link: conta sem senha recebe o código para
+        // criar uma, em vez de o pedido morrer em silêncio.
+        if (user) {
             const otp = await authService.gerarOtpResetSenha(user.id);
             // WhatsApp só se tiver telefone; senão cai no email para o código não se perder.
             if (canal === "whatsapp" && user.phone) {
                 await whatsappService.enviarOtpReset(user.phone, otp);
-            } else {
+            } else if (user.passwordHash) {
                 await emailService.enviarOtpReset(email, otp);
+            } else {
+                await emailService.enviarOtpCriarSenha(email, otp, await provedorDe(user.id));
             }
         }
 

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -69,6 +69,44 @@ export const emailService = {
         const text = `Redefina sua senha no ensina.dev (o link vale por 1 hora):\n${link}\n\nSe você não pediu isso, ignore este email.`;
         await enviar({ to: email, subject: "Redefinir sua senha · ensina.dev", html, text });
     },
+    /**
+     * Quem entrou por login social não tem senha para redefinir, então o email
+     * de "esqueci a senha" precisa dizer outra coisa: que dá para criar uma agora,
+     * e que o acesso pelo provedor continua valendo. Antes disso a pessoa pedia o
+     * link, recebia a mensagem de que ele tinha sido enviado, e nada chegava nunca.
+     */
+    async enviarCriarSenha(email: string, token: string, provedor: string | null) {
+        const link = `${env.FRONTEND_URL}/redefinir-senha?token=${token}`;
+        const entra = provedor ? `pelo ${provedor}` : "por login social";
+        const html = layout(
+            "Crie uma senha para sua conta",
+            `<p style="font-size:15px;line-height:1.6;color:#555">Você pediu para redefinir a senha, mas sua conta entra ${entra} e ainda não tem uma. Clique no botão abaixo para criar. O link vale por 1 hora.</p>
+  <a href="${link}" style="display:inline-block;margin:20px 0;background:#2d6bf5;color:#fff;text-decoration:none;padding:12px 28px;border-radius:10px;font-weight:600">Criar senha</a>
+  <p style="font-size:13px;line-height:1.6;color:#888">Se o botão não funcionar, cole este link no navegador:<br><a href="${link}" style="color:#2d6bf5;word-break:break-all">${link}</a></p>
+  <p style="font-size:13px;line-height:1.6;color:#888;margin-top:24px">Depois de criar, você poderá entrar das duas formas: com email e senha, ou ${entra} como sempre fez.</p>
+  <p style="font-size:13px;color:#888;margin-top:12px">Se você não pediu isso, pode ignorar este email: sua conta continua como está.</p>`,
+        );
+        const text = `Sua conta no ensina.dev entra ${entra} e ainda não tem senha. Crie uma por este link (vale por 1 hora):\n${link}\n\nDepois você poderá entrar das duas formas. Se você não pediu isso, ignore este email.`;
+        await enviar({ to: email, subject: "Crie uma senha · ensina.dev", html, text });
+    },
+    /** A mesma ideia do enviarCriarSenha, no caminho do código de seis dígitos. */
+    async enviarOtpCriarSenha(email: string, otp: string, provedor: string | null) {
+        const entra = provedor ? `pelo ${provedor}` : "por login social";
+        const html = layout(
+            "Seu código para criar uma senha",
+            `<p style="font-size:15px;line-height:1.6;color:#555">Sua conta entra ${entra} e ainda não tem senha. Use o código abaixo para criar uma. Ele vale por 10 minutos.</p>
+  <div style="font-size:30px;font-weight:700;letter-spacing:6px;color:#2d6bf5;margin:18px 0">${otp}</div>
+  <p style="font-size:13px;line-height:1.6;color:#888;margin-top:24px">Depois de criar, você poderá entrar das duas formas: com email e senha, ou ${entra} como sempre fez.</p>
+  <p style="font-size:13px;color:#888;margin-top:12px">Se você não pediu isso, ignore este email.</p>`,
+        );
+        const text = `Seu código para criar uma senha no ensina.dev é ${otp}. Ele vale por 10 minutos.\n\nSe você não pediu isso, ignore este email.`;
+        await enviar({
+            to: email,
+            subject: "Seu código para criar a senha · ensina.dev",
+            html,
+            text,
+        });
+    },
     async enviarOtpReset(email: string, otp: string) {
         const html = layout(
             "Seu código para redefinir a senha",

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -337,3 +337,111 @@ describe("GET /users (RBAC)", () => {
         assert.equal(res.status, 401);
     });
 });
+
+// Relato de produção: uma aluna que entrou pelo Google pediu para redefinir a senha,
+// recebeu a mensagem de que o link tinha sido enviado, e nada chegou nunca. O motivo
+// era o pedido ser descartado em silêncio quando a conta não tinha senha para
+// redefinir. Ela não queria redefinir: queria passar a ter uma.
+describe("Recuperação de senha em conta de login social", () => {
+    // Simula quem entrou por provedor: sem senha, e com a conta social vinculada.
+    async function contaSocial(provider = "google") {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        await verificarEmail(dados.email);
+        const { db } = await import("../db.ts");
+        const { users, oauthAccounts } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        const [u] = await db
+            .select({ id: users.id })
+            .from(users)
+            .where(eq(users.email, dados.email));
+        await db.update(users).set({ passwordHash: null }).where(eq(users.id, u.id));
+        await db.insert(oauthAccounts).values({ userId: u.id, provider, providerId: `id-${u.id}` });
+        return { id: u.id, email: dados.email };
+    }
+
+    async function tokensDe(userId: string, tipo: string) {
+        const { db } = await import("../db.ts");
+        const { tokens } = await import("../schema.ts");
+        const { and, eq } = await import("drizzle-orm");
+        return db
+            .select()
+            .from(tokens)
+            .where(and(eq(tokens.userId, userId), eq(tokens.type, tipo)));
+    }
+
+    test("pedido de conta sem senha passa a gerar o link, em vez de morrer calado", async () => {
+        const conta = await contaSocial();
+        assert.equal((await tokensDe(conta.id, "password_reset")).length, 0);
+
+        const res = await server.request("POST", "/forgot-password", {
+            body: { email: conta.email },
+        });
+        assert.equal(res.status, 200);
+        assert.equal(
+            (await tokensDe(conta.id, "password_reset")).length,
+            1,
+            "a conta sem senha precisa receber um link para criar uma",
+        );
+    });
+
+    test("o link cria a senha e libera o login por email", async () => {
+        const conta = await contaSocial();
+        const { authService } = await import("../src/services/auth.service.ts");
+        const token = await authService.gerarTokenResetSenha(conta.id);
+
+        const troca = await server.request("POST", "/reset-password", {
+            body: { token, password: "NovaSenha123!" },
+        });
+        assert.equal(troca.status, 200);
+
+        const login = await server.request("POST", "/login", {
+            body: { email: conta.email, password: "NovaSenha123!" },
+        });
+        assert.equal(login.status, 200);
+    });
+
+    // Criar senha não pode custar o acesso que ela já tinha.
+    test("criar a senha não desvincula a conta social", async () => {
+        const conta = await contaSocial();
+        const { authService } = await import("../src/services/auth.service.ts");
+        const token = await authService.gerarTokenResetSenha(conta.id);
+        await server.request("POST", "/reset-password", {
+            body: { token, password: "NovaSenha123!" },
+        });
+
+        const { db } = await import("../db.ts");
+        const { oauthAccounts } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        const vinculos = await db
+            .select()
+            .from(oauthAccounts)
+            .where(eq(oauthAccounts.userId, conta.id));
+        assert.equal(vinculos.length, 1);
+        assert.equal(vinculos[0].provider, "google");
+    });
+
+    test("o caminho do código de seis dígitos também atende conta sem senha", async () => {
+        const conta = await contaSocial();
+        const res = await server.request("POST", "/forgot-password-otp", {
+            body: { email: conta.email, canal: "email" },
+        });
+        assert.equal(res.status, 200);
+        assert.equal((await tokensDe(conta.id, "password_reset_otp")).length, 1);
+    });
+
+    // A resposta continua sem revelar se o email tem conta, que é o motivo de ela ser
+    // genérica. O que mudou foi só o que acontece por baixo.
+    test("email sem conta continua sem gerar token e com a mesma resposta", async () => {
+        const conta = await contaSocial();
+        const res = await server.request("POST", "/forgot-password", {
+            body: { email: `naoexiste_${Date.now()}@email.com` },
+        });
+        assert.equal(res.status, 200);
+
+        const comConta = await server.request("POST", "/forgot-password", {
+            body: { email: conta.email },
+        });
+        assert.deepEqual(res.body, comConta.body, "as duas respostas precisam ser iguais");
+    });
+});


### PR DESCRIPTION
Corrige o caso da aluna `alineaos`: pediu para redefinir a senha, a tela disse que o link foi enviado, e nada chegou.

## Não era entrega de email

Conferido em produção antes de tocar em código:

| Verificação | Resultado |
|---|---|
| SMTP configurado (host, user, pass) | ok |
| Token de reset gerado para ela | **nenhum, nunca** |
| `password_hash` da conta | **nulo** |
| Login social vinculado | **google** |

Ela entrou pelo Google. O `forgotPassword` achava a conta, via que não havia senha para redefinir e **não fazia nada**, devolvendo a mesma mensagem genérica de sempre.

## O beco sem saída

A intenção da guarda estava certa: login social não tem o que redefinir. O efeito não, porque **também não existe nenhuma tela para definir senha estando logado**. Procurei: não há rota, controller nem serviço para isso. Então a pessoa podia pedir o link quantas vezes quisesse, e a mensagem sempre diria que o email saiu.

A leitura errada era supor que quem pede o link quer *redefinir*. Ela não queria redefinir, queria **passar a ter** uma senha.

## A correção é pequena porque o resto já funcionava

O `resetPassword` já sabia atender conta sem senha: ele só grava o hash, sem exigir que existisse um antes. Faltava alguém gerar o token e mandar o email.

Agora conta sem senha recebe o link igual, com o texto certo para o caso dela:

> Você pediu para redefinir a senha, mas sua conta entra pelo Google e ainda não tem uma. [Criar senha]
>
> Depois de criar, você poderá entrar das duas formas: com email e senha, ou pelo Google como sempre fez.

O nome do provedor sai do vínculo real da conta, então quem entrou pelo GitHub lê GitHub. O caminho do código de seis dígitos ganhou o mesmo tratamento, senão a correção seria pela metade.

## A resposta da API não mudou

Continua idêntica nos três casos: conta com senha, conta sem senha e email inexistente. É isso que impede descobrir por tentativa quais emails têm conta. O que mudou foi só o que acontece por baixo dela.

## Prova de que os testes pegam o bug

Cinco testes novos. Não bastava vê-los verdes, então rodei com a guarda antiga de volta:

```
✖ pedido de conta sem senha passa a gerar o link, em vez de morrer calado
    actual: 0, expected: 1
✖ o caminho do código de seis dígitos também atende conta sem senha
    actual: 0, expected: 1
✔ o link cria a senha e libera o login por email
```

Zero token onde se espera um, nos dois caminhos: exatamente o relato. O terceiro passa nos dois códigos **de propósito**, porque documenta que a segunda metade do fluxo nunca esteve quebrada.

Há também um teste garantindo que **criar a senha não desvincula a conta social**: ela continua entrando pelo Google depois.

Suíte completa em **154 testes**.

## Para a aluna

Depois do deploy, basta ela pedir a redefinição de novo e o email chega. Se quiser destravar antes disso, dá para gerar um link de criação de senha para ela sem esperar o release: é só pedir.
