### PR TITLE
feat: ampliar a foto e a capa no perfil de outra pessoa

### DIFF
--- a/frontend/src/components/VisorImagem.tsx
+++ b/frontend/src/components/VisorImagem.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { X } from './Icons';
+
+interface Props {
+  src: string;
+  alt: string;
+  /** Avatar é recortado em círculo, como aparece no perfil. Capa fica retangular. */
+  redondo?: boolean;
+  onFechar: () => void;
+}
+
+/**
+ * Abre uma imagem do perfil em tamanho grande, por cima da página.
+ *
+ * O gesto é o do Twitter: clicar na foto ou na capa de outra pessoa amplia, e sair
+ * é fácil por três caminhos (Escape, clique fora, botão de fechar). O foco vai para
+ * o botão ao abrir e volta para o elemento de origem ao fechar, senão quem navega
+ * por teclado é jogado para o começo da página.
+ */
+export function VisorImagem({ src, alt, redondo = false, onFechar }: Props) {
+  const fechar = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const origem = document.activeElement as HTMLElement | null;
+    fechar.current?.focus();
+
+    function tecla(e: KeyboardEvent) {
+      if (e.key === 'Escape') onFechar();
+    }
+    window.addEventListener('keydown', tecla);
+
+    // Com a imagem na frente da tela, rolar a página atrás não faz sentido.
+    const antes = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.removeEventListener('keydown', tecla);
+      document.body.style.overflow = antes;
+      origem?.focus?.();
+    };
+  }, [onFechar]);
+
+  return (
+    <div className="visor" role="dialog" aria-modal="true" aria-label={alt} onClick={onFechar}>
+      <button ref={fechar} className="visor__fechar" onClick={onFechar} aria-label="Fechar">
+        <X size={18} />
+      </button>
+      <img
+        className={`visor__img${redondo ? ' visor__img--redondo' : ''}`}
+        src={src}
+        alt={alt}
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/PerfilPublico/index.tsx
+++ b/frontend/src/pages/PerfilPublico/index.tsx
@@ -5,6 +5,7 @@ import { Logo } from '../../components/Logo';
 import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
+import { VisorImagem } from '../../components/VisorImagem';
 import {
   Flame,
   AtSign,
@@ -49,6 +50,10 @@ export function PerfilPublico() {
   const { user, isAuthenticated } = useAuth();
   const [perfil, setPerfil] = useState<PerfilPublicoData | null>(null);
   const [estado, setEstado] = useState<'carregando' | 'ok' | 'nao_encontrado'>('carregando');
+  // Qual imagem do perfil está ampliada, ou nulo com o visor fechado.
+  const [ampliada, setAmpliada] = useState<{ src: string; alt: string; redondo: boolean } | null>(
+    null,
+  );
   const [copiado, setCopiado] = useState(false);
   const [seguindo, setSeguindo] = useState<boolean | null>(null);
   const [salvandoSeguir, setSalvandoSeguir] = useState(false);
@@ -153,7 +158,7 @@ export function PerfilPublico() {
           <div className="pf">
             <div className="pf-card">
               <div
-                className="pf-banner"
+                className={`pf-banner${capaUrl ? ' pf-banner--ampliavel' : ''}`}
                 style={
                   capaUrl
                     ? {
@@ -163,6 +168,29 @@ export function PerfilPublico() {
                       }
                     : undefined
                 }
+                {...(capaUrl
+                  ? {
+                      role: 'button',
+                      tabIndex: 0,
+                      'aria-label': `Ver a capa de ${perfil.name}`,
+                      onClick: () =>
+                        setAmpliada({
+                          src: capaUrl,
+                          alt: `Capa de ${perfil.name}`,
+                          redondo: false,
+                        }),
+                      onKeyDown: (e: React.KeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setAmpliada({
+                            src: capaUrl,
+                            alt: `Capa de ${perfil.name}`,
+                            redondo: false,
+                          });
+                        }
+                      },
+                    }
+                  : {})}
               >
                 {!capaUrl && (
                   <>
@@ -174,13 +202,36 @@ export function PerfilPublico() {
               <div className="pf-head">
                 <div className="pf-avatar-wrap">
                   <div
-                    className="pf-avatar"
+                    className={`pf-avatar${fotoUrl ? ' pf-avatar--ampliavel' : ''}`}
                     style={{
                       width: 104,
                       height: 104,
                       fontSize: 38,
                       border: '4px solid var(--surface)',
                     }}
+                    {...(fotoUrl
+                      ? {
+                          role: 'button',
+                          tabIndex: 0,
+                          'aria-label': `Ver a foto de ${perfil.name}`,
+                          onClick: () =>
+                            setAmpliada({
+                              src: fotoUrl,
+                              alt: `Foto de ${perfil.name}`,
+                              redondo: true,
+                            }),
+                          onKeyDown: (e: React.KeyboardEvent) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              setAmpliada({
+                                src: fotoUrl,
+                                alt: `Foto de ${perfil.name}`,
+                                redondo: true,
+                              });
+                            }
+                          },
+                        }
+                      : {})}
                   >
                     {fotoUrl ? <img src={fotoUrl} alt={perfil.name} /> : getInitials(perfil.name)}
                   </div>
@@ -367,6 +418,15 @@ export function PerfilPublico() {
           </div>
         )}
       </div>
+
+      {ampliada && (
+        <VisorImagem
+          src={ampliada.src}
+          alt={ampliada.alt}
+          redondo={ampliada.redondo}
+          onFechar={() => setAmpliada(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -6218,3 +6218,89 @@ a.logo {
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ---------- Visor de imagem do perfil ---------- */
+
+/* Ampliar a foto e a capa de outra pessoa, no gesto que o Twitter ensinou. Só
+   entra quando existe imagem: não há o que ampliar num gradiente nem em iniciais. */
+.pf-banner--ampliavel,
+.pf-avatar--ampliavel {
+  cursor: zoom-in;
+}
+.pf-avatar--ampliavel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+/* Na capa o anel vai para dentro: ela ocupa a largura do card, e por fora ele sai
+   cortado pela borda e vira um risco solto em vez de um contorno. */
+.pf-banner--ampliavel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -4px;
+}
+
+.visor {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(6, 8, 15, 0.86);
+  cursor: zoom-out;
+  animation: visor-entra 0.16s ease both;
+}
+@keyframes visor-entra {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.visor__img {
+  max-width: min(760px, 100%);
+  max-height: 86vh;
+  object-fit: contain;
+  border-radius: var(--r-lg);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  cursor: default;
+}
+/* O avatar é redondo no perfil, e ampliá-lo em quadrado quebraria o vínculo
+   visual com o que foi clicado. */
+.visor__img--redondo {
+  width: min(360px, 78vw);
+  height: min(360px, 78vw);
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.visor__fechar {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  cursor: pointer;
+}
+.visor__fechar:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+.visor__fechar:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .visor {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Clicar na foto ou na capa de outra pessoa não fazia nada. Agora abre a imagem em tamanho grande por cima da página, no gesto que o Twitter ensinou.

## Como funciona

- **Foto** amplia **redonda**, como aparece no perfil. Ampliar em quadrado quebraria o vínculo visual com o que foi clicado.
- **Capa** amplia **inteira**, e não a faixa estreita que o cabeçalho mostra. Ver a imagem completa é justamente a graça de ampliar.
- Três saídas: **Escape**, **clique fora** e **botão de fechar**.
- A rolagem da página trava enquanto a imagem está aberta.

## Só entra quando existe imagem

Capa vazia é um gradiente e avatar vazio são as iniciais. Não há o que ampliar em nenhum dos dois, então nesses casos nada fica clicável e nem o cursor muda. Sem isso, a pessoa clicaria num gradiente esperando algo acontecer.

## Fica só no perfil público, e isso é decisão

No perfil próprio a foto e a capa já têm botões de **editar e remover** sobrepostos, então clicar ali significa outra coisa. Somar zoom criaria ambiguidade num gesto que hoje é claro. Se depois fizer sentido, o caminho é o do Twitter: tirar a edição de cima da imagem e colocá-la atrás de um botão de editar perfil.

## Acessibilidade

Os dois viram alvo focável com `role="button"` e respondem a **Enter** e **espaço**, e não só ao clique. O foco vai para o botão de fechar ao abrir e **volta para a imagem de origem** ao fechar, senão quem navega por teclado é jogado para o começo da página.

O anel de foco da capa é desenhado **por dentro** (`outline-offset: -4px`). Por fora, a borda do card o corta e ele vira um risco azul solto em vez de um contorno. Descobri isso vendo na tela, não no código.

A animação de entrada respeita `prefers-reduced-motion`.

## Verificado no navegador

Foto abrindo redonda, capa abrindo inteira, Escape fechando, foco voltando para a capa com o anel correto, e a página travada atrás. As duas imagens são de perfil e não de conteúdo, então não há nada além delas para paginar.

## Uma nota sobre o ambiente local

Para testar, semeei foto e capa no usuário `testeroadmap` do banco de desenvolvimento, apontando para o picsum. Nenhum perfil de dev tinha imagem, então não havia como ver a feature. Para desfazer:

```sql
update users set avatar_url = null, cover_url = null where username = 'testeroadmap';
```

Também precisei aplicar as migrations pendentes no banco de dev: ele estava sem a coluna `acertou_em` do PR #640, e por isso o perfil público respondia 500.
