### PR TITLE
fix: revisão lembra o baralho escolhido

### DIFF
--- a/frontend/src/components/ModoEntrevista.tsx
+++ b/frontend/src/components/ModoEntrevista.tsx
@@ -10,10 +10,34 @@ import {
   type TopicoEntrevista,
 } from '../services/entrevista';
 import type { Cartao } from '../services/flashcards';
+import { lerPreferencia, gravarPreferencia } from '../utils/preferencia';
 
 // Quantas perguntas por sessão. Ensaio de entrevista é curto de propósito: passar
 // de vinte perguntas de uma vez não é ensaio, é maratona.
 const OPCOES_QUANTIDADE = [5, 10, 20];
+
+// A combinação escolhida no último ensaio. Vive em chave própria, separada da
+// revisão do dia, porque são duas escolhas diferentes e o aluno alterna entre elas.
+const ESCOLHA = 'ensina:revisao:entrevista';
+
+interface EscolhaSalva {
+  nivel: Nivel;
+  topicos: string[];
+  quantas: number;
+}
+
+const ESCOLHA_PADRAO: EscolhaSalva = { nivel: 'junior', topicos: [], quantas: 10 };
+
+// Cada campo volta conferido: o nível vira classe de CSS e vai para a API, e a
+// quantidade precisa ser uma das três opções para o botão certo aparecer marcado.
+function lerEscolha(): EscolhaSalva {
+  const salvo = lerPreferencia(ESCOLHA, ESCOLHA_PADRAO);
+  return {
+    nivel: NIVEIS.some((n) => n.valor === salvo.nivel) ? salvo.nivel : ESCOLHA_PADRAO.nivel,
+    topicos: Array.isArray(salvo.topicos) ? salvo.topicos.filter((t) => typeof t === 'string') : [],
+    quantas: OPCOES_QUANTIDADE.includes(salvo.quantas) ? salvo.quantas : ESCOLHA_PADRAO.quantas,
+  };
+}
 
 interface Props {
   /** Entrega a fila pronta para a sala abrir a carta. */
@@ -29,11 +53,14 @@ interface Props {
  * estatísticas, porque a carta respondida aqui volta pela fila do dia.
  */
 export function ModoEntrevista({ onComecar }: Props) {
-  const [nivel, setNivel] = useState<Nivel>('junior');
+  // O painel some da tela ao trocar de modo, então o estado nasce do que ficou
+  // guardado: sem isso, ir ver a revisão do dia e voltar já apagava a escolha.
+  const [salvo] = useState(lerEscolha);
+  const [nivel, setNivel] = useState<Nivel>(salvo.nivel);
   const [topicos, setTopicos] = useState<TopicoEntrevista[]>([]);
-  const [escolhidos, setEscolhidos] = useState<Set<string>>(new Set());
+  const [escolhidos, setEscolhidos] = useState<Set<string>>(() => new Set(salvo.topicos));
   const [resumo, setResumo] = useState<ResumoEntrevista | null>(null);
-  const [quantas, setQuantas] = useState(10);
+  const [quantas, setQuantas] = useState(salvo.quantas);
   const [carregando, setCarregando] = useState(true);
   const [erro, setErro] = useState('');
 
@@ -55,6 +82,12 @@ export function ModoEntrevista({ onComecar }: Props) {
   useEffect(() => {
     void carregar(nivel);
   }, [nivel, carregar]);
+
+  // Guarda a escolha inteira, inclusive assunto que não é do nível aberto agora:
+  // quem sobe para pleno e volta para júnior espera reencontrar o que tinha marcado.
+  useEffect(() => {
+    gravarPreferencia(ESCOLHA, { nivel, topicos: [...escolhidos], quantas });
+  }, [nivel, escolhidos, quantas]);
 
   // Trocar de nível não pode carregar assunto que sumiu da lista, porque um tópico
   // só de sênior deixa de existir ao voltar para estágio. A marcação é derivada em

--- a/frontend/src/pages/Revisao/index.tsx
+++ b/frontend/src/pages/Revisao/index.tsx
@@ -10,6 +10,7 @@ import { Flame, Check, X } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user as userMock } from '../../data/home';
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
+import { lerPreferencia, gravarPreferencia } from '../../utils/preferencia';
 import {
   filaDoDia,
   obterBaralhos,
@@ -42,6 +43,38 @@ const SAIDA_MS = 300;
 
 // Onde a sessão em andamento fica guardada, para um F5 não perder o lugar.
 const SESSAO = 'ensina:revisao';
+
+// A escolha do baralho, guardada à parte da sessão. A sessão morre ao terminar; a
+// escolha não, senão a cada visita o aluno remarca as mesmas áreas e redigita a
+// mesma quantidade. Guarda também o modo, para a aba voltar onde ele estava.
+const ESCOLHA = 'ensina:revisao:escolha';
+
+interface EscolhaSalva {
+  modo: 'dia' | 'entrevista';
+  trilhas: string[];
+  glossario: boolean;
+  limite: string;
+}
+
+const ESCOLHA_PADRAO: EscolhaSalva = {
+  modo: 'dia',
+  trilhas: [],
+  glossario: false,
+  limite: '',
+};
+
+// O que vem do navegador é conferido antes de virar estado. Chave estranha é raro,
+// mas um `new Set` de um número derruba a aba inteira, e perder a escolha guardada
+// custa muito menos do que isso.
+function lerEscolha(): EscolhaSalva {
+  const salvo = lerPreferencia(ESCOLHA, ESCOLHA_PADRAO);
+  return {
+    modo: salvo.modo === 'entrevista' ? 'entrevista' : 'dia',
+    trilhas: Array.isArray(salvo.trilhas) ? salvo.trilhas.filter((t) => typeof t === 'string') : [],
+    glossario: Boolean(salvo.glossario),
+    limite: /^\d+$/.test(String(salvo.limite)) ? String(salvo.limite) : '',
+  };
+}
 
 // Teto do campo de quantidade. Acima disso não é sessão, é maratona, e o campo
 // precisa de um limite para não aceitar número absurdo digitado sem querer.
@@ -124,19 +157,24 @@ export function Revisao() {
   const [stats, setStats] = useState<Estatisticas | null>(null);
   const [historico, setHistorico] = useState<SessaoRevisao[]>([]);
   const [fracos, setFracos] = useState<PontoFraco[]>([]);
+  // A escolha da última visita, lida uma vez antes do primeiro render. Marcar o
+  // estado depois, por efeito, faria a aba abrir no padrão e se corrigir sozinha na
+  // frente do aluno.
+  const [salvo] = useState(lerEscolha);
   // Qual dos dois modos está aberto. Os dois compartilham baralho, agenda e
   // estatísticas; o que muda é como o aluno escolhe o que entra na sessão.
-  const [modo, setModo] = useState<'dia' | 'entrevista'>('dia');
-  // Trilhas escolhidas. Vazio significa o baralho inteiro, e é como a aba abre.
-  const [selecao, setSelecao] = useState<Set<string>>(new Set());
-  const [comGlossario, setComGlossario] = useState(false);
+  const [modo, setModo] = useState<'dia' | 'entrevista'>(salvo.modo);
+  // Trilhas escolhidas. Vazio significa o baralho inteiro, e é como a aba abre na
+  // primeira visita.
+  const [selecao, setSelecao] = useState<Set<string>>(() => new Set(salvo.trilhas));
+  const [comGlossario, setComGlossario] = useState(salvo.glossario);
   const [escolhendo, setEscolhendo] = useState(false);
   // Busca da lista de áreas. Some junto com o painel, para não sobrar filtro
   // invisível na próxima vez que ele abrir.
   const [busca, setBusca] = useState('');
   const [vazio, setVazio] = useState(false);
   // Quantas cartas a sessão entrega, como o aluno digitou. Vazio é "vai até acabar".
-  const [limiteTexto, setLimiteTexto] = useState('');
+  const [limiteTexto, setLimiteTexto] = useState(salvo.limite);
   // Nulo é "sessão não começou"; a fila só é buscada quando o aluno manda começar.
   const [fila, setFila] = useState<Cartao[] | null>(null);
   const [indice, setIndice] = useState(0);
@@ -158,6 +196,12 @@ export function Revisao() {
   const mostradaEm = useRef<number>(0);
 
   const limite = limiteTexto ? Math.min(Number(limiteTexto), MAX_POR_SESSAO) : null;
+
+  // Uma área guardada pode ter saído do ar desde a última visita. Ela some da conta e
+  // da fila, mas continua marcada no estado: enquanto o baralho não chega, esquecer a
+  // escolha seria pior do que esperar por ela.
+  const noBaralho = new Set((baralhos?.trilhas ?? []).map((t) => t.id));
+  const selecaoAtiva = baralhos ? new Set([...selecao].filter((id) => noBaralho.has(id))) : selecao;
 
   const carregarSala = useCallback(async () => {
     setErro('');
@@ -191,7 +235,7 @@ export function Revisao() {
   }, []);
 
   async function comecar() {
-    const escolha = { trilhas: [...selecao], glossario: comGlossario, limite };
+    const escolha = { trilhas: [...selecaoAtiva], glossario: comGlossario, limite };
     setVazio(false);
     try {
       const cartoes = await filaDoDia(escolha, limite);
@@ -227,6 +271,18 @@ export function Revisao() {
   useEffect(() => {
     void carregarSala();
   }, [carregarSala]);
+
+  // A escolha é anotada a cada mudança, e não no "Começar": sair da aba sem começar
+  // também é uma escolha feita, e refazê-la na visita seguinte é justamente o
+  // incômodo que estamos tirando.
+  useEffect(() => {
+    gravarPreferencia(ESCOLHA, {
+      modo,
+      trilhas: [...selecao],
+      glossario: comGlossario,
+      limite: limiteTexto,
+    });
+  }, [modo, selecao, comGlossario, limiteTexto]);
 
   // Recarregar a página no meio da revisão não pode jogar o aluno de volta para a
   // escolha. A sessão volta parada, com o botão de continuar, e não abre sozinha.
@@ -441,12 +497,12 @@ export function Revisao() {
   });
 
   const restantes = total - indice;
-  const tudoMarcado = selecao.size === 0 && !comGlossario;
+  const tudoMarcado = selecaoAtiva.size === 0 && !comGlossario;
   const baralhoVazio = (resumo?.total ?? 0) === 0;
   const descricaoSelecao = tudoMarcado
     ? 'Todo o seu baralho'
     : [
-        ...(baralhos?.trilhas ?? []).filter((t) => selecao.has(t.id)).map((t) => t.nome),
+        ...(baralhos?.trilhas ?? []).filter((t) => selecaoAtiva.has(t.id)).map((t) => t.nome),
         ...(comGlossario ? ['Glossário'] : []),
       ].join(' + ');
   // Quantas cartas a escolha atual tem, e não quantas venceram: a fila serve o
@@ -455,7 +511,7 @@ export function Revisao() {
   const escolhidos = tudoMarcado
     ? (resumo?.total ?? 0)
     : (baralhos?.trilhas ?? [])
-        .filter((t) => selecao.has(t.id))
+        .filter((t) => selecaoAtiva.has(t.id))
         .reduce((soma, t) => soma + t.disponiveis, 0) +
       (comGlossario ? (baralhos?.glossario.total ?? 0) : 0);
   // 87 áreas não cabem numa lista rolável sem busca.

--- a/frontend/src/utils/preferencia.ts
+++ b/frontend/src/utils/preferencia.ts
@@ -1,0 +1,29 @@
+/**
+ * Preferências de tela guardadas no navegador.
+ *
+ * O acesso vai sempre dentro de try: em aba anônima, com dados de site bloqueados
+ * ou com a cota estourada, o próprio localStorage lança, e uma preferência de
+ * conveniência nunca pode derrubar a página. Sem valor guardado, ou com valor
+ * ilegível, volta o padrão.
+ *
+ * As chaves são limpas no logout junto com o resto, porque o AuthContext chama
+ * localStorage.clear(), então a escolha de uma pessoa não aparece para a seguinte.
+ */
+export function lerPreferencia<T>(chave: string, padrao: T): T {
+  try {
+    const bruto = localStorage.getItem(chave);
+    if (!bruto) return padrao;
+    return { ...padrao, ...(JSON.parse(bruto) as Partial<T>) };
+  } catch (err) {
+    console.error(`Preferência "${chave}" ilegível, usando o padrão.`, err);
+    return padrao;
+  }
+}
+
+export function gravarPreferencia(chave: string, valor: unknown) {
+  try {
+    localStorage.setItem(chave, JSON.stringify(valor));
+  } catch (err) {
+    console.error(`Não foi possível guardar a preferência "${chave}".`, err);
+  }
+}


### PR DESCRIPTION
## O problema

A escolha do que revisar vivia só na memória da página. Recarregar, trocar de aba
ou voltar no dia seguinte devolvia o painel zerado, e o aluno remarcava as mesmas
áreas e redigitava a mesma quantidade toda vez.

## O que mudou

- A revisão do dia guarda o modo aberto, as áreas marcadas, o glossário e a
  quantidade de cartas. O estado nasce do que ficou guardado, então a aba já abre
  marcada em vez de piscar o padrão e se corrigir sozinha.
- O ensaio de entrevista guarda nível, assuntos e tamanho da sessão em chave
  própria, inclusive assunto que não é do nível aberto agora: quem sobe para pleno
  e volta para júnior reencontra o que tinha marcado.
- Área que saiu do ar desde a última visita deixa de contar e de entrar na fila,
  para uma escolha antiga não virar uma sessão vazia sem explicação.
- `lerPreferencia` e `gravarPreferencia` centralizam o acesso ao localStorage
  dentro de `try`: em aba anônima ou com dados de site bloqueados, o próprio
  localStorage lança, e uma preferência de conveniência não pode derrubar a página.

As chaves entram no `localStorage.clear()` que o logout já faz, então a escolha de
uma pessoa não aparece para a seguinte.

## Como testar

1. Abrir a Revisão, marcar duas áreas e digitar uma quantidade.
2. Dar F5: as áreas continuam marcadas e a quantidade continua no campo.
3. Trocar para o ensaio de entrevista, escolher nível e assuntos, voltar para a
   revisão do dia e voltar de novo: a combinação continua lá.
