### PR TITLE
chore: leva para produção as perguntas de entrevista e as dependências atualizadas

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3701,9 +3701,9 @@
             }
         },
         "node_modules/nodemailer": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.4.tgz",
-            "integrity": "sha512-LmJNRVRtfSCULxcZpy0Cpg4WWenlUZ9+zbmTO+S7v9wD6XreYLjXRFtDjtV/4F0HT5p1GyZfA0Ux/myxHb18CQ==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.5.tgz",
+            "integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==",
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5151,9 +5151,9 @@
             "license": "MIT"
         },
         "node_modules/unpdf": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.8.0.tgz",
-            "integrity": "sha512-jQlkckbe5nKxRHQdbvo9IKHlU6Cjq00UlxxB8lrCIxvS2o5IbAL1wM+4a1Yc3+BIohg9p5AsoaftwO+G4Aq/qQ==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.8.1.tgz",
+            "integrity": "sha512-xkURhy2SoGpOIH0a1gLHNkASPIQYonadDJs2AQwPEfUakafeD9EA1WTWWsaR++gfTCXJpV27W7tU1nXuk82UKQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=22"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@anthropic-ai/sdk": "^0.116.0",
+                "@anthropic-ai/sdk": "^0.117.1",
                 "@types/cookie-parser": "^1.4.10",
                 "@types/cors": "^2.8.19",
                 "@types/ws": "^8.18.1",
@@ -51,9 +51,9 @@
             }
         },
         "node_modules/@anthropic-ai/sdk": {
-            "version": "0.116.0",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
-            "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
+            "version": "0.117.1",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
+            "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
             "license": "MIT",
             "dependencies": {
                 "json-schema-to-ts": "^3.1.1",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1420,17 +1420,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-            "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+            "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/type-utils": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/type-utils": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -1443,7 +1443,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.66.0",
+                "@typescript-eslint/parser": "^8.67.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -1459,16 +1459,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-            "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+            "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1484,14 +1484,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-            "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+            "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.66.0",
-                "@typescript-eslint/types": "^8.66.0",
+                "@typescript-eslint/tsconfig-utils": "^8.67.0",
+                "@typescript-eslint/types": "^8.67.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1506,14 +1506,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-            "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+            "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0"
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1524,9 +1524,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-            "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1541,15 +1541,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-            "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+            "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -1566,9 +1566,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-            "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+            "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1580,16 +1580,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-            "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.66.0",
-                "@typescript-eslint/tsconfig-utils": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/project-service": "8.67.0",
+                "@typescript-eslint/tsconfig-utils": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1608,16 +1608,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-            "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+            "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0"
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1632,13 +1632,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-            "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+            "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/types": "8.67.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -5095,16 +5095,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
-            "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+            "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.66.0",
-                "@typescript-eslint/parser": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0"
+                "@typescript-eslint/eslint-plugin": "8.67.0",
+                "@typescript-eslint/parser": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3219,9 +3219,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.10.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.10.0.tgz",
-            "integrity": "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA==",
+            "version": "17.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+            "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@anthropic-ai/sdk": "^0.116.0",
+        "@anthropic-ai/sdk": "^0.117.1",
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
         "@types/ws": "^8.18.1",

--- a/backend/scripts/data/entrevista/index.ts
+++ b/backend/scripts/data/entrevista/index.ts
@@ -10,5 +10,17 @@ import { java } from "./java.ts";
 import { react } from "./react.ts";
 import { node } from "./node.ts";
 import { typescript } from "./typescript.ts";
+import { systemDesign } from "./system-design.ts";
 
-export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java, react, node, typescript];
+export const TOPICOS: TopicoDeEntrevista[] = [
+    go,
+    csharp,
+    cpp,
+    docker,
+    git,
+    java,
+    react,
+    node,
+    typescript,
+    systemDesign,
+];

--- a/backend/scripts/data/entrevista/index.ts
+++ b/backend/scripts/data/entrevista/index.ts
@@ -6,5 +6,6 @@ import { csharp } from "./csharp.ts";
 import { cpp } from "./cpp.ts";
 import { docker } from "./docker.ts";
 import { git } from "./git.ts";
+import { java } from "./java.ts";
 
-export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git];
+export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java];

--- a/backend/scripts/data/entrevista/index.ts
+++ b/backend/scripts/data/entrevista/index.ts
@@ -9,5 +9,6 @@ import { git } from "./git.ts";
 import { java } from "./java.ts";
 import { react } from "./react.ts";
 import { node } from "./node.ts";
+import { typescript } from "./typescript.ts";
 
-export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java, react, node];
+export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java, react, node, typescript];

--- a/backend/scripts/data/entrevista/index.ts
+++ b/backend/scripts/data/entrevista/index.ts
@@ -7,5 +7,6 @@ import { cpp } from "./cpp.ts";
 import { docker } from "./docker.ts";
 import { git } from "./git.ts";
 import { java } from "./java.ts";
+import { react } from "./react.ts";
 
-export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java];
+export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java, react];

--- a/backend/scripts/data/entrevista/index.ts
+++ b/backend/scripts/data/entrevista/index.ts
@@ -8,5 +8,6 @@ import { docker } from "./docker.ts";
 import { git } from "./git.ts";
 import { java } from "./java.ts";
 import { react } from "./react.ts";
+import { node } from "./node.ts";
 
-export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java, react];
+export const TOPICOS: TopicoDeEntrevista[] = [go, csharp, cpp, docker, git, java, react, node];

--- a/backend/scripts/data/entrevista/java.ts
+++ b/backend/scripts/data/entrevista/java.ts
@@ -1,0 +1,1144 @@
+import type { TopicoDeEntrevista } from "../../seed-entrevista.ts";
+
+/**
+ * Perguntas de entrevista de Java.
+ *
+ * O nível segue o que a pergunta cobra, e não o assunto. Coleção aparece nos quatro
+ * níveis: em estágio é "qual a diferença entre ArrayList e LinkedList", em sênior é
+ * como o time decide o que usar sem transformar cada revisão numa discussão.
+ */
+export const java: TopicoDeEntrevista = {
+    slug: "java",
+    nome: "Java",
+    position: 6,
+    perguntas: {
+        estagio: [
+            {
+                frente: "O que a JVM faz para o mesmo programa rodar em sistemas diferentes?",
+                verso: "O compilador gera bytecode, que não é código de máquina de nenhum processador. Quem traduz para a máquina real é a JVM daquele sistema, na hora da execução. Por isso o mesmo jar roda em Linux, Windows e Mac, desde que exista uma JVM compatível instalada.",
+            },
+            {
+                frente: "Qual a diferença entre JDK, JRE e JVM?",
+                verso: "A JVM é quem executa o bytecode. O JRE é a JVM mais as bibliotecas padrão, o suficiente para rodar. O JDK acrescenta o compilador e as ferramentas de desenvolvimento. Para escrever código você precisa do JDK; para só executar, o JRE bastava.",
+            },
+            {
+                frente: "Qual a diferença entre compilar e executar um programa Java?",
+                verso: "Compilar transforma o código em bytecode e é quando erro de tipo e de sintaxe aparece. Executar é a JVM interpretar e otimizar esse bytecode, e é quando erro de lógica, nulo e falha de ambiente aparecem. Compilar sem erro não diz nada sobre o comportamento.",
+            },
+            {
+                frente: "O que é uma classe e o que é um objeto?",
+                verso: "A classe é o molde: descreve quais dados e comportamentos aquele tipo tem. O objeto é uma instância desse molde, criada com new, com seus próprios valores. Mil objetos da mesma classe compartilham o comportamento e não compartilham o estado.",
+            },
+            {
+                frente: "Para que serve o construtor?",
+                verso: "Para o objeto nascer num estado válido, recebendo o que ele precisa para funcionar. Se você não declara nenhum, o compilador cria um sem argumentos. Deixar campo obrigatório fora do construtor é o que produz objeto pela metade circulando pelo código.",
+            },
+            {
+                frente: "O que o this representa?",
+                verso: "A referência ao próprio objeto em que o método está rodando. Serve para diferenciar o campo do parâmetro de mesmo nome e para um construtor chamar outro da mesma classe. Em método estático ele não existe, porque não há instância.",
+            },
+            {
+                frente: "Qual a diferença entre tipo primitivo e wrapper?",
+                verso: "O primitivo guarda o valor direto e não pode ser nulo, como int e boolean. O wrapper é um objeto que embrulha esse valor, como Integer, e aceita nulo. Coleção só guarda objeto, então lista de números usa wrapper, e isso custa memória e uma indireção.",
+            },
+            {
+                frente: "O que é autoboxing e que armadilha ele traz?",
+                verso: "É a conversão automática entre primitivo e wrapper, como colocar um int numa List de Integer. A armadilha é o Integer nulo desembrulhado, que estoura NullPointerException numa linha que parece aritmética, e a comparação com == entre wrappers, que compara referência.",
+            },
+            {
+                frente: "Por que String é imutável em Java?",
+                verso: "Porque isso permite compartilhar a mesma instância com segurança entre threads e reaproveitar literais no pool. Também torna o hash estável, o que faz String ser boa chave de mapa. O custo é que toda alteração cria um novo objeto.",
+            },
+            {
+                frente: "Quando você usaria == e quando usaria equals?",
+                verso: "O == compara referência, ou seja, se as duas variáveis apontam para o mesmo objeto. O equals compara conteúdo, do jeito que a classe definiu. Para primitivo o == compara valor mesmo. Comparar String com == funciona às vezes por causa do pool, e é por isso que engana.",
+            },
+            {
+                frente: "Como você compararia dois textos ignorando maiúsculas e minúsculas?",
+                verso: "Com equalsIgnoreCase, que já trata a diferença sem criar cópias. Converter os dois para minúsculo antes de comparar também funciona, mas gera objetos à toa e esbarra em regra de idioma em alguns alfabetos. Antes disso, garanta que nenhum dos dois é nulo.",
+            },
+            {
+                frente: "O que acontece se você sobrescrever equals e esquecer hashCode?",
+                verso: "Dois objetos passam a ser iguais mas caem em posições diferentes de um HashMap ou HashSet. O resultado é elemento duplicado no conjunto e busca que não encontra o que foi guardado. O contrato é claro: objetos iguais precisam ter o mesmo hash.",
+            },
+            {
+                frente: "Como você compararia dois objetos sem correr risco de nulo?",
+                verso: "Com Objects.equals, que trata os dois lados nulos e só delega para o equals quando faz sentido. Chamar equals direto numa referência que pode ser nula é uma das causas mais comuns de NullPointerException em código que parece defensivo.",
+            },
+            {
+                frente: "Por que concatenar String dentro de um laço é problema?",
+                verso: "Cada concatenação cria um objeto novo e copia o conteúdo anterior, então o custo cresce com o quadrado do tamanho. Dentro de laço isso aparece rápido. StringBuilder acumula num buffer que cresce, e só materializa a String no final.",
+            },
+            {
+                frente: "Quando você usaria String.format em vez de concatenar?",
+                verso: "Quando o texto tem vários pontos variáveis e a leitura fica ruim com sinais de mais espalhados, ou quando há formatação de número e data envolvida. Para juntar duas partes simples, concatenar continua mais direto e mais rápido de ler.",
+            },
+            {
+                frente: "O que muda entre um bloco de texto e uma String comum?",
+                verso: "O bloco de texto usa três aspas e permite várias linhas sem escapar aspas nem juntar pedaços com n escapado. Serve muito bem para SQL, JSON e HTML embutidos. É açúcar de sintaxe: no fim continua sendo uma String comum.",
+            },
+            {
+                frente: "Como você converteria um texto em número?",
+                verso: "Com Integer.parseInt ou Double.parseDouble, lembrando que texto inválido lança NumberFormatException. Em entrada vinda de usuário isso precisa de tratamento, e não de confiança. Para valor decimal com vírgula, o formato local importa.",
+            },
+            {
+                frente: "Por que não usar double para representar dinheiro?",
+                verso: "Porque double é binário e não representa exatamente valores como 0,1, então somas acumulam erro e o total fecha errado por centavos. Para dinheiro se usa BigDecimal, criado a partir de String, ou um inteiro contando a menor unidade.",
+            },
+            {
+                frente: "O que acontece ao dividir um número inteiro por zero?",
+                verso: "Lança ArithmeticException na hora. Com ponto flutuante o comportamento é outro: o resultado vira infinito ou NaN, sem exceção nenhuma, e o problema só aparece páginas depois. Por isso divisão com denominador vindo de fora sempre precisa de checagem.",
+            },
+            {
+                frente: "O que é um array em Java?",
+                verso: "Uma sequência de tamanho fixo, definido na criação, com todos os elementos do mesmo tipo e acesso por índice a partir do zero. Índice fora do intervalo lança exceção em vez de ler memória qualquer. Na maior parte do código do dia a dia se usa List no lugar.",
+            },
+            {
+                frente: "Qual a diferença entre length, length() e size()?",
+                verso: "O length é campo de array, o length() é método de String, e o size() é método de coleção. Não é inconsistência à toa: são três tipos diferentes com histórias diferentes. Confundir os três é erro de compilação, então o compilador avisa.",
+            },
+            {
+                frente: "Qual a diferença entre ArrayList e LinkedList?",
+                verso: "O ArrayList guarda os elementos em um array, então acesso por índice é imediato e inserir no meio exige deslocar o resto. O LinkedList guarda nós ligados, e inserir no meio é barato se você já está na posição. Na prática o ArrayList vence quase sempre, por causa da localidade de memória.",
+            },
+            {
+                frente: "Como você escolheria entre List, Set e Map?",
+                verso: "List quando a ordem importa e a repetição é aceitável. Set quando cada elemento aparece uma vez só e você quer checar pertencimento rápido. Map quando cada valor é encontrado por uma chave. A escolha errada aparece como laço buscando dentro de laço.",
+            },
+            {
+                frente: "Como você percorreria uma lista?",
+                verso: "Com for aprimorado quando você só precisa do elemento, que é o caso comum e o mais legível. Com índice quando a posição importa. Com iterador quando precisa remover durante a passagem, porque remover pela lista dentro do for aprimorado lança ConcurrentModificationException.",
+            },
+            {
+                frente: "O que é uma coleção imutável?",
+                verso: "Uma coleção que recusa alteração depois de criada, como as devolvidas por List.of. Tentar adicionar lança UnsupportedOperationException. Serve para constante e para retorno que ninguém deve mexer, e evita que um chamador altere a lista interna de um objeto.",
+            },
+            {
+                frente: "Como você juntaria uma lista de nomes numa única String?",
+                verso: "Com String.join passando o separador, que já cuida de não sobrar separador no fim. Em fluxo com stream, o Collectors.joining faz o mesmo e ainda aceita prefixo e sufixo. Montar na mão com laço e if de primeira volta é onde o erro de vírgula aparece.",
+            },
+            {
+                frente: "Qual a diferença entre interface e classe abstrata?",
+                verso: "A interface declara o que um tipo sabe fazer, e uma classe pode implementar várias. A classe abstrata é herança de verdade, com estado e construtor, e só se herda de uma. A regra prática é usar interface para contrato e classe abstrata para compartilhar implementação.",
+            },
+            {
+                frente: "O que é herança e quando ela ajuda?",
+                verso: "É uma classe estender outra e receber comportamento e estado dela. Ajuda quando existe relação de é um de verdade e a subclasse pode substituir a superclasse sem surpresa. Para só reaproveitar código, composição costuma envelhecer melhor.",
+            },
+            {
+                frente: "O que o super faz?",
+                verso: "Chama o construtor da superclasse ou acessa o membro dela quando a subclasse sobrescreveu. É comum na primeira linha do construtor para inicializar a parte herdada. Sem chamada explícita, o compilador insere a chamada ao construtor sem argumentos.",
+            },
+            {
+                frente: "O que é polimorfismo na prática?",
+                verso: "Tratar objetos diferentes pelo mesmo tipo e deixar cada um responder do seu jeito. Uma lista de Forma chamando desenhar executa o código do círculo ou do quadrado conforme o objeto real. É o que substitui cadeia de if verificando tipo.",
+            },
+            {
+                frente: "O que muda entre sobrecarga e sobrescrita de método?",
+                verso: "Sobrecarga é ter métodos de mesmo nome e parâmetros diferentes na mesma classe, e o compilador escolhe qual chamar. Sobrescrita é a subclasse trocar o comportamento de um método herdado, e a escolha acontece em tempo de execução pelo tipo real do objeto.",
+            },
+            {
+                frente: "O que a anotação Override faz?",
+                verso: "Pede ao compilador que confirme que aquele método realmente sobrescreve algo. Se você errar a assinatura, ele acusa em vez de criar um método novo que nunca é chamado. É barata e evita um dos bugs mais silenciosos da linguagem.",
+            },
+            {
+                frente: "O que o instanceof faz?",
+                verso: "Testa se a referência aponta para um objeto daquele tipo, e devolve falso para nulo. Nas versões recentes ele já declara a variável convertida no mesmo teste. Cadeia grande de instanceof costuma ser sinal de que faltou polimorfismo.",
+            },
+            {
+                frente: "Para que serve a palavra static?",
+                verso: "Liga o membro à classe, e não a cada instância. Existe uma cópia só, acessível sem criar objeto. Serve para constante e método utilitário. O cuidado é que campo estático mutável vira estado global compartilhado entre todas as requisições.",
+            },
+            {
+                frente: "O que final significa em variável, método e classe?",
+                verso: "Em variável, o valor não pode ser reatribuído depois de definido, o que não impede alterar o objeto apontado. Em método, a subclasse não pode sobrescrever. Em classe, ninguém pode herdar. É uma forma de declarar intenção e evitar mudança acidental.",
+            },
+            {
+                frente: "Como você declararia uma constante?",
+                verso: "Como campo static final, em maiúsculas com palavras separadas por sublinhado, por convenção. O static evita uma cópia por objeto e o final impede reatribuição. Se a constante for uma coleção, ela ainda precisa ser imutável para valer de verdade.",
+            },
+            {
+                frente: "Qual a diferença entre variável local, de instância e de classe?",
+                verso: "A local vive dentro do método e some no fim dele. A de instância pertence a cada objeto e vive enquanto ele existir. A de classe é estática e existe uma só para todos. Escolher a errada é o que faz estado vazar entre requisições.",
+            },
+            {
+                frente: "O que acontece com uma variável local não inicializada?",
+                verso: "O compilador recusa o código se você tentar lê-la, o que é uma proteção e não um incômodo. Campo de instância é diferente: ele recebe o valor padrão do tipo, zero, falso ou nulo. Essa diferença explica muito NullPointerException em campo esquecido.",
+            },
+            {
+                frente: "Qual a diferença entre exceção checada e não checada?",
+                verso: "A checada precisa ser tratada ou declarada na assinatura, e o compilador cobra. A não checada, que herda de RuntimeException, não obriga nada. A ideia original era usar checada para falha esperada e recuperável, mas na prática muita gente só declara e repassa.",
+            },
+            {
+                frente: "O que o bloco finally garante?",
+                verso: "Que o trecho roda com ou sem exceção, e mesmo quando há return antes dele. É onde a liberação de recurso vive quando não se usa try com recursos. Não roda se a JVM morre no meio, então não serve como garantia de consistência de dado.",
+            },
+            {
+                frente: "O que a pilha de execução de um erro está te dizendo?",
+                verso: "A sequência de chamadas até o ponto onde a exceção nasceu, do mais recente para o mais antigo, e a causa encadeada quando existe. A primeira linha do seu pacote costuma ser onde investigar. Ler de baixo para cima ajuda a achar o que originou.",
+            },
+            {
+                frente: "Como você trataria a leitura de um arquivo que pode não existir?",
+                verso: "Checando antes ou tratando a exceção de entrada e saída, e decidindo o que fazer: usar um padrão, avisar o usuário ou falhar de forma clara. O que não pode é capturar e seguir em silêncio, porque aí o problema aparece como dado faltando muito depois.",
+            },
+            {
+                frente: "O que os modificadores de visibilidade controlam?",
+                verso: "Quem enxerga o membro. Private só a própria classe, sem modificador só o mesmo pacote, protected acrescenta as subclasses, e public todo mundo. Deixar tudo público transforma detalhe interno em contrato, e depois qualquer mudança quebra alguém.",
+            },
+            {
+                frente: "O que é um pacote e por que ele importa?",
+                verso: "É o agrupamento das classes, refletido na estrutura de pastas, que evita choque de nomes e organiza o projeto por assunto. Ele também é fronteira de visibilidade: membro sem modificador só é visto dentro do mesmo pacote.",
+            },
+            {
+                frente: "O que acontece se duas bibliotecas tiverem classes de mesmo nome?",
+                verso: "Nada, desde que estejam em pacotes diferentes, porque o nome completo inclui o pacote. No arquivo você importa uma e usa a outra pelo nome completo. O problema real é a mesma classe aparecer em duas versões no classpath, e aí vence a primeira encontrada.",
+            },
+            {
+                frente: "O que o coletor de lixo faz, e o que ele não faz?",
+                verso: "Libera memória de objetos que não são mais alcançáveis a partir das raízes do programa. Ele não fecha arquivo, conexão nem socket, e não roda em momento previsível. Objeto ainda referenciado por engano, como numa lista estática, nunca é recolhido.",
+            },
+            {
+                frente: "Para que serve o var, e quando ele atrapalha?",
+                verso: "Deixa o compilador inferir o tipo da variável local, tirando repetição de nomes longos. Atrapalha quando o lado direito não diz qual é o tipo, como uma chamada de método com nome vago, e quem lê o código precisa abrir outra classe para entender.",
+            },
+            {
+                frente: "O que acontece quando você chama um método em uma referência nula?",
+                verso: "A JVM lança NullPointerException no ponto da chamada. Nas versões recentes a mensagem diz qual referência era nula, o que reduz muito o tempo de investigação. Evitar o problema é questão de desenho: não devolver nulo onde a lista vazia serve.",
+            },
+            {
+                frente: "Para que serve o Objects.requireNonNull?",
+                verso: "Para falhar no construtor ou no início do método, e não vinte linhas depois com uma exceção sem contexto. Ele deixa a exigência explícita na leitura do código e permite passar uma mensagem dizendo qual argumento faltou.",
+            },
+            {
+                frente: "O que o método main precisa ter para a JVM encontrá-lo?",
+                verso: "Precisa ser público, estático, sem retorno e receber um array de String. A JVM procura essa assinatura exata na classe indicada. Assinatura parecida compila normalmente, mas a aplicação não sobe, e o erro só aparece na hora de rodar.",
+            },
+            {
+                frente: "Como você leria uma entrada digitada no console?",
+                verso: "Com Scanner sobre a entrada padrão, lendo linha ou valor conforme o caso. O cuidado clássico é misturar leitura de número com leitura de linha, que deixa a quebra de linha pendente e faz a próxima leitura vir vazia. Em serviço real isso quase não aparece.",
+            },
+            {
+                frente: "Qual a diferença entre while e do while?",
+                verso: "O while testa antes, então pode nunca executar. O do while executa uma vez e testa depois. Na prática o do while é raro, e aparece quando a primeira execução é obrigatória, como pedir entrada até vir algo válido.",
+            },
+            {
+                frente: "Qual a diferença entre break e continue?",
+                verso: "O break sai do laço inteiro, e o continue pula para a próxima iteração. Os dois deixam o fluxo mais difícil de acompanhar quando aparecem no meio de laço grande, e é aí que extrair um método com nome bom costuma resolver melhor.",
+            },
+            {
+                frente: "Quando o switch é melhor que uma cadeia de if?",
+                verso: "Quando você compara o mesmo valor contra várias opções fixas, como um enum. Fica mais legível e o compilador ajuda a cobrar todos os casos. Para condições diferentes entre si, if encadeado continua sendo o certo.",
+            },
+            {
+                frente: "O que o operador ternário resolve?",
+                verso: "Escolher entre dois valores numa única expressão, o que permite atribuir direto e usar em campo final. Ele deixa de ajudar quando é aninhado: dois ternários dentro de outro custam mais para ler do que um if bem escrito.",
+            },
+            {
+                frente: "Como você faria um método devolver mais de um valor?",
+                verso: "Criando um tipo que represente o resultado, que hoje costuma ser um record de duas ou três linhas. Isso dá nome aos campos e sobrevive à evolução. Devolver array, mapa ou lista de Object economiza uma classe e cobra em toda leitura futura.",
+            },
+            {
+                frente: "Por que alterar um objeto dentro de um método afeta quem chamou, se Java é por valor?",
+                verso: "Porque o que é copiado é a referência, e não o objeto. As duas variáveis apontam para o mesmo lugar, então alterar um campo é visível fora. Reatribuir o parâmetro, ao contrário, não muda nada para quem chamou.",
+            },
+            {
+                frente: "Para que serve o método toString?",
+                verso: "Para o objeto ter uma representação legível em log e depuração. O padrão herdado mostra o nome da classe e um número, que não ajuda ninguém. Ao sobrescrever, o cuidado é não vazar dado sensível, porque isso acaba em arquivo de log.",
+            },
+            {
+                frente: "O que é uma classe anônima e onde ela ainda aparece?",
+                verso: "É implementar uma interface ou estender uma classe no ponto de uso, sem dar nome. Aparecia muito em ouvinte de evento e comparador. Hoje lambda cobre a maior parte dos casos, e a classe anônima fica para quando é preciso mais de um método ou estado.",
+            },
+            {
+                frente: "O que é o classpath?",
+                verso: "A lista de lugares onde a JVM procura as classes e recursos que o programa usa. Erro de classe não encontrada em tempo de execução quase sempre é classpath, e não código. Ferramenta de build monta isso para você a partir das dependências declaradas.",
+            },
+            {
+                frente: "Para que serve o Maven ou o Gradle num projeto Java?",
+                verso: "Para declarar dependências e baixá-las com suas próprias dependências, padronizar a estrutura de pastas e rodar compilação, teste e empacotamento com um comando. Sem isso, cada máquina monta o classpath do seu jeito e o build da sua difere do da minha.",
+            },
+            {
+                frente: "O que é um jar?",
+                verso: "Um arquivo compactado com as classes compiladas e os recursos do projeto, mais um manifesto. Pode ser biblioteca ou executável, quando o manifesto aponta a classe principal. É a unidade que você publica ou entrega para rodar.",
+            },
+            {
+                frente: "Como você escreveria um teste automatizado simples?",
+                verso: "Com JUnit, um método anotado como teste que prepara a entrada, chama o código e verifica o resultado com uma asserção. Um caso por comportamento, com nome dizendo o que se espera. Teste que não falha quando o código quebra não está testando.",
+            },
+            {
+                frente: "O que uma exceção interrompe?",
+                verso: "O fluxo normal do método, que devolve o controle para quem chamou até alguém capturar. Nada depois da linha que lançou executa, exceto o finally e o fechamento do try com recursos. Por isso operação pela metade precisa de transação, e não de esperança.",
+            },
+            {
+                frente: "Como você documentaria uma classe pública?",
+                verso: "Com Javadoc dizendo o que ela faz e o que não faz, mais o significado dos parâmetros e do retorno. O que já está óbvio na assinatura não precisa ser repetido. Documentação que só reescreve o nome do método envelhece e ninguém corrige.",
+            },
+            {
+                frente: "O que é sombreamento de variável?",
+                verso: "É declarar no escopo interno um nome que já existe no externo, como parâmetro com o mesmo nome do campo. O interno esconde o externo, e a atribuição vai para o lugar errado sem erro de compilação. Por isso construtor usa this ao atribuir campo.",
+            },
+            {
+                frente: "Como um laço infinito aparece por engano?",
+                verso: "Quando a condição depende de algo que o corpo esqueceu de atualizar, ou quando o incremento está dentro de um if que nem sempre roda. O sintoma é uso de CPU no talo com o programa parado. Sair pelo meio com break é o remendo, não a correção.",
+            },
+            {
+                frente: "O que muda ao declarar uma variável como o tipo da interface e não da classe?",
+                verso: "O código passa a depender do contrato, e trocar a implementação vira uma linha. Declarar List e instanciar ArrayList é o caso mais comum. Declarar pelo tipo concreto amarra quem usa a detalhes que não precisava conhecer.",
+            },
+            {
+                frente: "Como você organizaria as classes de um projeto pequeno?",
+                verso: "Por assunto, e não por tipo técnico. Um pacote por área do problema, com o que muda junto ficando junto. Separar em controladores, serviços e repositórios espalha uma mudança simples por três pastas, e essa conta piora conforme o projeto cresce.",
+            },
+            {
+                frente: "Que convenções de nome Java espera de você?",
+                verso: "Classe em PascalCase, método e variável em camelCase, constante em maiúsculas com sublinhado e pacote em minúsculas. Não é firula: ferramenta, framework e quem revisa contam com isso. Nome que descreve o papel vale mais que nome curto.",
+            },
+        ],
+        junior: [
+            {
+                frente: "Como um HashMap encontra um valor?",
+                verso: "Calcula o hash da chave, usa esse número para escolher um balde e compara com equals dentro dele. Com boa distribuição, a busca é praticamente imediata. Quando muitas chaves caem no mesmo balde, a lista interna vira árvore para não degradar tanto.",
+            },
+            {
+                frente: "O que quebra se a chave de um HashMap for mutável?",
+                verso: "Alterar o campo que entra no hash muda o balde calculado, mas o objeto continua guardado no balde antigo. A entrada some das buscas e continua ocupando memória. Por isso chave boa é imutável, como String ou um record de campos finais.",
+            },
+            {
+                frente: "Qual a diferença entre HashMap, LinkedHashMap e TreeMap?",
+                verso: "O HashMap não garante ordem nenhuma. O LinkedHashMap mantém a ordem de inserção, ao custo de uma lista ligada extra. O TreeMap mantém as chaves ordenadas usando comparação, com custo logarítmico em vez de constante. Escolha pelo que a saída precisa garantir.",
+            },
+            {
+                frente: "Como você implementaria equals corretamente?",
+                verso: "Checando identidade primeiro, depois o tipo, depois cada campo que define igualdade, e sempre junto com hashCode usando os mesmos campos. Ele precisa ser simétrico, transitivo e consistente. Em tipo de dado, o record já entrega tudo isso pronto.",
+            },
+            {
+                frente: "Quando você usaria um HashSet em vez de uma lista?",
+                verso: "Quando a pergunta que você faz é se o elemento está lá, e não em que posição ele está. A checagem sai de percorrer tudo para praticamente imediata. Trocar contains de lista por conjunto costuma ser a otimização mais barata de um laço aninhado.",
+            },
+            {
+                frente: "O que acontece se você alterar uma coleção enquanto itera sobre ela?",
+                verso: "O iterador detecta a modificação e lança ConcurrentModificationException, mesmo sem thread nenhuma envolvida. Para remover durante a passagem, use o remove do próprio iterador ou removeIf. Copiar a lista antes resolve, mas paga uma cópia.",
+            },
+            {
+                frente: "Como você percorreria um Map?",
+                verso: "Iterando sobre entrySet, que dá chave e valor numa passada só. Percorrer keySet e chamar get para cada chave faz duas buscas por elemento sem necessidade. Para só um dos lados, existem keySet e values.",
+            },
+            {
+                frente: "Quando você implementaria Comparable e quando passaria um Comparator?",
+                verso: "Comparable quando o tipo tem uma ordem natural única, como data ou dinheiro. Comparator quando a ordem depende do contexto, como listar por nome numa tela e por valor em outra. Comparator também evita sujar o domínio com regra de apresentação.",
+            },
+            {
+                frente: "Como você ordenaria uma lista por dois critérios?",
+                verso: "Com Comparator.comparing no primeiro campo e thenComparing no seguinte, o que lê quase como a frase do requisito. Para inverter só um deles, reversed se aplica ao comparador construído até ali, e é onde a ordem das chamadas engana.",
+            },
+            {
+                frente: "O que muda ao trocar um laço por um stream?",
+                verso: "O código passa a descrever a transformação em vez do passo a passo, o que costuma ler melhor em filtro e mapeamento encadeados. Em troca, a pilha de erro fica mais confusa e depurar exige mais esforço. Para laço simples com efeito colateral, o for continua melhor.",
+            },
+            {
+                frente: "Quando um stream é realmente executado?",
+                verso: "Só quando chega uma operação terminal, como collect, forEach ou count. Antes disso as etapas apenas são registradas. É por isso que um stream sem terminal não faz nada e não dá erro, e que o elemento atravessa todas as etapas de uma vez, e não etapa por etapa em toda a coleção.",
+            },
+            {
+                frente: "O que acontece se você reutilizar um stream já consumido?",
+                verso: "Lança IllegalStateException, porque o stream é de passagem única. Se precisar de duas leituras, guarde a coleção e crie um stream novo a cada vez. Isso também explica por que não se guarda stream em campo nem se devolve um em API pública sem pensar.",
+            },
+            {
+                frente: "Qual a diferença entre map e flatMap?",
+                verso: "O map transforma cada elemento em outro, mantendo a contagem. O flatMap transforma cada elemento em um stream e junta todos num só, então serve para achatar lista de listas. Se o resultado do map já é uma coleção, o que você queria era flatMap.",
+            },
+            {
+                frente: "Como você agruparia uma lista por um campo?",
+                verso: "Com Collectors.groupingBy passando a função que extrai a chave, o que devolve um Map de chave para lista. Um segundo coletor permite contar, somar ou mapear cada grupo direto. É o caso onde stream ganha do laço com folga.",
+            },
+            {
+                frente: "Qual a diferença entre findFirst e findAny?",
+                verso: "O findFirst respeita a ordem do stream e devolve o primeiro. O findAny pode devolver qualquer um, o que permite parar mais cedo em stream paralelo. Em stream sequencial os dois costumam dar o mesmo resultado, mas o contrato é diferente.",
+            },
+            {
+                frente: "Quando o Optional ajuda, e quando ele só empurra o problema?",
+                verso: "Ajuda como retorno de método que pode não achar nada, porque obriga quem chama a decidir. Empurra o problema quando vira campo de entidade, parâmetro ou quando o código só chama get sem checar, que é o NullPointerException com outro nome.",
+            },
+            {
+                frente: "Qual a diferença entre orElse e orElseGet?",
+                verso: "O orElse recebe um valor, que é calculado sempre, mesmo quando o Optional tem conteúdo. O orElseGet recebe uma função, avaliada só quando falta valor. Quando o valor de reserva é caro, como uma consulta ao banco, essa diferença deixa de ser detalhe.",
+            },
+            {
+                frente: "O que é uma interface funcional?",
+                verso: "Uma interface com um único método abstrato, o que permite passá-la como lambda ou referência de método. É o que faz Runnable, Comparator e Function funcionarem com sintaxe curta. A anotação FunctionalInterface não cria a regra, apenas faz o compilador cobrá-la.",
+            },
+            {
+                frente: "O que muda entre Function, Consumer, Supplier e Predicate?",
+                verso: "Function recebe e devolve, Consumer recebe e não devolve, Supplier não recebe e devolve, e Predicate recebe e devolve booleano. São só nomes para as formas mais comuns de lambda, e conhecê-las evita criar interface própria para cada caso.",
+            },
+            {
+                frente: "O que é uma referência de método?",
+                verso: "Uma forma curta de escrever um lambda que só chama um método existente, como Usuario::getNome no lugar de u para u.getNome(). Lê melhor quando não há transformação extra. Quando há qualquer lógica no meio, o lambda explícito é mais honesto.",
+            },
+            {
+                frente: "Como você trataria uma exceção checada dentro de um lambda?",
+                verso: "Capturando dentro do próprio lambda e traduzindo para algo não checado, ou tirando o trecho para um método que já trata. As interfaces funcionais padrão não declaram exceção checada, então não existe jeito limpo de deixar subir sem envolver o erro.",
+            },
+            {
+                frente: "O que o apagamento de tipos custa em generics?",
+                verso: "O tipo genérico existe só na compilação, e em tempo de execução List de String e List de Integer são a mesma coisa. Isso impede checar o tipo com instanceof, criar array do tipo genérico e sobrecarregar métodos que só diferem no parâmetro genérico.",
+            },
+            {
+                frente: "Para que serve o curinga numa assinatura genérica?",
+                verso: "Para o método aceitar uma família de tipos em vez de um só. O extends serve para quem só lê da coleção, e o super para quem só escreve nela. Sem isso, um método que soma números não aceitaria uma lista de inteiros, porque generics não é covariante.",
+            },
+            {
+                frente: "O que o try com recursos resolve?",
+                verso: "Fecha o recurso automaticamente ao sair do bloco, na ordem inversa da abertura, inclusive quando há exceção. Evita o finally aninhado e o recurso esquecido aberto. Também guarda a exceção do fechamento como suprimida, em vez de esconder a original.",
+            },
+            {
+                frente: "O que acontece se o finally lançar uma exceção?",
+                verso: "Ela substitui a exceção original, que se perde sem deixar rastro. É por isso que finally não é lugar para lógica que pode falhar, e é uma das razões do try com recursos existir: lá a falha do fechamento vira exceção suprimida em vez de apagar a causa.",
+            },
+            {
+                frente: "Como você deixaria uma classe imutável?",
+                verso: "Campos finais e privados, sem setter, classe final ou construtor privado para ninguém herdar e furar a regra, e cópia defensiva do que entra e do que sai quando o campo é mutável. Um record já faz boa parte disso, menos a cópia defensiva.",
+            },
+            {
+                frente: "Qual a diferença entre cópia rasa e cópia profunda?",
+                verso: "A rasa copia os campos, então os objetos internos continuam sendo os mesmos e compartilhados. A profunda copia também o que está dentro. Devolver uma cópia rasa de uma lista de objetos mutáveis dá falsa sensação de proteção.",
+            },
+            {
+                frente: "O que Cloneable tem de problemático?",
+                verso: "É uma interface sem método, e o clone herdado é protegido, faz cópia rasa e não chama construtor. Na prática se usa construtor de cópia ou fábrica estática, que são explícitos e funcionam com campos finais. Clone é história antiga da linguagem.",
+            },
+            {
+                frente: "O que um enum em Java pode fazer além de listar constantes?",
+                verso: "Ter campos, construtor e métodos, inclusive comportamento diferente por constante. Isso permite trocar um switch espalhado por polimorfismo dentro do próprio enum. Ele também é a forma mais simples e segura de singleton na linguagem.",
+            },
+            {
+                frente: "Quando um record é a escolha certa?",
+                verso: "Quando o tipo existe para transportar dado, e a identidade dele é o conjunto dos valores. Ele já vem com construtor, acessores, equals, hashCode e toString coerentes. Não serve quando o objeto precisa de estado mutável ou de herança.",
+            },
+            {
+                frente: "O que é uma classe selada, e que problema ela resolve?",
+                verso: "É uma classe ou interface que declara quais tipos podem estendê-la. Isso fecha a hierarquia e permite ao compilador saber que os casos são aqueles, cobrando switch completo. Serve bem para modelar resultado com poucas variações conhecidas.",
+            },
+            {
+                frente: "O que o switch com padrão mudou no código Java?",
+                verso: "Permite decidir pelo tipo e já receber a variável convertida, com o compilador cobrando que todos os casos de uma hierarquia selada sejam tratados. Substitui cadeia de instanceof com conversão manual, que era onde o erro de esquecer um caso aparecia.",
+            },
+            {
+                frente: "O que é um método default numa interface?",
+                verso: "Um método com corpo dentro da interface, criado para permitir acrescentar comportamento sem quebrar quem já implementava. Serve para evolução de API, não para virar lugar de lógica de negócio. Se duas interfaces trazem o mesmo default, a classe precisa desempatar.",
+            },
+            {
+                frente: "Qual a diferença entre classe interna estática e não estática?",
+                verso: "A não estática guarda uma referência implícita ao objeto externo, o que a impede de ser coletada enquanto viver e vaza contexto sem ninguém perceber. A estática é apenas uma classe aninhada por organização. Na dúvida, estática.",
+            },
+            {
+                frente: "O que é um bloco estático de inicialização?",
+                verso: "Um trecho que roda uma vez quando a classe é carregada, usado para preparar constante que exige mais de uma linha. É difícil de testar e a ordem de carga engana, então quase sempre uma fábrica estática ou inicialização preguiçosa serve melhor.",
+            },
+            {
+                frente: "Como você evitaria um construtor com dez parâmetros?",
+                verso: "Agrupando o que anda junto em tipos próprios, o que quase sempre revela um conceito que faltava. Se ainda sobrar muita coisa opcional, um builder deixa a chamada legível e evita trocar dois parâmetros de mesmo tipo sem o compilador notar.",
+            },
+            {
+                frente: "O que synchronized garante, além de exclusão mútua?",
+                verso: "Garante visibilidade: o que uma thread escreveu antes de soltar o monitor fica visível para a próxima que o adquire. Sem isso, uma thread poderia ler um valor velho em cache. Exclusão sem visibilidade não resolveria nada em máquina com vários núcleos.",
+            },
+            {
+                frente: "Por que criar uma Thread por tarefa é ruim?",
+                verso: "Thread de plataforma custa memória e troca de contexto, então mil tarefas viram mil threads competindo. Um pool limita a concorrência, reaproveita as threads e dá um lugar para tratar fila e rejeição. Threads virtuais mudam essa conta, mas não a ideia de limitar.",
+            },
+            {
+                frente: "Qual a diferença entre StringBuilder e StringBuffer?",
+                verso: "Os dois acumulam texto num buffer que cresce. O StringBuffer sincroniza os métodos, o que só faz sentido se a mesma instância for compartilhada entre threads, algo raro. Como quase sempre a construção é local, o StringBuilder é a escolha padrão.",
+            },
+            {
+                frente: "Como você trataria uma exceção que sua camada não sabe resolver?",
+                verso: "Deixando subir, sem capturar para logar e relançar em cada nível. Se precisar traduzir para um tipo do domínio, sempre encadeando a causa original. Capturar e engolir é o que transforma erro em comportamento estranho meses depois.",
+            },
+            {
+                frente: "Quando criar uma exceção própria compensa?",
+                verso: "Quando quem chama precisa distinguir aquele caso para reagir diferente, como registro não encontrado e regra de negócio violada. Se ninguém vai tratar de forma específica, uma exceção existente com boa mensagem basta. Hierarquia inteira de exceções sem uso é peso morto.",
+            },
+            {
+                frente: "Por que encadear a causa ao relançar uma exceção?",
+                verso: "Porque sem a causa a pilha mostra só onde você embrulhou, e não onde quebrou. Passar a original no construtor preserva o rastro inteiro. Perder a causa é o motivo mais comum de log que diz que houve erro e não diz qual.",
+            },
+            {
+                frente: "O que muda ao capturar Exception em vez do tipo específico?",
+                verso: "Você passa a capturar também o que não previu, inclusive erro de programação, e trata tudo do mesmo jeito. Isso esconde bug e dificulta distinguir falha de negócio de falha técnica. Captura ampla só faz sentido na borda, para virar resposta de erro.",
+            },
+            {
+                frente: "Como você testaria um método que depende de outra classe?",
+                verso: "Injetando a dependência e passando um dublê no teste, seja um mock ou uma implementação simples de mentira. Se a classe cria a dependência com new dentro dela, não há como testar isoladamente, e o teste vira teste de integração sem querer.",
+            },
+            {
+                frente: "Qual a diferença entre teste de unidade e de integração?",
+                verso: "O de unidade exercita uma peça isolada, roda em milissegundos e falha apontando o lugar. O de integração exercita as peças juntas, com banco e rede de verdade, e é o que prova que a configuração funciona. Um não substitui o outro, e a proporção importa.",
+            },
+            {
+                frente: "O que a anotação de transação faz num serviço Spring?",
+                verso: "Abre a transação antes do método e confirma no fim, ou desfaz quando sobe exceção não checada. O detalhe que pega é que ela funciona por proxy: chamar o método anotado de dentro da mesma classe não passa pelo proxy e não abre transação nenhuma.",
+            },
+            {
+                frente: "Qual a diferença entre um bean singleton e um prototype?",
+                verso: "O singleton é criado uma vez e compartilhado pelo contêiner, então não pode guardar estado de requisição. O prototype é criado a cada pedido de injeção. Injetar um prototype dentro de um singleton congela a primeira instância, que é a armadilha clássica.",
+            },
+            {
+                frente: "O que a injeção de dependência resolve num projeto Spring?",
+                verso: "Tira da classe a responsabilidade de criar suas dependências, o que permite trocar implementação e passar dublê em teste sem mexer no código. O contêiner monta o grafo e cuida do ciclo de vida. O ganho real é testabilidade, não a anotação.",
+            },
+            {
+                frente: "Por que injetar pelo construtor é preferível a injetar no campo?",
+                verso: "Porque o objeto nasce completo e os campos podem ser finais, o que deixa a dependência obrigatória explícita. Também permite instanciar a classe num teste sem subir o contêiner. Injeção no campo esconde dependência e facilita a classe crescer sem ninguém notar.",
+            },
+            {
+                frente: "O que um repositório do Spring Data entrega sem você escrever código?",
+                verso: "As operações básicas de gravar, buscar por identificador, listar e paginar, mais consultas derivadas do nome do método. Para o que não cabe nisso, existe a consulta escrita à mão. O risco é o nome do método virar frase enorme que ninguém consegue ler.",
+            },
+            {
+                frente: "O que é um DTO, e por que não devolver a entidade direto?",
+                verso: "É um tipo que representa o que aquela fronteira precisa trafegar. Devolver a entidade acopla a resposta ao schema do banco, vaza campo que não deveria sair e dispara carga preguiçosa na serialização. O DTO deixa a mudança de banco invisível para o cliente.",
+            },
+            {
+                frente: "Como você validaria o corpo de uma requisição?",
+                verso: "Com as anotações de validação no objeto de entrada e a marcação que pede a checagem no controlador, deixando o framework juntar todos os erros de uma vez. Validação espalhada em if dentro do serviço devolve um erro por vez e cansa quem consome a API.",
+            },
+            {
+                frente: "Como você devolveria um código de status diferente de 200?",
+                verso: "Devolvendo uma resposta que carrega o status, ou lançando uma exceção que o manipulador global traduz. O importante é ser consistente: criação devolve 201, erro do cliente devolve 4xx, e falha inesperada devolve 5xx sem detalhe interno no corpo.",
+            },
+            {
+                frente: "Como você deixaria uma configuração fora do código?",
+                verso: "Num arquivo de propriedades por ambiente, com o valor podendo ser sobrescrito por variável de ambiente na hora do deploy. O código lê por injeção de configuração tipada. Segredo nunca entra no repositório, nem no arquivo de exemplo.",
+            },
+            {
+                frente: "O que o Spring Boot faz de configuração automática?",
+                verso: "Olha o que está no classpath e monta os beans padrão daquilo, como fonte de dados quando existe um driver e servidor web quando existe a dependência web. Isso acelera muito o começo, e cobra depois: quando algo estranho acontece, é preciso saber o que ele decidiu por você.",
+            },
+            {
+                frente: "Por que usar uma fachada de log em vez de System.out?",
+                verso: "Porque log tem nível, contexto e destino configuráveis, e a saída padrão não tem nada disso. Em contêiner, System.out ainda vai parar em algum lugar, mas sem nível não dá para reduzir ruído nem elevar detalhe num incidente sem mexer no código.",
+            },
+            {
+                frente: "Como você escolheria o nível de um log?",
+                verso: "Erro para o que exige alguém agir, aviso para o que degradou mas seguiu, informação para marco de negócio, e depuração para detalhe de investigação. Se tudo é erro, ninguém olha. O nível é o que separa alerta de ruído às três da manhã.",
+            },
+            {
+                frente: "Como você serializaria um objeto para JSON?",
+                verso: "Com uma biblioteca de mapeamento, expondo um tipo pensado para a saída em vez da entidade. Vale definir o que fazer com nulo, o formato de data e o nome dos campos. Deixar a serialização adivinhar é como surge campo interno vazando na resposta.",
+            },
+            {
+                frente: "Qual a diferença entre LocalDate, LocalDateTime e Instant?",
+                verso: "LocalDate é data sem hora nem fuso, boa para aniversário e vencimento. LocalDateTime tem data e hora, ainda sem fuso. Instant é um ponto na linha do tempo em UTC, que é o que você guarda quando o evento aconteceu de fato.",
+            },
+            {
+                frente: "Como você calcularia a diferença entre duas datas?",
+                verso: "Com Duration para tempo baseado em segundos e Period para diferença em anos, meses e dias de calendário. Subtrair milissegundos na mão erra em horário de verão e em mês de tamanhos diferentes, que é justamente o que a biblioteca de data resolve.",
+            },
+            {
+                frente: "Qual a diferença entre List.of e new ArrayList?",
+                verso: "List.of devolve uma lista imutável e recusa nulo, então tentar adicionar estoura UnsupportedOperationException. É ótimo para constante e para retorno que ninguém deve alterar. Quando a lista precisa crescer, ArrayList continua sendo o caminho.",
+            },
+            {
+                frente: "O que você olharia antes de trocar um stream sequencial por paralelo?",
+                verso: "Se o trabalho por elemento é pesado o bastante para pagar a divisão, se a fonte divide bem, e se a operação é livre de estado compartilhado. Em coleção pequena ou tarefa de entrada e saída, o paralelo costuma piorar, porque disputa o mesmo pool comum.",
+            },
+            {
+                frente: "Como você mediria o tempo de um trecho de código?",
+                verso: "Com nanoTime nas pontas para uma medida grosseira, ciente de que a primeira execução inclui carga de classe e ainda não passou pela compilação otimizada. Para comparar implementações a sério, o caminho é uma ferramenta de microbenchmark, e não um laço com cronômetro.",
+            },
+            {
+                frente: "O que a interface Iterable permite ao seu tipo?",
+                verso: "Ser percorrido com for aprimorado, porque o compilador só precisa do método que devolve um iterador. É a forma de expor uma coleção interna sem entregar a lista para quem chama alterar. Também casa com os utilitários que aceitam Iterable.",
+            },
+            {
+                frente: "Como você exporia uma coleção interna sem deixar alterarem seu estado?",
+                verso: "Devolvendo uma visão imutável ou uma cópia, e oferecendo métodos para as operações que fazem sentido no domínio. Devolver a lista original permite que qualquer chamador adicione item furando toda regra que a classe protege.",
+            },
+            {
+                frente: "Quando você usaria varargs num método?",
+                verso: "Quando a quantidade de argumentos varia e a chamada fica mais natural sem montar lista. Por baixo é um array, então é possível passar zero argumentos, e sobrecarga com varargs confunde a escolha do compilador. Para coleção que já existe, receber Collection é mais claro.",
+            },
+            {
+                frente: "O que muda ao declarar o retorno como interface em vez de classe concreta?",
+                verso: "Você fica livre para trocar a implementação depois sem quebrar quem chama. Devolver ArrayList amarra o contrato ao detalhe. O mesmo vale para parâmetro: receber Collection aceita mais entradas do que receber ArrayList.",
+            },
+            {
+                frente: "Como você trataria um método que às vezes não tem resultado?",
+                verso: "Devolvendo Optional quando a ausência é normal, ou lançando exceção quando ela é erro. O que não ajuda é devolver nulo sem documentar, porque quem chama descobre pelo NullPointerException em produção. Para coleção, o certo é lista vazia.",
+            },
+            {
+                frente: "Como você mapearia uma requisição HTTP para um método?",
+                verso: "Anotando a classe como controlador REST e cada método com o verbo e o caminho, declarando o que vem da rota, da consulta e do corpo. O framework cuida da conversão. Concentrar regra de negócio no controlador é o que depois impede testar sem subir a aplicação.",
+            },
+            {
+                frente: "O que é um proxy, e por que ele explica comportamento estranho no Spring?",
+                verso: "É um objeto gerado que embrulha o seu bean para aplicar transação, cache ou segurança antes de delegar. Como a chamada precisa passar por ele, método privado, final ou chamado de dentro da própria classe não recebe esse comportamento, e a anotação parece ignorada.",
+            },
+        ],
+        pleno: [
+            {
+                frente: "Como você investigaria um vazamento de memória numa aplicação Java?",
+                verso: "Confirmando primeiro pelo gráfico de heap depois das coletas completas, que sobe sem voltar. Depois tirando um despejo de memória em dois momentos e comparando o que cresceu. O caminho até a raiz costuma apontar cache sem limite, lista estática ou listener nunca removido.",
+            },
+            {
+                frente: "Que armadilha de ThreadLocal aparece em servidor com pool de threads?",
+                verso: "A thread volta para o pool com o valor ainda pendurado, e a próxima requisição herda dado de outro usuário. Além do vazamento, isso vira falha de segurança. A regra é limpar no finally, sempre, e desconfiar de qualquer contexto guardado por thread.",
+            },
+            {
+                frente: "O que volatile garante, e o que ele não garante?",
+                verso: "Garante que a escrita fica visível para as outras threads e impede reordenação em torno dela. Não garante atomicidade: um incremento continua sendo ler, somar e escrever, e duas threads ainda se atropelam. Para contador, o caminho é um tipo atômico.",
+            },
+            {
+                frente: "O que a dupla checagem sem volatile tem de errado?",
+                verso: "Outra thread pode enxergar a referência já atribuída antes de o construtor terminar, e usar um objeto pela metade. O campo precisa ser volatile para impedir essa reordenação. Na prática, inicialização por classe interna ou por enum evita o assunto inteiro.",
+            },
+            {
+                frente: "Quando você usaria CompletableFuture em vez de simplesmente bloquear?",
+                verso: "Quando há chamadas independentes que podem correr juntas, e o ganho é o tempo total virar o da mais lenta em vez da soma. Vale a pena com pool próprio e timeout definido. Encadear tudo em fluxo assíncrono só para parecer moderno cobra caro na depuração.",
+            },
+            {
+                frente: "Por que ConcurrentHashMap não resolve toda corrida de dado?",
+                verso: "Porque cada operação é atômica isoladamente, mas a sequência não é. Checar se a chave existe e depois inserir continua tendo uma janela entre as duas. Para isso existem operações compostas como computeIfAbsent e merge, que fazem tudo numa passada.",
+            },
+            {
+                frente: "Como você escolheria entre synchronized e um lock explícito?",
+                verso: "Synchronized quando basta exclusão simples num bloco, porque é mais difícil de errar e a JVM otimiza bem. Lock explícito quando você precisa de tentativa com timeout, aquisição interrompível ou condições separadas. O custo dele é lembrar de destravar no finally.",
+            },
+            {
+                frente: "Como você limitaria a concorrência de uma operação cara?",
+                verso: "Com um semáforo permitindo N execuções simultâneas, ou com um pool dedicado de tamanho fixo para aquele trabalho. O que não funciona é confiar no pool geral: uma operação pesada sem limite consome todas as threads e derruba o resto do serviço junto.",
+            },
+            {
+                frente: "O que acontece quando o pool de threads enche?",
+                verso: "As tarefas vão para a fila, e quando a fila também enche a política de rejeição decide: lançar erro, descartar ou executar na thread de quem chamou. Fila ilimitada parece gentil e é pior, porque troca erro rápido por latência crescente e memória subindo.",
+            },
+            {
+                frente: "O que significa interromper uma thread em Java?",
+                verso: "É apenas sinalizar uma marca que o código precisa observar. Métodos bloqueantes lançam InterruptedException, e o certo é encerrar o trabalho ou restaurar a marca. Capturar e ignorar essa exceção é o que faz uma aplicação não conseguir mais desligar.",
+            },
+            {
+                frente: "Como você diagnosticaria um travamento entre threads?",
+                verso: "Tirando um despejo de threads no momento do problema e procurando quem está esperando por qual monitor. A JVM ainda aponta ciclos de trava detectados. A correção estrutural é sempre adquirir travas na mesma ordem, ou não precisar de duas.",
+            },
+            {
+                frente: "Como você diagnosticaria pausas longas de coleta de lixo?",
+                verso: "Ligando o registro de coleta e olhando frequência, duração e quanto sobra depois de cada ciclo. Pausa longa costuma vir de heap pequeno demais, de promoção excessiva para a geração velha ou de objeto grande criado em rajada. Trocar de coletor é a última decisão, não a primeira.",
+            },
+            {
+                frente: "O que muda ao rodar Java num contêiner com limite de memória?",
+                verso: "A JVM moderna enxerga o limite do contêiner e dimensiona o heap por porcentagem dele. O ponto de atenção é que heap não é tudo: pilha por thread, metaespaço e buffers fora do heap somam. Se o total passar do limite, o processo é morto sem exceção nenhuma.",
+            },
+            {
+                frente: "Como você reduziria o tempo de subida de um serviço Spring?",
+                verso: "Medindo o que demora, porque costuma ser varredura de pacote grande, cliente que se conecta na subida e bean criado sem necessidade. Inicialização preguiçosa ajuda, e compilação nativa resolve de vez em troca de build mais complicado e reflexão declarada à mão.",
+            },
+            {
+                frente: "O que causa o problema de N+1 consultas com JPA, e como você o encontra?",
+                verso: "Carregar uma lista e, ao acessar uma associação preguiçosa de cada item, disparar uma consulta por linha. Aparece ligando o registro de SQL e vendo a mesma consulta repetida com parâmetros diferentes. Resolve com junção explícita, entity graph ou consulta em lote.",
+            },
+            {
+                frente: "Como você trataria LazyInitializationException sem carregar tudo ansiosamente?",
+                verso: "Buscando na consulta exatamente o que a tela precisa, com junção ou projeção direta para um DTO. O erro é sintoma de dado sendo acessado fora da transação, então a correção é decidir a fronteira, e não abrir a sessão até a camada de apresentação.",
+            },
+            {
+                frente: "O que a propagação de transação muda no comportamento de um método?",
+                verso: "Define se ele entra na transação de quem chamou, abre uma nova ou roda sem nenhuma. Requires new é o que permite gravar um registro de auditoria mesmo com a operação principal voltando atrás. O engano comum é anotar um método chamado de dentro da mesma classe, onde o proxy não age.",
+            },
+            {
+                frente: "Como você escolheria o nível de isolamento de uma transação?",
+                verso: "Pelo tipo de anomalia que aquele fluxo não pode aceitar, e não pelo nível mais alto disponível. Read committed serve para a maioria. Subir custa concorrência e bloqueio, então para casos pontuais costuma ser melhor travar a linha na consulta do que endurecer tudo.",
+            },
+            {
+                frente: "Como você trataria duas requisições tentando alterar o mesmo registro?",
+                verso: "Com trava otimista por versão, que falha na gravação e permite ao chamador refazer com o dado atual. Trava pessimista só quando o conflito é frequente e refazer é caro, ciente de que ela segura a linha e enfileira todo mundo atrás.",
+            },
+            {
+                frente: "O que você olharia num travamento de banco durante um deploy?",
+                verso: "Quais transações estão abertas e há quanto tempo, e qual comando está esperando. Migração que altera tabela grande pede trava e fica atrás de qualquer transação longa, segurando o resto. Por isso migração pesada roda separada do deploy, e com timeout de trava.",
+            },
+            {
+                frente: "Como você dimensionaria o pool de conexões de uma aplicação?",
+                verso: "Pelo que o banco aguenta e pelo tempo médio de consulta, e não pelo número de usuários. Pool grande demais empurra a fila para dentro do banco e piora a latência de todo mundo. Vale medir com carga real e observar tempo de espera por conexão.",
+            },
+            {
+                frente: "Como você faria paginação eficiente numa tabela muito grande?",
+                verso: "Paginando por chave, com filtro do tipo maior que o último identificador visto, em vez de deslocamento. Deslocamento alto obriga o banco a percorrer e descartar tudo que veio antes. A troca é perder o salto direto para uma página qualquer.",
+            },
+            {
+                frente: "Como você atacaria uma consulta lenta?",
+                verso: "Olhando o plano de execução antes de mexer no código, para saber se é varredura completa, junção ruim ou falta de índice. Depois medindo de novo. Adicionar índice sem olhar o plano costuma resolver por acaso, e ainda cobra em toda escrita.",
+            },
+            {
+                frente: "Por que um índice existente pode não ser usado?",
+                verso: "Porque a consulta aplica função sobre a coluna, converte tipo, usa curinga no começo do texto, ou porque o otimizador julgou que varrer é mais barato pelo volume esperado. Estatística desatualizada também engana o planejador.",
+            },
+            {
+                frente: "Como você processaria um arquivo grande demais para caber na memória?",
+                verso: "Lendo em fluxo, processando linha a linha e gravando em lotes, sem materializar a coleção inteira. O erro clássico é usar um método que lê tudo de uma vez e só descobrir na produção. Gravar em lote também evita ida e volta por registro.",
+            },
+            {
+                frente: "Como você faria uma carga em lote sem estourar memória nem transação?",
+                verso: "Em blocos de tamanho fixo, confirmando por bloco, limpando o contexto de persistência a cada bloco e desligando o que gera consulta por linha. Uma transação única de um milhão de registros trava tabela, incha o log do banco e não permite retomar do meio.",
+            },
+            {
+                frente: "Como você garantiria que a mesma requisição não seja processada duas vezes?",
+                verso: "Com chave de idempotência enviada pelo cliente e uma restrição de unicidade no banco, de modo que a segunda tentativa devolva o resultado da primeira. Repetição é normal em rede, e confiar que o cliente não repete é o que gera cobrança dobrada.",
+            },
+            {
+                frente: "Como você publicaria um evento e gravaria no banco sem inconsistência?",
+                verso: "Gravando o evento numa tabela dentro da mesma transação do dado, e publicando depois a partir dela. Escrever no banco e publicar na fila em passos separados sempre tem a janela em que um deu certo e o outro não, e reconciliar isso depois é caro.",
+            },
+            {
+                frente: "Como você trataria uma mensagem que falha repetidamente numa fila?",
+                verso: "Com um número limitado de tentativas, espera crescente e desvio para uma fila de mensagens mortas, com contexto suficiente para reprocessar depois. Sem esse desvio, uma mensagem envenenada trava o consumo e para o processamento de todo o resto.",
+            },
+            {
+                frente: "Como você impediria uma tarefa agendada de rodar em duas instâncias?",
+                verso: "Com trava compartilhada, seja uma linha no banco com dono e validade, seja um agendador que já coordena isso. Confiar em uma instância única é uma configuração esperando para quebrar no primeiro escalonamento horizontal.",
+            },
+            {
+                frente: "Quando as threads virtuais mudam o desenho de um serviço?",
+                verso: "Quando o gargalo é espera de entrada e saída, e não CPU. Elas permitem manter o código bloqueante e ainda assim ter milhares de tarefas em voo. O cuidado é que trecho bloqueante dentro de bloco sincronizado prende a thread carregadora, e que o limite passa a ser o pool de conexões.",
+            },
+            {
+                frente: "Como você lidaria com chamadas a outro serviço que às vezes travam?",
+                verso: "Timeout em toda chamada, sempre, porque sem ele a thread fica presa até o sistema operacional desistir. Depois um número pequeno de tentativas com espera crescente, só para erro transitório, e um disjuntor para parar de bater num serviço que já caiu.",
+            },
+            {
+                frente: "Como você definiria o valor de um timeout?",
+                verso: "A partir da latência observada do dependente, com folga sobre o percentil alto, e sempre menor que o timeout de quem chama você. Timeout maior que o do chamador é inútil: ele já desistiu, e você segue segurando thread e conexão por nada.",
+            },
+            {
+                frente: "Quando repetir uma chamada que falhou é perigoso?",
+                verso: "Quando a operação não é idempotente, porque a primeira pode ter chegado e só a resposta se perdeu. Repetir cobrança nesse caso duplica. Também é perigoso repetir em massa durante uma queda, porque a repetição de todos derruba de vez quem estava se recuperando.",
+            },
+            {
+                frente: "Como você evitaria efeito cascata quando um dependente fica lento?",
+                verso: "Isolando o acesso a ele num pool próprio, para a lentidão não consumir as threads do serviço inteiro. Somado a timeout curto, disjuntor e resposta degradada. Sem isolamento, um dependente lento vira indisponibilidade total, o que é pior do que a falha original.",
+            },
+            {
+                frente: "Como você decidiria entre otimizar a consulta e colocar cache?",
+                verso: "Otimizando primeiro, porque cache sobre consulta ruim esconde o problema e cobra na primeira invalidação. Cache entra quando o dado é lido muito mais do que escrito e tolera estar velho por um tempo definido. Antes disso é preciso saber quem invalida.",
+            },
+            {
+                frente: "Como você trataria a expiração simultânea de muitas chaves de cache?",
+                verso: "Espalhando o vencimento com uma variação aleatória e deixando só uma requisição recalcular enquanto as outras servem o valor antigo. Sem isso, todas as chaves vencem juntas e a carga cai inteira no banco no mesmo segundo.",
+            },
+            {
+                frente: "O que muda ao sair de um cache local para um distribuído?",
+                verso: "Você troca coerência entre instâncias por uma chamada de rede a cada acesso, com serialização e novo ponto de falha. Cache local é mais rápido e diverge entre instâncias. A escolha depende de o dado tolerar divergência de segundos ou não.",
+            },
+            {
+                frente: "Como você exporia métricas úteis de uma aplicação Java?",
+                verso: "Publicando contadores e histogramas por rota e por dependência, mais os do runtime, como heap, threads e coleta de lixo. Histograma permite ver percentil; média esconde a cauda. Métrica com rótulo de alta cardinalidade, como identificador de usuário, derruba o coletor.",
+            },
+            {
+                frente: "Como você ligaria os logs de uma requisição que passa por vários serviços?",
+                verso: "Propagando um identificador de rastreamento pelo cabeçalho e colocando ele no contexto de log de cada serviço. Com isso, uma busca reúne a requisição inteira. Sem isso, correlacionar por horário e mensagem é adivinhação em qualquer volume real.",
+            },
+            {
+                frente: "O que você mudaria numa API para o cliente tratar erro sem adivinhar?",
+                verso: "Código de status coerente, um corpo com formato fixo trazendo um identificador estável de erro, e mensagem separada do que é para o usuário final. Um manipulador global evita cada controlador inventar o seu. E nunca vazar pilha de execução na resposta.",
+            },
+            {
+                frente: "Como você faria uma verificação de saúde que diz a verdade?",
+                verso: "Separando a de vivacidade, que só diz que o processo não travou, da de prontidão, que checa dependências essenciais. Prontidão que consulta tudo a cada segundo vira carga e faz o serviço sair de rotação por soluço do dependente.",
+            },
+            {
+                frente: "Como você faria a aplicação desligar sem derrubar requisição em andamento?",
+                verso: "Tratando o sinal de término: parar de aceitar novas requisições, sair da rotação do balanceador, esperar as em andamento até um limite e só então fechar pools e conexões. Sem isso, cada deploy devolve erro para quem estava no meio de uma chamada.",
+            },
+            {
+                frente: "Como você guardaria a senha dos usuários?",
+                verso: "Com uma função de derivação lenta e com sal, feita para senha, como bcrypt ou Argon2, nunca com hash rápido de propósito geral. O custo é parâmetro, e precisa ser revisto com o tempo. Guardar em texto ou cifrado de forma reversível não é opção.",
+            },
+            {
+                frente: "Como você evitaria injeção de SQL num projeto que usa JPA?",
+                verso: "Usando parâmetros em toda consulta, inclusive nas escritas à mão, e nunca concatenando valor vindo do usuário. Ordenação dinâmica é o ponto fraco, porque nome de coluna não entra como parâmetro: ali a defesa é lista fixa de valores aceitos.",
+            },
+            {
+                frente: "Como você evitaria vazar dado sensível nos logs?",
+                verso: "Não logando objeto inteiro, controlando o toString das entidades, e mascarando campo sensível na serialização. Log é copiado para vários lugares e fica muito tempo, então o que vaza ali vaza para sempre. Vale ter um teste que impeça a regressão.",
+            },
+            {
+                frente: "Como você validaria um token entre serviços?",
+                verso: "Conferindo assinatura com a chave pública do emissor, mais expiração, emissor e público esperado, e a permissão exigida pela rota. Aceitar token sem checar o público é o que permite reaproveitar um token válido de outro serviço.",
+            },
+            {
+                frente: "Como você protegeria uma API de abuso?",
+                verso: "Limite por cliente e por rota, aplicado antes do trabalho caro, com resposta clara dizendo quando tentar de novo. Limite só na borda deixa o serviço interno exposto. E o limite precisa ser por identidade autenticada, senão troca de IP contorna.",
+            },
+            {
+                frente: "Como você trataria upload de arquivo grande numa API?",
+                verso: "Recebendo em fluxo direto para o armazenamento, com limite de tamanho e tipo checados antes, sem carregar tudo na memória. Melhor ainda é o cliente enviar direto para o armazenamento com uma URL assinada, e a API só registrar o resultado.",
+            },
+            {
+                frente: "Como você testaria integração com banco sem depender da máquina de quem roda?",
+                verso: "Subindo o banco real em contêiner efêmero durante o teste, com o mesmo motor e versão da produção. Banco em memória mente sobre dialeto e restrição, e passa teste que quebra em produção. Cada caso limpa o que criou, ou o banco sobe por classe.",
+            },
+            {
+                frente: "Como você testaria código que depende da data de hoje?",
+                verso: "Injetando um relógio em vez de chamar o agora direto, e fixando esse relógio no teste. Sem isso o teste passa hoje e falha na virada do mês, e a única forma de reproduzir é mexer no relógio da máquina.",
+            },
+            {
+                frente: "Como você trataria um teste que falha de vez em quando?",
+                verso: "Tratando como defeito, não como azar. As causas comuns são dependência de ordem, estado compartilhado entre casos, espera por tempo fixo e concorrência real. Repetir até passar esconde a causa e ensina o time a ignorar o vermelho.",
+            },
+            {
+                frente: "Como você testaria um comportamento concorrente?",
+                verso: "Forçando a sobreposição com barreira ou latch, em vez de esperar por sorte, e rodando o cenário muitas vezes. Mesmo assim o teste prova pouco, então a garantia real vem do desenho: estado imutável, tipos atômicos e seções críticas pequenas.",
+            },
+            {
+                frente: "O que você olharia num perfilamento antes de otimizar código?",
+                verso: "Onde o tempo realmente é gasto, com amostragem sob carga parecida com a de produção. Costuma ser espera de rede ou banco, e não o laço que parecia caro. Otimizar sem medir troca legibilidade por nada, e ainda esconde o gargalo verdadeiro.",
+            },
+            {
+                frente: "Como você trataria datas e fusos numa API que atende vários países?",
+                verso: "Guardando instante em UTC e convertendo só na borda, com o fuso vindo do contexto do usuário. Data sem hora é outro tipo, e misturar os dois é o que gera erro de um dia. Serializar em formato padrão evita cada cliente interpretar do seu jeito.",
+            },
+            {
+                frente: "Como você versionaria o schema do banco junto com o código?",
+                verso: "Com scripts de migração versionados no mesmo repositório, aplicados na subida ou no deploy, e nunca editando um script já aplicado. Toda mudança precisa ser compatível com a versão anterior da aplicação, senão o deploy vira janela de indisponibilidade.",
+            },
+            {
+                frente: "Como você renomearia uma coluna usada em produção?",
+                verso: "Em passos: criar a nova, passar a escrever nas duas, copiar o histórico, mudar a leitura e só depois remover a antiga. Cada passo é reversível sozinho. Renomear direto exige que código e banco troquem no mesmo instante, e isso não existe com várias instâncias.",
+            },
+            {
+                frente: "Como você configuraria a mesma aplicação para vários ambientes?",
+                verso: "Configuração em camadas, com o específico do ambiente sobrescrevendo o comum, e validação na subida para falhar cedo em vez de na primeira requisição. Segredo fora do repositório, injetado no deploy. Perfil serve para ligar comportamento, não para esconder valor.",
+            },
+            {
+                frente: "O que faz um log ser útil durante um incidente?",
+                verso: "Ter identificador de correlação atravessando as chamadas, contexto estruturado em vez de frase concatenada, e nível coerente para o volume não esconder o que importa. Log sem o dado que identifica a requisição obriga a adivinhar qual linha é do caso relatado.",
+            },
+            {
+                frente: "Como você geraria identificadores em várias instâncias sem colisão?",
+                verso: "Com UUID quando não importa a ordem, ou com um identificador ordenável no tempo quando o banco sofre com índice aleatório. Sequência no banco funciona e cria um ponto de coordenação. A escolha pesa colisão contra fragmentação de índice.",
+            },
+            {
+                frente: "Como você lidaria com um serviço que consome mais CPU depois de um deploy?",
+                verso: "Comparando com a versão anterior sob a mesma carga e tirando amostras de CPU em produção. Costuma ser serialização nova, log em nível alto, expressão regular cara em caminho quente ou coleta subindo por mais alocação. O perfil aponta em minutos o que a leitura do diff não acha.",
+            },
+            {
+                frente: "Como você trataria a serialização de um campo que mudou de tipo?",
+                verso: "Aceitando os dois formatos na leitura por um tempo e escrevendo só o novo, com versão no contrato quando faz sentido. Trocar o tipo de uma vez quebra consumidor antigo e mensagem já na fila, que é onde o problema costuma aparecer.",
+            },
+            {
+                frente: "Como você lidaria com um relatório que derruba a aplicação quando roda?",
+                verso: "Tirando ele do caminho das requisições: fila própria, réplica de leitura e resultado materializado. Relatório pesado no mesmo pool e no mesmo banco disputa conexão e cache com o fluxo normal, e o sintoma aparece como lentidão geral sem causa aparente.",
+            },
+            {
+                frente: "Como você reduziria alocação num trecho crítico?",
+                verso: "Evitando criar objeto por elemento em laço quente, reaproveitando buffer, usando tipos primitivos onde a coleção obriga a embrulhar, e cortando concatenação em log que nem será impresso. Só depois de medir: alocação barata é justamente o que a JVM faz bem.",
+            },
+            {
+                frente: "Quando faz sentido cachear dentro da própria aplicação?",
+                verso: "Quando o dado é pequeno, muito lido e tolera atraso, como tabela de domínio e configuração. Com limite de tamanho e vencimento, sempre. Cache sem limite é vazamento com outro nome, e é a causa mais comum de heap crescendo devagar até estourar.",
+            },
+            {
+                frente: "Como você identificaria qual endpoint está segurando o pool de conexões?",
+                verso: "Instrumentando tempo de espera por conexão e tempo de transação por rota, e olhando quem abre transação longa. Costuma ser um método que faz chamada externa dentro da transação. A correção é fechar a transação antes de sair para a rede.",
+            },
+            {
+                frente: "Como você trataria uma dependência que só falha em produção?",
+                verso: "Reproduzindo o ambiente, não o código: versão, configuração, latência e volume. Costuma ser timeout diferente, certificado, DNS ou dado real que o teste não tem. Log com contexto e um cenário reproduzível valem mais que tentativas às cegas em produção.",
+            },
+            {
+                frente: "Como você montaria uma resposta que depende de três serviços diferentes?",
+                verso: "Disparando as chamadas independentes em paralelo, com timeout por chamada e um orçamento total para a requisição. Depois decidindo o que é essencial e o que pode faltar, devolvendo resposta parcial em vez de erro. Encadear as três em sequência soma as latências sem motivo.",
+            },
+            {
+                frente: "O que você mediria para saber se adianta subir mais instâncias?",
+                verso: "Onde está a saturação. Se o gargalo é CPU da aplicação, mais instâncias ajudam. Se é o banco, a fila de conexões ou uma trava compartilhada, elas só aumentam a disputa e pioram a latência. Escalar sem medir troca um problema por uma conta maior.",
+            },
+            {
+                frente: "Como você decidiria entre processar de forma síncrona ou por fila?",
+                verso: "Pela pergunta: o usuário precisa do resultado agora? Se não precisa, fila tira latência da requisição e absorve pico. O custo é passar a lidar com repetição, ordem e falha assíncrona, e a explicar para o usuário que o trabalho está em andamento.",
+            },
+        ],
+        senior: [
+            {
+                frente: "Como você conduziria a atualização de Java 8 para uma versão LTS recente?",
+                verso: "Subindo primeiro o compilador com o código como está, resolvendo o que quebrou por remoção de módulo e reflexão fechada. Depois as dependências, que costumam ser o real bloqueio. Adotar recurso novo vem por último, e nunca no mesmo passo da migração.",
+            },
+            {
+                frente: "Como você avaliaria trocar o Spring por algo mais enxuto?",
+                verso: "Pelo que dói hoje: tempo de subida, consumo de memória por instância ou dificuldade de entender o que o contêiner faz. Se a dor é custo de contêiner, compilação nativa ou framework leve ajudam. Se é só gosto, a conta inclui reescrever integração que já funciona.",
+            },
+            {
+                frente: "Quando faz sentido adotar outra linguagem da JVM no projeto?",
+                verso: "Quando ela resolve uma dor concreta e o time inteiro sustenta, não só quem propôs. Conviver é possível, mas cada linguagem a mais é ferramental, revisão e contratação a mais. A pergunta honesta é quem mantém isso daqui a dois anos.",
+            },
+            {
+                frente: "Como você revisaria código concorrente de outra pessoa?",
+                verso: "Procurando estado mutável compartilhado sem proteção, trava adquirida em ordens diferentes, coleção comum onde deveria haver concorrente, e tarefa submetida sem timeout nem tratamento de falha. Depois perguntando qual invariante o autor acha que está protegendo.",
+            },
+            {
+                frente: "Como você decidiria entre programação reativa e threads virtuais?",
+                verso: "Pelo custo de manutenção. As duas resolvem espera de entrada e saída, mas a reativa muda o modelo mental do time inteiro e complica pilha de erro e depuração. Threads virtuais entregam boa parte do ganho mantendo o código direto, e hoje são o padrão razoável.",
+            },
+            {
+                frente: "Como você definiria as fronteiras entre camadas num projeto Java grande?",
+                verso: "Pelo sentido da dependência: o domínio não conhece framework nem banco, e a borda só orquestra. Se o domínio precisa de algo de fora, ele declara a interface e a infraestrutura implementa. Entidade de persistência atravessando até o controlador é o sinal de que a fronteira caiu.",
+            },
+            {
+                frente: "Como você avaliaria adotar arquitetura hexagonal num projeto existente?",
+                verso: "Pelo problema que ela resolve ali: trocar de fornecedor, testar domínio sem infraestrutura, ou isolar regra que muda muito. Sem essa dor, ela entrega três arquivos por caso de uso e o time paga sem receber. Vale aplicar primeiro no módulo que mais sofre.",
+            },
+            {
+                frente: "Quando você aceitaria abrir mão da pureza arquitetural?",
+                verso: "Quando o custo da abstração é maior que o risco que ela evita, como num serviço pequeno e estável, ou num prazo em que o certo é entregar e marcar a dívida. O que não pode é a exceção virar padrão sem ninguém registrar por que ela existiu.",
+            },
+            {
+                frente: "Como você lidaria com um Hibernate que se espalhou por todo o domínio?",
+                verso: "Sem reescrita grande. Isolando primeiro o que dói, tirando consulta do domínio para um repositório com contrato próprio, e devolvendo projeção em vez de entidade nas leituras. Depois medindo se o resto compensa, porque puxar tudo de uma vez rende meses sem comportamento novo.",
+            },
+            {
+                frente: "Como você mediria a saúde de um serviço Java em produção?",
+                verso: "Latência de cauda por rota e não média, taxa de erro, saturação de pool de threads e de conexões, tempo em coleta de lixo e uso de heap depois das coletas. Somado a um teste que exercite o caminho real, porque endpoint que só devolve OK não prova nada.",
+            },
+            {
+                frente: "Como você decidiria o que vira alerta e o que só fica no painel?",
+                verso: "Alerta é o que exige alguém acordar e agir agora, ligado a sintoma sentido pelo usuário, como erro e latência acima do acordado. Causa provável fica no painel para a investigação. Alerta que ninguém age treina o time a ignorar, e o próximo é real.",
+            },
+            {
+                frente: "Como você definiria o alvo de disponibilidade de um serviço?",
+                verso: "A partir do que o negócio perde com indisponibilidade, e não do número mais bonito. Cada nove a mais multiplica custo e complexidade, e exige redundância que o time precisa saber operar. Alvo definido também dá margem de erro para arriscar entregas.",
+            },
+            {
+                frente: "Como você conduziria um incidente em produção?",
+                verso: "Primeiro restaurar o serviço, depois entender: reverter, desligar a funcionalidade nova ou desviar carga vem antes de achar a causa raiz. Uma pessoa coordenando e comunicando, e registro do que foi feito. Investigar com o sistema fora do ar é como se perde a madrugada.",
+            },
+            {
+                frente: "Como você conduziria a análise depois de um incidente?",
+                verso: "Sem procurar culpado, porque isso só ensina o time a não relatar. Linha do tempo, o que faltou detectar, o que atrasou a recuperação, e um punhado de ações com dono e prazo. Documento sem ação vira ritual, e o mesmo incidente volta em três meses.",
+            },
+            {
+                frente: "Como você lidaria com uma suíte de testes que passou de trinta minutos?",
+                verso: "Medindo antes: quase sempre uma minoria dos testes domina o tempo, e são os que sobem contexto ou banco por caso. Separar unidade de integração devolve o ciclo curto. Paralelizar ajuda depois, e só funciona se os testes não compartilharem estado.",
+            },
+            {
+                frente: "Como você desenharia a estratégia de testes de um sistema?",
+                verso: "Muitos testes rápidos sobre a regra, um conjunto médio de integração cobrindo configuração e banco, e poucos de ponta a ponta nos fluxos que geram receita. O critério é confiança por minuto de execução, não porcentagem de linhas cobertas.",
+            },
+            {
+                frente: "Como você lidaria com um serviço com cobertura alta e bugs em produção?",
+                verso: "Olhando o que os testes exercitam: cobertura mede linha executada, não comportamento verificado. Costuma faltar caso de borda, integração real e asserção de verdade. Também vale ver se os bugs vêm de configuração e dado, que teste unitário nunca pega.",
+            },
+            {
+                frente: "Como você lidaria com um time que não escreve testes?",
+                verso: "Entendendo o motivo antes de cobrar: código difícil de testar, prazo, ou nunca terem visto teste que ajuda. Começar pelo bug recém corrigido, com um teste que falha antes, mostra valor rápido. Meta de cobertura imposta produz teste sem asserção.",
+            },
+            {
+                frente: "Como você padronizaria o tratamento de erro entre times?",
+                verso: "Definindo o formato da resposta, um catálogo de identificadores estáveis e quem traduz exceção para resposta. Depois entregando isso como biblioteca pequena, não como documento. Padrão que exige disciplina em cada controlador não sobrevive ao primeiro prazo apertado.",
+            },
+            {
+                frente: "Como você padronizaria sem matar a autonomia dos times?",
+                verso: "Padronizando o que atravessa fronteira, como contrato, log, métrica e segurança, e deixando o resto livre. Entregar como biblioteca e modelo pronto, que é mais fácil seguir do que ignorar. Padrão só no documento vira discussão de revisão toda semana.",
+            },
+            {
+                frente: "Como você versionaria uma biblioteca interna usada por vários times?",
+                verso: "Versão semântica levada a sério, acrescentando em vez de mudar assinatura, e marcando o que sai como obsoleto por pelo menos uma versão. Mudança maior precisa de prazo e caminho de migração escrito, senão os times travam na versão antiga e você mantém duas.",
+            },
+            {
+                frente: "Como você trataria a mesma biblioteca reescrita por três times?",
+                verso: "Escolhendo uma para sobreviver com base em quem a mantém e quem já depende dela, e migrando as outras com prazo. Antes disso vale perguntar por que duplicaram: costuma ser dificuldade de contribuir na primeira, e isso volta a acontecer se não mudar.",
+            },
+            {
+                frente: "Como você decidiria dividir um serviço Java em dois?",
+                verso: "Por motivo organizacional ou de escala independente, e não por estética. Se a fronteira não está clara entre pacotes do mesmo projeto, ela não vai ficar clara atravessando a rede: você só ganha latência, falha parcial e deploy que precisa ser coordenado.",
+            },
+            {
+                frente: "Como você conduziria a quebra de um monólito Java?",
+                verso: "Extraindo primeiro o que tem fronteira clara e escala diferente, com o monólito chamando o novo serviço, e mantendo a capacidade de voltar atrás. Dado por último, porque é a parte cara. Quebrar tudo de uma vez é como se troca um problema conhecido por vários novos.",
+            },
+            {
+                frente: "Como você trataria dois serviços que compartilham o mesmo banco?",
+                verso: "Tratando como acoplamento sério, porque um deles migra o schema e quebra o outro. O caminho é dar dono à tabela e expor o resto por API ou evento. Enquanto isso não acontece, ao menos migração coordenada e nenhuma escrita cruzada.",
+            },
+            {
+                frente: "Como você garantiria compatibilidade de mensagens entre versões?",
+                verso: "Só acrescentando campo opcional, nunca mudando significado, e mantendo o consumidor tolerante ao que não conhece. Mudança incompatível pede tópico ou versão nova, com os dois rodando por um tempo. Mensagem já na fila é a que quebra na virada.",
+            },
+            {
+                frente: "Como você planejaria a evolução de uma API pública?",
+                verso: "Com política de compatibilidade escrita, prazo de descontinuação e aviso antes, mais métrica de uso por versão para saber quem ainda depende do quê. Sem esse número, toda remoção vira aposta, e a decisão acaba sendo adiada para sempre.",
+            },
+            {
+                frente: "Como você lidaria com clientes que não atualizam a versão da sua API?",
+                verso: "Medindo quem são e quanto representam, dando prazo com aviso claro e ajuda para migrar. Se forem poucos e importantes, uma camada de compatibilidade paga o tempo. O que não funciona é manter tudo para sempre, porque o custo aparece em cada mudança futura.",
+            },
+            {
+                frente: "Como você definiria o contrato entre dois times antes de existir código?",
+                verso: "Escrevendo o contrato primeiro e concordando nele, com exemplo de requisição e resposta, incluindo erro. Depois cada lado desenvolve contra um dublê. Teste de contrato mantém isso honesto. Combinar por conversa e integrar no fim é o que estoura prazo.",
+            },
+            {
+                frente: "Como você faria revisão de código sem virar gargalo do time?",
+                verso: "Limitando o tamanho do que se pede para revisar, acordando prazo curto para responder, e separando o que bloqueia do que é sugestão. Automatizar estilo e checagem óbvia libera a revisão para o que importa: desenho, risco e caso de borda.",
+            },
+            {
+                frente: "Como você trataria a diferença de experiência do time numa revisão?",
+                verso: "Explicando o porquê e não só o quê, apontando o que bloqueia com clareza e deixando o resto como sugestão. Para quem está começando, revisão em par resolve em minutos o que trinta comentários não resolvem. Revisão também é onde o padrão da casa se ensina.",
+            },
+            {
+                frente: "Como você garantiria que o conhecimento não fique com uma pessoa só?",
+                verso: "Rodando quem faz o quê, revisando em par o que é crítico, e escrevendo o que só existe na cabeça de alguém. Documento curto sobre decisão e operação vale mais que manual grande. O teste é simples: essa pessoa consegue tirar férias?",
+            },
+            {
+                frente: "Como você faria a integração de alguém novo num projeto Java grande?",
+                verso: "Ambiente subindo em um comando no primeiro dia, uma tarefa pequena de verdade na primeira semana, e um mapa curto de como o sistema se divide. Aprender lendo o código inteiro não funciona, e mês de leitura sem entregar desanima antes de virar produtivo.",
+            },
+            {
+                frente: "Como você ensinaria streams a um time que só escreveu laços?",
+                verso: "Começando pelos casos onde ele ganha claramente, como filtrar, mapear e agrupar, e deixando claro que laço com efeito colateral continua legítimo. Mostrando também a pilha de erro de um stream quebrado, porque é o custo real que ninguém conta antes.",
+            },
+            {
+                frente: "Como você trataria dependências desatualizadas num projeto antigo?",
+                verso: "Automatizando a proposta de atualização e tratando como fluxo contínuo, não como mutirão anual. Priorizando por exposição e vulnerabilidade conhecida. Antes disso é preciso ter teste suficiente para confiar no verde, senão ninguém aprova a subida.",
+            },
+            {
+                frente: "Como você avaliaria a segurança de uma dependência nova?",
+                verso: "Olhando manutenção ativa, quantas dependências ela arrasta, histórico de vulnerabilidade e o que ela realmente precisa acessar. Biblioteca de duzentas linhas que puxa quinze pacotes custa mais do que escrever aquilo. E precisa haver quem atualize depois.",
+            },
+            {
+                frente: "Como você conduziria a resposta a uma vulnerabilidade conhecida numa dependência?",
+                verso: "Confirmando se o caminho vulnerável é usado, o que muda a urgência, e verificando exposição real. Depois corrigindo pela versão, ou mitigando na borda enquanto a correção não vem. E registrando, porque auditoria e cliente vão perguntar.",
+            },
+            {
+                frente: "Como você agiria diante de um segredo vazado no repositório?",
+                verso: "Revogando e trocando a credencial primeiro, porque o histórico já vazou e apagar commit não resolve. Depois checando uso indevido nos registros de acesso e colocando varredura automática para não repetir. Reescrever histórico é o último passo, e o menos urgente.",
+            },
+            {
+                frente: "Como você decidiria adotar um framework novo no meio de um projeto?",
+                verso: "Perguntando qual problema medido ele resolve, quem no time sustenta em uma madrugada de incidente, e como se volta atrás. Prova de conceito num fluxo real, com prazo. Adotar por bom marketing custa reescrita e uma base com dois jeitos de fazer a mesma coisa.",
+            },
+            {
+                frente: "Como você avaliaria uma proposta de reescrever o sistema do zero?",
+                verso: "Perguntando o que exatamente não dá para consertar de forma incremental, e quem paga o período em que dois sistemas existem. Reescrita perde regra de negócio que ninguém documentou e só aparece em produção. Reescrever por módulo costuma entregar o mesmo com menos risco.",
+            },
+            {
+                frente: "Como você escolheria entre construir e contratar uma solução pronta?",
+                verso: "Se é diferencial do produto, construir; se é infraestrutura que todo mundo tem, comprar costuma sair mais barato que manter. A conta precisa incluir operação, plantão e evolução, que é a parte esquecida quando se compara só com o tempo de escrever.",
+            },
+            {
+                frente: "Como você priorizaria dívida técnica frente a entregas de produto?",
+                verso: "Traduzindo dívida em risco e custo com números: tempo perdido por entrega, incidentes recorrentes, área que ninguém mexe sem medo. Assim ela entra na mesma fila e não numa disputa de gosto. Reservar uma fatia fixa da capacidade evita a negociação semanal.",
+            },
+            {
+                frente: "Que dívida técnica você atacaria primeiro numa base Java legada?",
+                verso: "A que impede mudar com segurança: ausência de teste no fluxo mais alterado. Com rede de segurança, o resto vira refatoração barata. Começar pela arquitetura bonita sem teste é como trocar a fundação com a casa cheia de gente dentro.",
+            },
+            {
+                frente: "Como você documentaria uma decisão de arquitetura?",
+                verso: "Um registro curto por decisão: contexto, opções, escolha e consequências, datado e versionado junto do código. O valor está em explicar por que não escolheram o outro caminho. Sem isso, seis meses depois alguém desfaz a decisão sem saber o que ela evitava.",
+            },
+            {
+                frente: "Como você lidaria com uma decisão técnica que você discorda, mas que foi tomada?",
+                verso: "Registrando a discordância com argumento e critério de revisão, e depois apoiando a execução de verdade. Sabotagem passiva custa mais que a decisão errada. Combinar o que faria o time reavaliar transforma opinião em experimento com data.",
+            },
+            {
+                frente: "Como você lidaria com pressão para pular teste por causa de prazo?",
+                verso: "Mostrando o custo em vez de discutir princípio: o que acontece se isso quebrar, quanto tempo leva para descobrir e corrigir. Depois oferecendo o corte mínimo, cobrindo só o caminho crítico. Dívida assumida com prazo é aceitável; dívida escondida não.",
+            },
+            {
+                frente: "Como você trataria um requisito de desempenho vago como precisa ser rápido?",
+                verso: "Transformando em número antes de codificar: qual operação, em qual percentil, com quanta carga e por quanto tempo. Sem isso não existe pronto nem otimização defensável. E o número costuma vir de comparação com o que o usuário já sente hoje.",
+            },
+            {
+                frente: "Como você planejaria capacidade para um pico previsto de tráfego?",
+                verso: "Medindo o que uma instância aguenta hoje, projetando o pico com folga e testando com carga real antes, não no dia. O gargalo raramente é a aplicação: costuma ser banco, conexão e serviço externo. E é preciso ter plano de degradação para o pior caso.",
+            },
+            {
+                frente: "Como você investigaria latência alta só na cauda das requisições?",
+                verso: "Olhando o percentil e não a média, e correlacionando com coleta de lixo, espera por conexão e chamada externa lenta. Cauda costuma ser fila em algum ponto saturado. Rastreamento distribuído mostra onde o tempo fica, o que log solto raramente revela.",
+            },
+            {
+                frente: "Como você garantiria que a mesma versão gera o mesmo artefato?",
+                verso: "Fixando versões em vez de faixas, travando o build com um arquivo de dependências resolvidas, e construindo em imagem controlada com JDK definido. Sem isso, o build de terça e o de quinta produzem artefatos diferentes, e depurar produção vira adivinhação.",
+            },
+            {
+                frente: "Como você trataria o tempo de build crescendo sem parar?",
+                verso: "Medindo por etapa antes de comprar máquina maior. Costuma ser teste de integração no caminho de todo mundo, cache mal aproveitado e módulo que recompila tudo. Build de vinte minutos muda o comportamento do time: as pessoas passam a agrupar mudanças e a arriscar mais.",
+            },
+            {
+                frente: "Como você organizaria o código de vários serviços de um mesmo time?",
+                verso: "Repositório único quando eles mudam juntos e o time é o mesmo, porque mudança atravessada vira um commit. Separados quando os ciclos e os donos são diferentes. O critério é onde a mudança dói, e não moda: os dois exigem ferramenta para não virar bagunça.",
+            },
+            {
+                frente: "Como você definiria a política de branches e deploy?",
+                verso: "Pela frequência de entrega que o time precisa. Branches curtos e integração diária evitam o inferno de conflito; fluxo com muitos branches longos só paga com versões suportadas em paralelo. O que decide é o tempo entre escrever e estar em produção.",
+            },
+            {
+                frente: "Como você faria deploy sem indisponibilidade quando há mudança de banco?",
+                verso: "Separando a migração do deploy e mantendo compatibilidade nos dois sentidos por uma versão: o schema novo funciona com o código antigo, e vice-versa. Assim as instâncias podem conviver durante a troca. É o que permite voltar atrás sem restaurar backup.",
+            },
+            {
+                frente: "Como você avaliaria se um serviço está pronto para produção?",
+                verso: "Por uma lista curta e objetiva: métrica e log, alerta ligado, verificação de saúde, limite de recurso, plano de reversão, segredo fora do código e alguém de plantão. Pronto não é funcionar na máquina de quem escreveu, é poder ser operado por outra pessoa.",
+            },
+            {
+                frente: "Como você planejaria uma migração de dados sem parar a aplicação?",
+                verso: "Em passos compatíveis: criar o novo, escrever nos dois, preencher o histórico em lotes, ler do novo e só depois remover o antigo. Cada passo sozinho é reversível. O que quebra deploy sem parada é mudança que exige código e schema trocarem no mesmo instante.",
+            },
+            {
+                frente: "O que você exigiria antes de aprovar uso de reflexão numa base grande?",
+                verso: "Um motivo que o código normal não resolve, escopo pequeno e teste cobrindo, porque reflexão quebra em silêncio quando alguém renomeia um campo. Em versões recentes ela também esbarra em módulo fechado, então o custo aparece na próxima atualização.",
+            },
+            {
+                frente: "Como você estimaria a memória de um serviço para dimensionar o contêiner?",
+                verso: "Contando heap, metaespaço, pilha por thread e memória fora do heap, e não só o heap. O limite do contêiner precisa sobrar acima disso, senão o processo é morto pelo sistema sem nem lançar erro. Medir sob carga real vale mais que qualquer fórmula.",
+            },
+            {
+                frente: "Como você avaliaria o custo de infraestrutura de um serviço Java?",
+                verso: "Custo por requisição, e não conta total: instâncias, memória reservada, banco e tráfego. Java costuma pesar em memória, então superdimensionar por medo é caro. Reduzir instância ociosa e ajustar limite com dado de uso rende mais que trocar de tecnologia.",
+            },
+            {
+                frente: "Como você decidiria migrar para compilação nativa?",
+                verso: "Se o ganho de subida e memória resolve uma dor real, como escala a zero ou muitas instâncias pequenas. O custo é reflexão declarada à mão, biblioteca incompatível e build lento. Para serviço que sobe e fica de pé, o ganho é pequeno demais para pagar.",
+            },
+            {
+                frente: "Como você mediria a qualidade de uma base de código?",
+                verso: "Por sinais de fora: tempo para entregar uma mudança pequena, taxa de defeito que volta, quanto tempo leva para alguém novo produzir, e quantas áreas ninguém quer tocar. Métrica interna de complexidade ajuda a localizar, mas sozinha vira meta que se engana.",
+            },
+            {
+                frente: "Como você lidaria com um serviço que ninguém do time quer manter?",
+                verso: "Descobrindo por que: costuma ser falta de teste, ambiente difícil e medo de quebrar. Melhorar o ciclo de desenvolvimento muda isso mais rápido que designar um responsável. Se ele não é mais essencial, a melhor manutenção é desligar e reduzir superfície.",
+            },
+            {
+                frente: "Como você definiria quem é dono de cada parte do sistema?",
+                verso: "Cada serviço com um time responsável, incluindo plantão, e isso visível no repositório. Sem dono, todo mundo é responsável e ninguém age no incidente. Dono não significa que só ele altera: significa que alguém revisa, decide e responde.",
+            },
+            {
+                frente: "Como você escolheria entre corrigir a causa e mitigar o sintoma num incidente?",
+                verso: "Mitigando primeiro para o usuário parar de sofrer, e registrando a causa como tarefa com prazo. Correção definitiva sob pressão costuma sair errada. O que não pode é a mitigação virar permanente sem ninguém saber que ela está lá segurando o serviço.",
+            },
+            {
+                frente: "Como você lidaria com um time que registra quase tudo como singleton?",
+                verso: "Mostrando o custo concreto: estado compartilhado entre requisições, dependência cativa e teste que passa isolado e falha em conjunto. Depois firmando um padrão simples, com o escopo de requisição como escolha inicial, e deixando singleton exigir justificativa na revisão.",
+            },
+            {
+                frente: "Como você avaliaria uma proposta de adotar uma arquitetura orientada a eventos?",
+                verso: "Perguntando qual acoplamento ela desfaz e quem opera a fila em produção. Ela paga quando há vários consumidores e picos a absorver. Adotada sem isso, troca chamada simples por depuração distribuída, ordem duvidosa e reprocessamento que ninguém desenhou.",
+            },
+            {
+                frente: "Como você decidiria entre resolver no código e resolver na infraestrutura?",
+                verso: "Pelo que fica mais fácil de operar e entender depois. Repetição, limite de taxa e roteamento costumam ficar melhores fora do código; regra de negócio, nunca. O risco de empurrar tudo para a infraestrutura é o comportamento sumir do repositório e ninguém achar.",
+            },
+            {
+                frente: "Como você reduziria o risco de uma entrega grande e demorada?",
+                verso: "Quebrando em partes que vão para produção desligadas atrás de uma chave, integrando cedo e medindo com uma fatia dos usuários. Entrega de três meses que vira ao vivo de uma vez concentra todo o risco no pior momento, que é a noite do lançamento.",
+            },
+            {
+                frente: "Como você decidiria o que roda em cada ambiente antes da produção?",
+                verso: "Pelo que cada um responde: o de desenvolvimento prova que compila e passa, e o de homologação precisa parecer produção em dado, volume e integração para valer alguma coisa. Ambiente que mente dá falsa confiança, e é mais barato ter menos ambientes e mais chave de funcionalidade.",
+            },
+            {
+                frente: "Como você conduziria a padronização de observabilidade da casa?",
+                verso: "Definindo o mínimo que todo serviço expõe, entregando como biblioteca com padrão pronto, e um painel modelo que nasce junto do serviço novo. Nome de métrica e formato de log precisam ser iguais, senão cada consulta em incidente vira tradução manual.",
+            },
+        ],
+    },
+};

--- a/backend/scripts/data/entrevista/node.ts
+++ b/backend/scripts/data/entrevista/node.ts
@@ -1,0 +1,1144 @@
+import type { TopicoDeEntrevista } from "../../seed-entrevista.ts";
+
+/**
+ * Perguntas de entrevista de Node.js.
+ *
+ * O nível segue o que a pergunta cobra, e não o assunto. O laço de eventos aparece
+ * nos quatro níveis: em estágio é o que significa ser de thread única, em sênior é
+ * decidir quando o problema não é do Node e sim da arquitetura em volta.
+ */
+export const node: TopicoDeEntrevista = {
+    slug: "node",
+    nome: "Node.js",
+    position: 8,
+    perguntas: {
+        estagio: [
+            {
+                frente: "O que é o Node?",
+                verso: "Um ambiente para executar JavaScript fora do navegador, usando o motor V8 e uma camada que dá acesso a arquivo, rede e processo. É o que permite escrever servidor, ferramenta de linha de comando e script com a mesma linguagem do front.",
+            },
+            {
+                frente: "Que vantagem prática existe em usar a mesma linguagem no servidor e no cliente?",
+                verso: "Compartilhar validação, tipos e utilitários, e reduzir a troca de contexto de quem trabalha nos dois lados. O ganho não é desempenho: é fluxo de trabalho. E o cuidado é lembrar que servidor e navegador têm ambientes e riscos diferentes.",
+            },
+            {
+                frente: "O que significa dizer que o Node é de thread única?",
+                verso: "Que o seu código roda numa thread só, a do laço de eventos. Entrada e saída acontece fora dela, e o resultado volta em forma de retorno de chamada. Por isso o Node aguenta muitas conexões esperando, e sofre com cálculo pesado, que trava essa única thread.",
+            },
+            {
+                frente: "O que é o laço de eventos, em uma frase?",
+                verso: "É o ciclo que fica pegando trabalho pronto numa fila e executando na thread principal. Enquanto ele estiver ocupado com o seu código, nada mais acontece: nenhuma requisição é atendida e nenhum retorno de chamada roda.",
+            },
+            {
+                frente: "O que é uma operação assíncrona?",
+                verso: "Uma operação que você inicia e não espera parado: o Node continua atendendo outras coisas e avisa quando ela termina. Leitura de arquivo, consulta ao banco e chamada HTTP são assim. É o que permite um processo só atender muitas conexões.",
+            },
+            {
+                frente: "O que é um retorno de chamada?",
+                verso: "Uma função passada para outra ser chamada quando o trabalho terminar. É o formato mais antigo de assíncrono no Node, com o erro no primeiro parâmetro. Encadear muitos deles é o que produz aquele código em degraus difícil de ler.",
+            },
+            {
+                frente: "O que é uma Promise?",
+                verso: "Um objeto que representa um valor que ainda vai existir, com três estados: pendente, resolvida e rejeitada. Ela permite encadear passos e tratar erro num lugar só, e é a base do async e await. Uma vez resolvida, ela não muda mais.",
+            },
+            {
+                frente: "O que async e await fazem?",
+                verso: "O async faz a função devolver uma promessa, e o await pausa aquela função até a promessa resolver, sem bloquear o laço de eventos. O código passa a ler de cima para baixo, mantendo o comportamento assíncrono por baixo.",
+            },
+            {
+                frente: "Como você trata erro com async e await?",
+                verso: "Com try e catch em volta do await, como em código síncrono. Sem isso, a promessa rejeitada sobe e vira uma rejeição não tratada. Em rota, o padrão é capturar e transformar em resposta de erro, e não deixar o processo lidar com isso.",
+            },
+            {
+                frente: "O que acontece com uma promessa rejeitada que ninguém trata?",
+                verso: "O Node emite um aviso de rejeição não tratada e, nas versões atuais, encerra o processo por padrão. É proposital: seguir rodando com um erro invisível costuma dar problema pior depois, com dado pela metade.",
+            },
+            {
+                frente: "Qual a diferença entre require e import?",
+                verso: "O require é do formato CommonJS, síncrono e resolvido em tempo de execução. O import é do formato de módulos padrão da linguagem, com análise estática e carregamento assíncrono. O que decide qual vale é a configuração do projeto e a extensão do arquivo.",
+            },
+            {
+                frente: "O que o package.json guarda?",
+                verso: "Nome, versão, ponto de entrada, scripts, dependências e configurações do projeto, como o tipo de módulo. É o arquivo que descreve o pacote para o gerenciador e para quem for usar. Sem ele, não há como instalar nem publicar de forma previsível.",
+            },
+            {
+                frente: "Para que serve o arquivo de trava de dependências?",
+                verso: "Para registrar a versão exata de tudo que foi instalado, inclusive das dependências das dependências. É o que faz a instalação de hoje ser igual à de três meses atrás. Ele precisa ser versionado no repositório, senão a máquina de cada um monta uma árvore diferente.",
+            },
+            {
+                frente: "Qual a diferença entre dependência e dependência de desenvolvimento?",
+                verso: "A primeira é necessária para o código rodar em produção; a segunda só para desenvolver e testar, como ferramenta de teste e de tipos. A separação reduz o que vai para a imagem final e deixa claro o que é usado de verdade em produção.",
+            },
+            {
+                frente: "O que o versionamento semântico comunica?",
+                verso: "Três números: quebra de compatibilidade, funcionalidade nova compatível e correção. O acento circunflexo na versão aceita atualizações que não quebram segundo esse contrato. Isso depende de quem publica respeitar a convenção, o que nem sempre acontece.",
+            },
+            {
+                frente: "Para que servem os scripts do package.json?",
+                verso: "Para dar nomes padronizados às tarefas do projeto, como subir, testar e construir, e permitir usar as ferramentas instaladas localmente sem instalar nada global. É o que faz um projeto novo rodar com um comando só.",
+            },
+            {
+                frente: "Como você lê uma variável de ambiente?",
+                verso: "Pelo objeto de ambiente do processo, e o valor sempre chega como texto, então número e booleano precisam de conversão. Vale validar na subida, porque variável faltando costuma aparecer como comportamento estranho no meio da primeira requisição.",
+            },
+            {
+                frente: "Por que segredo não fica dentro do código?",
+                verso: "Porque o repositório é copiado, clonado e compartilhado, e o histórico guarda tudo para sempre. Segredo vem de variável de ambiente injetada no deploy ou de um cofre. Arquivo de exemplo com nome das variáveis é o que fica versionado.",
+            },
+            {
+                frente: "Como você lê um arquivo em Node?",
+                verso: "Com a versão de promessas do módulo de arquivos, usando await. Para arquivo grande, o certo é ler em fluxo em vez de carregar tudo na memória. E é preciso decidir a codificação, senão o retorno vem como buffer, e não como texto.",
+            },
+            {
+                frente: "Qual a diferença entre a versão síncrona e a assíncrona de uma função de arquivo?",
+                verso: "A síncrona bloqueia o laço de eventos até terminar, então em servidor ela para o atendimento de todo mundo. Ela é aceitável em script e na subida da aplicação, quando ninguém está sendo atendido ainda.",
+            },
+            {
+                frente: "Como você sobe um servidor HTTP simples?",
+                verso: "Com o módulo HTTP nativo, criando um servidor com uma função que recebe requisição e resposta e ouvindo numa porta. Em projeto de verdade se usa um framework por causa de rotas, corpo e middlewares, mas o modelo por baixo continua esse.",
+            },
+            {
+                frente: "O que é uma rota numa API?",
+                verso: "A combinação de um método HTTP com um caminho, ligada a uma função que trata aquele pedido. É o que define o contrato: buscar num caminho é leitura, enviar no mesmo caminho é criação. Manter essa coerência é metade de uma API previsível.",
+            },
+            {
+                frente: "O que os principais códigos de status significam?",
+                verso: "Duzentos e pouco é sucesso, trezentos é redirecionamento, quatrocentos é erro de quem chamou e quinhentos é erro do servidor. Usar duzentos com uma mensagem de erro dentro obriga todo cliente a inventar a própria checagem.",
+            },
+            {
+                frente: "Como você lê o corpo de uma requisição?",
+                verso: "Com o middleware que interpreta JSON, que junta os pedaços e entrega o objeto. Sem ele, o corpo é um fluxo e chega vazio. Vale limitar o tamanho aceito, porque corpo enorme é um jeito barato de derrubar o serviço.",
+            },
+            {
+                frente: "Como você devolve JSON numa resposta?",
+                verso: "Com o método que serializa e já define o cabeçalho de tipo, junto com o código de status certo. O importante é ter um formato consistente para sucesso e para erro, para o cliente não precisar adivinhar o que vem em cada rota.",
+            },
+            {
+                frente: "O que é um middleware?",
+                verso: "Uma função que roda entre a chegada da requisição e o tratador final, com acesso à requisição, à resposta e ao próximo passo. Serve para autenticação, log, interpretação de corpo e tratamento de erro. A ordem em que são registrados importa.",
+            },
+            {
+                frente: "Como você lê parâmetro de rota e de consulta?",
+                verso: "Parâmetro de rota vem do caminho declarado, como o identificador num caminho de recurso. Parâmetro de consulta vem depois da interrogação e serve para filtro e paginação. Os dois chegam como texto e vêm do usuário, então precisam ser validados.",
+            },
+            {
+                frente: "Como você trata uma rota que não existe?",
+                verso: "Com um tratador registrado no fim, devolvendo o status de não encontrado num formato igual ao dos outros erros. Deixar o framework devolver a página padrão em HTML numa API quebra o cliente que espera JSON.",
+            },
+            {
+                frente: "O que é o objeto process?",
+                verso: "A representação do processo em execução: variáveis de ambiente, argumentos da linha de comando, saída padrão, sinais e código de saída. É por ele que você lê configuração e reage a um pedido de encerramento.",
+            },
+            {
+                frente: "Como você encerra um processo indicando falha?",
+                verso: "Saindo com código diferente de zero, para quem orquestra saber que deu errado. Isso importa em script de esteira e em contêiner. Sair com zero depois de um erro faz o orquestrador achar que tudo terminou bem.",
+            },
+            {
+                frente: "O que é o EventEmitter?",
+                verso: "A base do modelo de eventos do Node: um objeto que emite eventos nomeados e permite registrar ouvintes. Streams e servidores são construídos sobre ele. O detalhe que pega é o evento de erro: sem ouvinte, ele derruba o processo.",
+            },
+            {
+                frente: "Qual a diferença entre setTimeout e setInterval?",
+                verso: "O primeiro agenda uma execução depois do tempo; o segundo repete. O intervalo não espera o trabalho anterior terminar, então tarefa lenta se acumula. Por isso repetição costuma ser feita com agendamento no fim de cada execução.",
+            },
+            {
+                frente: "Como você espera um tempo dentro de uma função assíncrona?",
+                verso: "Com a versão em promessa dos temporizadores e await. Laço ocupando a CPU até o relógio passar bloqueia o laço de eventos e para o servidor inteiro, mesmo parecendo apenas uma espera curta.",
+            },
+            {
+                frente: "O que é uma stream, em uma frase?",
+                verso: "Um fluxo de dados processado em pedaços, em vez de tudo de uma vez. É o que permite ler um arquivo de gigabytes ou responder um download sem carregar tudo na memória. Requisição e resposta HTTP são streams.",
+            },
+            {
+                frente: "Quando ler um arquivo inteiro de uma vez é problema?",
+                verso: "Quando ele é grande o bastante para pesar na memória, ou quando muitos pedidos fazem isso ao mesmo tempo. Cada leitura ocupa memória até terminar, então dez requisições de cem megabytes derrubam um contêiner pequeno.",
+            },
+            {
+                frente: "O que é um buffer?",
+                verso: "Uma área de bytes crus, usada quando o dado não é texto ou quando a codificação ainda não foi decidida. Arquivo, rede e criptografia trabalham com buffer. Converter para texto sem informar a codificação é onde nascem os caracteres estranhos.",
+            },
+            {
+                frente: "O que o JSON.parse pode lançar, e o que fazer?",
+                verso: "Ele lança quando o texto não é JSON válido, o que é comum com corpo malformado ou resposta de erro em HTML. Precisa estar dentro de try, e o resultado precisa ser validado: JSON válido não significa que os campos esperados existem.",
+            },
+            {
+                frente: "Por que confiar no corpo da requisição é perigoso?",
+                verso: "Porque ele vem do cliente e pode ter qualquer coisa: campo faltando, tipo errado, campo a mais que você não deveria aceitar. Sem validação, isso vira erro em tempo de execução, ou pior, gravação de campo que o usuário não podia definir.",
+            },
+            {
+                frente: "Como você valida a entrada de uma rota?",
+                verso: "Com um esquema declarado para corpo, parâmetros e consulta, rejeitando cedo com uma mensagem clara. Assim o resto do código pode assumir dado válido. Validar com sequência de ifs espalhados devolve um erro por vez e sempre esquece um caso.",
+            },
+            {
+                frente: "O que é CORS e por que ele aparece?",
+                verso: "É a política do navegador que impede uma página de um domínio chamar outra API sem permissão explícita. A liberação vem em cabeçalhos da resposta do servidor. Não é proteção do servidor: quem chama por fora do navegador não passa por isso.",
+            },
+            {
+                frente: "Como você serve arquivos estáticos?",
+                verso: "Com o middleware que expõe uma pasta, cuidando para não expor mais do que deveria. Em produção, o normal é deixar isso com um servidor de borda ou uma rede de distribuição, que fazem cache e comprimem melhor que o processo Node.",
+            },
+            {
+                frente: "O que significa a porta já estar em uso?",
+                verso: "Que outro processo está ouvindo nela, muitas vezes uma execução anterior que não encerrou. A saída é encerrar o processo antigo ou usar outra porta, e no ambiente de desenvolvimento tornar a porta configurável para não travar quem trabalha em paralelo.",
+            },
+            {
+                frente: "Como você roda o servidor recarregando ao salvar?",
+                verso: "Com o modo de observação do próprio Node nas versões recentes, ou com uma ferramenta que reinicia o processo. Vale saber que recarregar não é atualização em memória: o processo morre e sobe de novo, perdendo o que estava guardado nele.",
+            },
+            {
+                frente: "Como você depura um servidor Node?",
+                verso: "Rodando com o inspetor ligado e conectando o depurador do editor ou do navegador, com pontos de parada. É bem mais rápido que espalhar impressões, principalmente em código assíncrono, onde a ordem das mensagens engana.",
+            },
+            {
+                frente: "O que acontece se você fizer um cálculo pesado numa rota?",
+                verso: "O laço de eventos fica preso, e nenhuma outra requisição é atendida enquanto isso, nem as que já estavam esperando. O sintoma é latência subindo para todo mundo por causa de um endpoint só. Esse trabalho precisa sair da thread principal.",
+            },
+            {
+                frente: "Que tipo de trabalho não combina com Node?",
+                verso: "Processamento intenso de CPU por longos períodos, como transformação de imagem e vídeo ou cálculo numérico pesado, porque a thread única vira o gargalo. Isso não impede usar Node: impede fazer esse trabalho dentro do processo que atende requisições.",
+            },
+            {
+                frente: "O que é o npx?",
+                verso: "Um atalho para executar um pacote sem instalar globalmente, usando a versão local do projeto quando existe. Serve para gerador de projeto e ferramenta de uso pontual, e evita a bagunça de instalações globais com versões diferentes por máquina.",
+            },
+            {
+                frente: "Qual a diferença entre instalar e instalar limpo?",
+                verso: "A instalação normal pode atualizar o arquivo de trava conforme as faixas de versão. A limpa apaga a pasta de dependências e instala exatamente o que a trava manda, falhando se ela estiver fora de sincronia. É a que se usa na esteira.",
+            },
+            {
+                frente: "O que é uma dependência transitiva?",
+                verso: "A dependência da sua dependência, que você não declarou mas está no seu projeto. É por isso que uma biblioteca pequena pode trazer dezenas de pacotes, e por isso vulnerabilidade aparece em coisa que você nunca instalou de propósito.",
+            },
+            {
+                frente: "Como você descobre se um projeto tem dependência vulnerável?",
+                verso: "Com o comando de auditoria do gerenciador, e melhor ainda com verificação automática na esteira. O resultado precisa ser lido com cuidado: nem todo alerta é explorável no seu uso, mas ignorar tudo por padrão é como se acumula risco.",
+            },
+            {
+                frente: "O que significa uma versão do Node ser LTS?",
+                verso: "Que ela tem suporte longo e recebe correções por mais tempo, o que a torna a escolha para produção. Versões ímpares são de vida curta. Ficar numa versão fora de suporte significa não receber correção de segurança.",
+            },
+            {
+                frente: "Como você fixa a versão do Node de um projeto?",
+                verso: "Declarando no campo de motores e num arquivo de versão que as ferramentas de troca reconhecem, e usando a mesma na imagem do contêiner e na esteira. Sem isso, cada máquina roda uma versão e o erro só aparece em produção.",
+            },
+            {
+                frente: "O que é o CommonJS?",
+                verso: "O formato de módulos original do Node, com require e exports, carregado de forma síncrona. Ele ainda é a maior parte do ecossistema. Convive com o formato padrão da linguagem, e é essa convivência que gera boa parte da confusão de importação.",
+            },
+            {
+                frente: "O que o campo de tipo do package.json muda?",
+                verso: "Define se os arquivos com extensão comum são tratados como módulos ES ou como CommonJS. É o que decide se import funciona sem extensão especial. Trocar esse campo num projeto existente quebra qualquer arquivo que ainda use require.",
+            },
+            {
+                frente: "Por que não existe __dirname em módulos ES?",
+                verso: "Porque essas variáveis eram do embrulho do CommonJS. No formato padrão, o caminho do arquivo é obtido a partir da URL do módulo. É uma das primeiras diferenças que aparecem ao migrar, e a correção é mecânica.",
+            },
+            {
+                frente: "Por que juntar caminhos com o módulo de caminho em vez de concatenar?",
+                verso: "Porque ele cuida do separador do sistema, de barras duplicadas e de trechos relativos. Concatenar com barra funciona até o dia em que roda noutro sistema ou recebe um trecho vazio, e aí o caminho aponta para o lugar errado.",
+            },
+            {
+                frente: "Como você organizaria as pastas de uma API Node pequena?",
+                verso: "Separando rota, regra de negócio e acesso a dado, com um lugar só para configuração. Não precisa de arquitetura elaborada no começo, mas colocar consulta de banco dentro do tratador de rota é o que impede testar e reaproveitar depois.",
+            },
+            {
+                frente: "O que é uma API REST?",
+                verso: "Um estilo em que recursos são identificados por caminhos e manipulados pelos métodos HTTP, com respostas em formato padrão e uso correto dos status. Não é regra rígida: o que importa é ser previsível para quem consome.",
+            },
+            {
+                frente: "Como você trataria um erro que acontece dentro de uma rota?",
+                verso: "Capturando, registrando com contexto e devolvendo uma resposta de erro no formato padrão da API, sem vazar pilha nem detalhe interno. Erro esperado, como registro não encontrado, é resposta de cliente; erro inesperado é falha de servidor.",
+            },
+            {
+                frente: "Como você faria uma API devolver a lista de um recurso?",
+                verso: "Com paginação desde o começo, mesmo que a tabela esteja pequena, e um formato que informe se há mais. Rota que devolve tudo funciona por meses e derruba o serviço no dia em que os dados crescerem.",
+            },
+            {
+                frente: "O que o console.log tem de limitação em produção?",
+                verso: "Não tem nível, não tem estrutura e não dá para filtrar sem mexer no código. Além disso ele pode bloquear dependendo do destino da saída. Log de produção precisa ser estruturado e ter nível, para reduzir ruído sem perder o que importa.",
+            },
+            {
+                frente: "Como você guardaria dados numa API sem banco, para um exercício?",
+                verso: "Num arquivo ou em memória, sabendo que memória some quando o processo reinicia e não é compartilhada entre instâncias. Serve para prototipar, e é justamente por essas duas razões que não sobrevive à primeira necessidade de escalar.",
+            },
+            {
+                frente: "O que muda entre rodar o Node no seu computador e num contêiner?",
+                verso: "Ambiente, versão, variáveis, limites de memória e usuário. A maior parte dos erros que só acontecem no contêiner vem dessas diferenças, e não do código. Por isso o objetivo é que os dois rodem a mesma imagem sempre que possível.",
+            },
+            {
+                frente: "Como você trataria uma dependência que só funciona no navegador?",
+                verso: "Não usando no servidor, porque objetos como janela e documento não existem lá. Se ela mistura os dois mundos, é preciso importar apenas o subcaminho que serve para servidor. Esse é um dos erros mais comuns ao mover código do front.",
+            },
+            {
+                frente: "O que acontece quando duas requisições chegam ao mesmo tempo?",
+                verso: "As duas entram no mesmo processo e são atendidas de forma intercalada: enquanto uma espera pelo banco, a outra avança. Não há paralelismo real no seu código, então uma operação que trava a thread atrasa a outra.",
+            },
+            {
+                frente: "Por que variável global em módulo é arriscada num servidor?",
+                verso: "Porque ela é compartilhada por todas as requisições daquele processo. Guardar o usuário atual ali faz uma requisição enxergar o dado da outra. Estado de requisição precisa viver na própria requisição, e não no módulo.",
+            },
+            {
+                frente: "Como você trataria um valor numérico vindo da URL?",
+                verso: "Convertendo explicitamente e checando o resultado, porque tudo chega como texto e uma conversão silenciosa devolve valor inválido. Passar isso direto para o banco é a origem de consulta estranha e de erro difícil de rastrear.",
+            },
+            {
+                frente: "O que você colocaria num arquivo de exemplo de variáveis de ambiente?",
+                verso: "O nome de todas as variáveis necessárias, com valor de exemplo inofensivo e um comentário curto quando o nome não basta. Nenhum valor real. É o que permite alguém subir o projeto sem perguntar quais variáveis existem.",
+            },
+            {
+                frente: "Como você escreveria um teste para uma função assíncrona?",
+                verso: "Deixando o teste ser assíncrono e usando await na chamada, e verificando também o caso de rejeição com a asserção própria para isso. Esquecer o await faz o teste terminar antes da asserção rodar, e ele passa mesmo com o código errado.",
+            },
+            {
+                frente: "Como você instalaria uma dependência que só serve para rodar testes?",
+                verso: "Como dependência de desenvolvimento, com a marcação própria, para ela não ir para a imagem de produção. Isso reduz o tamanho da imagem e a superfície de segurança. Instalar tudo como dependência normal é comum e passa despercebido até alguém olhar o que foi para o servidor.",
+            },
+        ],
+        junior: [
+            {
+                frente: "Quais são as fases do laço de eventos?",
+                verso: "Em ordem: temporizadores, retornos pendentes de entrada e saída, preparação, sondagem, checagem e fechamento. A sondagem é onde ele espera por trabalho novo. Saber isso importa para entender por que um temporizador de zero milissegundos não roda imediatamente.",
+            },
+            {
+                frente: "Qual a diferença entre microtarefa e macrotarefa?",
+                verso: "Microtarefa é a fila das promessas, esvaziada inteira depois de cada passo, antes de o laço seguir. Macrotarefa é o que entra nas fases, como temporizador e entrada e saída. Por isso um encadeamento de promessas roda antes de um temporizador já vencido.",
+            },
+            {
+                frente: "O que o nextTick tem de diferente?",
+                verso: "Ele roda antes das promessas, numa fila própria, esvaziada assim que a operação atual termina. Usado em excesso, ele deixa o laço de eventos sem avançar, porque a fila nunca acaba. É uma ferramenta de biblioteca, não de código de aplicação.",
+            },
+            {
+                frente: "Se o Node é de thread única, como a leitura de arquivo é assíncrona?",
+                verso: "Porque a operação é delegada. Parte vai para o sistema operacional e parte para um pool de threads da biblioteca interna, fora do seu código. Quando termina, o resultado volta como retorno de chamada na thread principal.",
+            },
+            {
+                frente: "Que operações usam o pool de threads interno?",
+                verso: "Arquivo, resolução de nomes por padrão, compressão e criptografia. Rede não usa: ela é assíncrona no próprio sistema. O pool tem tamanho fixo, então muitas operações de arquivo ou de hash de senha ao mesmo tempo formam fila invisível.",
+            },
+            {
+                frente: "Como você identifica que o laço de eventos está travando?",
+                verso: "Medindo o atraso do laço, que é a diferença entre quando um temporizador deveria disparar e quando ele disparou. Se esse número sobe junto com a latência das rotas, o problema é trabalho síncrono, e não banco nem rede.",
+            },
+            {
+                frente: "Como você tiraria um trabalho pesado de CPU do caminho da requisição?",
+                verso: "Passando para uma thread de trabalho, para um processo separado ou para uma fila com consumidor próprio. A escolha depende de precisar do resultado agora. O que não pode é o cálculo ficar na thread que atende todo mundo.",
+            },
+            {
+                frente: "Qual a diferença entre cluster e threads de trabalho?",
+                verso: "Cluster cria processos completos que dividem a mesma porta, e serve para usar todos os núcleos atendendo requisições. Threads de trabalho rodam dentro do mesmo processo, compartilham memória por buffers e servem para cálculo pesado.",
+            },
+            {
+                frente: "Quando você usaria um processo filho?",
+                verso: "Para executar um programa externo, como uma ferramenta de linha de comando, ou para isolar algo que pode travar. É preciso cuidar da entrada e saída para não encher o buffer, e nunca montar o comando concatenando texto vindo do usuário.",
+            },
+            {
+                frente: "O que é contrapressão numa stream?",
+                verso: "É o consumidor lento avisar que não dá conta, para o produtor parar de empurrar. Sem respeitar isso, os dados se acumulam na memória do processo. É a diferença entre transmitir um arquivo grande com memória estável ou ver o processo inchar até morrer.",
+            },
+            {
+                frente: "Por que usar pipeline em vez de encadear pipe?",
+                verso: "Porque o pipeline propaga erro e destrói todas as streams envolvidas quando uma falha. Com pipe encadeado, um erro no meio deixa as outras abertas, vazando descritor e memória. É a diferença entre limpar sozinho e vazar em silêncio.",
+            },
+            {
+                frente: "Como você leria um arquivo enorme linha a linha?",
+                verso: "Com uma stream de leitura passada para o utilitário de linhas, iterando com for await. Assim a memória fica constante independentemente do tamanho. Ler tudo e dividir por quebra de linha funciona no teste e derruba na produção.",
+            },
+            {
+                frente: "Como você transformaria dados no meio de um fluxo?",
+                verso: "Com uma stream de transformação entre a leitura e a escrita, que recebe pedaços e emite os transformados. É o que permite converter formato ou filtrar registros sem materializar o arquivo inteiro em memória.",
+            },
+            {
+                frente: "Como você trata erro numa stream?",
+                verso: "Ouvindo o evento de erro em todas elas, ou deixando o pipeline cuidar disso. Stream sem ouvinte de erro derruba o processo. E é preciso destruir as demais, senão o arquivo continua aberto e a conexão pendurada.",
+            },
+            {
+                frente: "O que o for await permite?",
+                verso: "Iterar sobre algo assíncrono, como uma stream ou um gerador, tratando cada item na sua vez. É a forma mais legível de consumir fluxo, e naturalmente respeita a contrapressão, porque o próximo item só é pedido quando o anterior termina.",
+            },
+            {
+                frente: "Como você limitaria a concorrência de várias chamadas assíncronas?",
+                verso: "Processando em blocos ou com um limitador que mantém no máximo N em voo. Disparar mil promessas de uma vez abre mil conexões e derruba o dependente. Concorrência controlada costuma ser mais rápida do que tudo de uma vez.",
+            },
+            {
+                frente: "Qual a diferença entre esperar todas e esperar todas com resultado?",
+                verso: "A primeira rejeita assim que uma falhar, descartando o resto, e é o que você quer quando tudo é obrigatório. A segunda espera todas e diz o que deu certo e o que não deu, e serve quando falha parcial é aceitável.",
+            },
+            {
+                frente: "Como você colocaria um tempo limite numa promessa?",
+                verso: "Correndo a promessa contra um temporizador, ou passando um sinal de aborto quando a API aceita. A segunda forma é melhor porque cancela o trabalho de verdade. Só correr contra o relógio deixa a operação original rodando até o fim.",
+            },
+            {
+                frente: "Como você cancelaria uma requisição HTTP em andamento?",
+                verso: "Com um controlador de aborto, passando o sinal para a chamada e abortando quando não interessa mais. Isso libera conexão e evita processar resposta que ninguém vai usar. O sinal precisa ser propagado para as chamadas internas também.",
+            },
+            {
+                frente: "O que acontece com uma exceção lançada dentro de um retorno de chamada assíncrono?",
+                verso: "Ela não é capturada pelo try que envolvia a chamada original, porque aquele bloco já terminou. Ela sobe como exceção não capturada e pode derrubar o processo. É um dos motivos de o padrão de promessas ter substituído esse estilo.",
+            },
+            {
+                frente: "O que fazer quando acontece uma exceção não capturada?",
+                verso: "Registrar com o máximo de contexto e encerrar o processo, deixando o orquestrador subir outro. Continuar rodando depois disso significa estado desconhecido, com conexão pela metade e dado inconsistente. Reiniciar é a opção conservadora.",
+            },
+            {
+                frente: "Como você faria um encerramento gracioso?",
+                verso: "Ouvindo o sinal de término, parando de aceitar conexões novas, esperando as requisições em andamento até um limite, fechando pool de banco e filas, e então saindo. Sem isso, todo deploy devolve erro para quem estava no meio de uma chamada.",
+            },
+            {
+                frente: "Como você estruturaria os erros de uma API Node?",
+                verso: "Com uma classe de erro própria carregando status, código estável e mensagem segura, e um tratador único traduzindo para resposta. Assim o resto do código só lança. Cada rota montando a própria resposta de erro é o que gera formatos diferentes.",
+            },
+            {
+                frente: "Como você diferencia erro esperado de defeito?",
+                verso: "Erro esperado faz parte do fluxo, como validação e registro não encontrado, e vira resposta de cliente. Defeito é o que não deveria acontecer e precisa de alerta. Tratar os dois igual enche o painel de erro com validação e esconde o que importa.",
+            },
+            {
+                frente: "Por que um erro assíncrono pode não chegar ao middleware de erro?",
+                verso: "Porque o framework só captura o que é lançado de forma síncrona ou passado adiante explicitamente, dependendo da versão. Sem embrulhar o tratador ou usar await com try, a rejeição escapa e a requisição fica pendurada até o timeout.",
+            },
+            {
+                frente: "Como você limitaria o tamanho do corpo de uma requisição?",
+                verso: "Configurando o limite no interpretador de corpo e, além disso, no servidor de borda. Sem limite, um corpo de centenas de megabytes consome memória e é a forma mais barata de derrubar um serviço Node.",
+            },
+            {
+                frente: "Como você configuraria CORS de forma correta?",
+                verso: "Listando as origens permitidas em vez de liberar todas, declarando métodos e cabeçalhos aceitos e tratando a requisição de verificação prévia. Liberar tudo com credenciais é o pior dos casos, porque permite qualquer site chamar a API com o cookie do usuário.",
+            },
+            {
+                frente: "Como você guardaria a senha dos usuários?",
+                verso: "Com uma função lenta e com sal, feita para senha, e nunca com hash rápido. No Node isso passa pelo pool de threads, então o custo precisa ser calibrado: parâmetro alto demais enfileira o pool e derruba a latência de todas as rotas.",
+            },
+            {
+                frente: "Como você emitiria e validaria um token de autenticação?",
+                verso: "Assinando com chave forte, com expiração curta e conferindo assinatura, expiração, emissor e público em toda requisição. Decodificar sem verificar a assinatura é um erro comum e transforma o token em texto que qualquer um edita.",
+            },
+            {
+                frente: "Como você guardaria uma sessão com várias instâncias?",
+                verso: "Num armazenamento compartilhado, como um cache distribuído, e não na memória do processo. Sessão em memória funciona com uma instância e quebra assim que houver duas, com o usuário caindo aleatoriamente conforme o balanceador escolhe.",
+            },
+            {
+                frente: "Como você aplicaria limite de requisições numa API?",
+                verso: "Contando por identidade e por rota num armazenamento compartilhado, respondendo com o status próprio e o cabeçalho que diz quando tentar de novo. Contador em memória com várias instâncias permite multiplicar o limite pelo número de processos.",
+            },
+            {
+                frente: "Como você registraria logs úteis numa API?",
+                verso: "Em formato estruturado, com nível, identificador de requisição, rota e duração, escrevendo na saída padrão para o coletor do ambiente. Frase concatenada não dá para filtrar nem agregar, e é o que transforma investigação em leitura de texto corrido.",
+            },
+            {
+                frente: "Como você correlacionaria todos os logs de uma requisição?",
+                verso: "Gerando ou propagando um identificador no cabeçalho e carregando ele no contexto até o fim da requisição, inclusive nas chamadas a outros serviços. Passar esse identificador por parâmetro em toda função é o que o armazenamento de contexto assíncrono resolve.",
+            },
+            {
+                frente: "Como você testaria uma rota HTTP?",
+                verso: "Subindo a aplicação em memória e fazendo a requisição de verdade contra ela, verificando status, corpo e efeito colateral. É mais valioso que testar o tratador isolado, porque exercita middleware, validação e serialização junto.",
+            },
+            {
+                frente: "Como você isolaria o banco nos testes?",
+                verso: "Subindo um banco real efêmero em contêiner e limpando entre casos, ou usando transação revertida no fim de cada teste. Substituir o banco por um dublê testa o seu código e não testa a consulta, que é justamente onde os erros aparecem.",
+            },
+            {
+                frente: "O que o executor de testes nativo do Node oferece?",
+                verso: "Estrutura de teste, asserções, execução paralela, cobertura e observação, sem dependência externa. Para projeto novo isso costuma bastar. A troca é ter menos ferramentas prontas de dublê e de teste de interface do que os ecossistemas maiores.",
+            },
+            {
+                frente: "Quando um dublê de teste atrapalha mais do que ajuda?",
+                verso: "Quando ele reproduz o comportamento que você acha que a dependência tem. O teste passa e a integração quebra. Para banco e serviço externo, é melhor o real efêmero ou a interceptação na camada de rede, que exercita o mesmo caminho.",
+            },
+            {
+                frente: "Como você organizaria as camadas de uma API Node?",
+                verso: "Rota cuidando de HTTP, serviço com a regra e um acesso a dado separado, com o domínio sem saber de framework. O sinal de que a fronteira caiu é o objeto de requisição chegando na função que fala com o banco.",
+            },
+            {
+                frente: "Como você faria injeção de dependência sem framework?",
+                verso: "Passando as dependências pelo construtor ou por parâmetro de uma função fábrica, montando tudo num ponto só na subida. É simples e testável. Importar o módulo do banco direto dentro do serviço é o que impede substituir no teste.",
+            },
+            {
+                frente: "Como você validaria a configuração na subida?",
+                verso: "Lendo todas as variáveis num módulo só, com esquema declarado, convertendo tipos e falhando com mensagem clara se faltar algo. Falhar na subida é muito melhor que descobrir a variável ausente na primeira requisição do dia seguinte.",
+            },
+            {
+                frente: "Como você se conectaria a um banco de dados numa API?",
+                verso: "Com um pool criado uma vez na subida e compartilhado, nunca abrindo conexão por requisição. O tamanho do pool precisa caber no que o banco aceita, considerando o número de instâncias. Abrir e fechar por requisição custa mais que a consulta.",
+            },
+            {
+                frente: "O que acontece quando o pool de conexões esgota?",
+                verso: "As requisições ficam esperando por uma conexão e a latência sobe, mesmo com o banco tranquilo. O sintoma engana. Costuma ser transação longa segurando conexão, ou chamada externa feita no meio da transação.",
+            },
+            {
+                frente: "Como você trataria uma transação numa API Node?",
+                verso: "Abrindo, executando e confirmando ou desfazendo dentro de um bloco que garante o fechamento, com a conexão passada explicitamente para as funções. O erro clássico é fazer chamada HTTP no meio da transação, segurando conexão pelo tempo da rede.",
+            },
+            {
+                frente: "Como você evitaria injeção de SQL em Node?",
+                verso: "Usando parâmetros em toda consulta, inclusive nas escritas à mão, e nunca montando SQL por concatenação de texto vindo do usuário. Nome de coluna e ordenação dinâmica não entram como parâmetro, e ali a defesa é aceitar só valores de uma lista fixa.",
+            },
+            {
+                frente: "O que é injeção em banco de documentos, e como evitar?",
+                verso: "É o cliente enviar um objeto onde o código espera um valor, transformando a comparação em operador de consulta. A defesa é validar o tipo antes de usar, rejeitando o que não for texto, e nunca passar o corpo da requisição direto para o filtro.",
+            },
+            {
+                frente: "Como você trataria upload de arquivo numa API?",
+                verso: "Recebendo em fluxo com limite de tamanho e tipo, gravando direto no armazenamento sem passar tudo pela memória. Melhor ainda é o cliente enviar direto para o armazenamento com uma URL assinada, e a API só registrar o resultado.",
+            },
+            {
+                frente: "Como você versionaria uma API?",
+                verso: "Por caminho quando a quebra é grande e visível, mantendo as duas versões por um tempo com prazo de descontinuação. Antes disso, vale evoluir sem quebrar: acrescentar campo, nunca mudar significado, e manter o cliente tolerante ao que não conhece.",
+            },
+            {
+                frente: "O que torna uma rota idempotente, e por que isso importa?",
+                verso: "Repetir a chamada com a mesma entrada produzir o mesmo efeito. Importa porque rede repete: cliente reenvia, proxy repete, usuário clica de novo. Sem isso, uma cobrança pode acontecer duas vezes por causa de uma resposta perdida.",
+            },
+            {
+                frente: "Como você trataria data e fuso numa API Node?",
+                verso: "Guardando instante em UTC, trafegando em formato padrão e convertendo só na apresentação. O objeto de data nativo é limitado e cheio de armadilhas, então operação de calendário costuma pedir biblioteca. Somar milissegundos erra no horário de verão.",
+            },
+            {
+                frente: "Como você representaria valores monetários?",
+                verso: "Em inteiro de menor unidade, como centavos, ou com uma biblioteca de decimal. Número de ponto flutuante acumula erro e faz o total fechar errado. Em JSON, valor muito grande também estoura a precisão do número, e aí o certo é trafegar como texto.",
+            },
+            {
+                frente: "Quando um cache em memória é a escolha errada?",
+                verso: "Quando existem várias instâncias e o dado precisa ser coerente entre elas, ou quando ele cresce sem limite. Cache em memória sem tamanho máximo é vazamento com outro nome, e é uma das causas mais comuns de processo crescendo devagar.",
+            },
+            {
+                frente: "Como você faria paginação de uma listagem grande?",
+                verso: "Por cursor, usando o último identificador visto, em vez de deslocamento, que obriga o banco a percorrer e descartar tudo antes. A resposta informa se há mais e qual o próximo cursor. A troca é perder o salto direto para uma página específica.",
+            },
+            {
+                frente: "Como você documentaria uma API para quem consome?",
+                verso: "Com uma especificação gerada a partir do código ou validada contra ele, com exemplos de requisição, resposta e erro. Documento escrito à parte envelhece em semanas, e é pior que não ter, porque as pessoas confiam nele.",
+            },
+            {
+                frente: "Como você lidaria com dependências nativas num projeto?",
+                verso: "Sabendo que elas compilam por plataforma e versão do Node, então a imagem precisa ter as ferramentas certas e a instalação precisa acontecer no mesmo ambiente de destino. Copiar a pasta de dependências do computador para o contêiner é o erro clássico.",
+            },
+            {
+                frente: "Como você trataria uma resposta HTTP com status de erro numa chamada externa?",
+                verso: "Checando o status explicitamente, porque a API de busca do navegador e do Node não rejeita em quatrocentos ou quinhentos. Sem essa checagem, o código segue tentando ler o corpo como se tudo tivesse dado certo.",
+            },
+            {
+                frente: "Como você repetiria uma chamada externa que falhou?",
+                verso: "Só para erro transitório, com poucas tentativas, espera crescente e um pouco de aleatoriedade, e nunca em operação que não é idempotente. Repetir erro de validação é desperdício, e repetir em massa durante uma queda derruba quem estava se recuperando.",
+            },
+            {
+                frente: "Como você lidaria com um serviço externo que às vezes demora muito?",
+                verso: "Timeout em toda chamada, sempre, porque sem ele a requisição fica pendurada até o outro lado desistir. Somado a limite de concorrência para aquele destino, evitando que a lentidão dele consuma toda a capacidade do seu serviço.",
+            },
+            {
+                frente: "Como você processaria uma tarefa demorada disparada por uma rota?",
+                verso: "Aceitando o pedido, gravando o trabalho numa fila e devolvendo aceito com uma forma de acompanhar. Fazer o trabalho dentro da requisição segura conexão, estoura timeout do balanceador e perde tudo se o processo reiniciar.",
+            },
+            {
+                frente: "Como você agendaria uma rotina periódica?",
+                verso: "Com um agendador que coordene entre instâncias, ou com trava compartilhada, porque um temporizador dentro do processo roda em todas as réplicas. E toda rotina precisa ser idempotente, porque ela vai rodar duas vezes algum dia.",
+            },
+            {
+                frente: "Como você lidaria com um evento que chega duas vezes?",
+                verso: "Guardando o identificador já processado e ignorando repetição, ou desenhando a operação para ser idempotente. Entrega ao menos uma vez é o padrão das filas, então duplicata não é exceção: é comportamento esperado.",
+            },
+            {
+                frente: "Como você faria a verificação de saúde de um serviço Node?",
+                verso: "Separando a que diz que o processo está vivo da que diz que ele está pronto, sendo que a de prontidão checa dependências essenciais. Verificação que consulta o banco a cada segundo vira carga, e tira o serviço de rotação por qualquer soluço.",
+            },
+            {
+                frente: "Como você exporia métricas de uma API Node?",
+                verso: "Contando requisições por rota e status, medindo duração em histograma, e expondo o atraso do laço de eventos e a memória. O atraso do laço é a métrica mais específica do Node, e é a que aponta bloqueio antes de virar latência para todo mundo.",
+            },
+            {
+                frente: "Como você trataria dados sensíveis nos logs?",
+                verso: "Com uma lista de campos mascarados na serialização do log e nunca registrando corpo inteiro de requisição. Log é copiado para vários lugares e fica muito tempo, então senha ou token que caiu ali precisa ser tratado como vazado.",
+            },
+            {
+                frente: "Como você lidaria com uma variável de ambiente diferente entre ambientes?",
+                verso: "Lendo tudo num módulo de configuração com valores padrão explícitos, e falhando quando obrigatório faltar. Espalhar leituras de ambiente pelo código faz surgir variável que só uma parte conhece, e ela é sempre a que falta no deploy.",
+            },
+            {
+                frente: "Como você trataria diferenças entre desenvolvimento e produção no código?",
+                verso: "Reduzindo ao mínimo, e sempre por configuração explícita, não por checagem de ambiente espalhada. Caminho que só roda em produção é caminho que ninguém testou, e é onde o erro aparece justamente quando dói mais.",
+            },
+            {
+                frente: "Como você faria a subida da aplicação falhar cedo?",
+                verso: "Validando configuração, testando a conexão com as dependências essenciais e saindo com código de erro se algo faltar. Subir e responder erro em toda requisição é pior que não subir: o orquestrador acha que está tudo bem.",
+            },
+            {
+                frente: "Como você compartilharia código entre dois serviços Node?",
+                verso: "Com um pacote interno versionado, e não copiando arquivo entre repositórios. Compartilhar cedo demais acopla os dois serviços a um ciclo de release comum, então vale reservar isso para o que é realmente estável, como contrato e utilitário.",
+            },
+            {
+                frente: "Como você trataria uma expressão regular que veio do usuário?",
+                verso: "Não aceitando, na maior parte dos casos. Expressão maliciosa provoca explosão de tempo de execução e trava a thread única inteira. Se for inevitável, é preciso um mecanismo com limite de tempo, fora do processo que atende requisições.",
+            },
+            {
+                frente: "Como você limitaria o que uma rota pode devolver de dado?",
+                verso: "Serializando por um tipo de saída explícito, e não devolvendo o objeto do banco. Assim campo novo não vaza sozinho quando alguém acrescenta uma coluna. Devolver o registro inteiro é como senha em hash e campos internos acabam expostos.",
+            },
+            {
+                frente: "Como você trataria uma dependência que faz efeito colateral ao ser importada?",
+                verso: "Isolando a importação atrás de uma função de inicialização, para o efeito acontecer quando você escolher. Módulo que conecta no banco ao ser importado quebra teste e torna a ordem de importação parte do comportamento.",
+            },
+        ],
+        pleno: [
+            {
+                frente: "Como você investigaria um vazamento de memória num serviço Node?",
+                verso: "Confirmando pelo gráfico de memória que sobe e não volta depois das coletas, e tirando dois retratos do heap em momentos diferentes para comparar o que cresceu. O caminho de retenção costuma apontar cache sem limite, ouvinte acumulado ou fechamento guardando contexto.",
+            },
+            {
+                frente: "O que costuma vazar memória em Node?",
+                verso: "Ouvinte de evento registrado a cada requisição e nunca removido, cache em memória sem tamanho máximo, mapa global crescendo por chave de usuário, e temporizador que nunca é limpo. Todos parecem inofensivos e só aparecem depois de horas de tráfego.",
+            },
+            {
+                frente: "Como você perfilaria CPU num serviço em produção?",
+                verso: "Coletando um perfil por amostragem durante a janela de lentidão, com o inspetor ou uma ferramenta contínua, e olhando o gráfico de chamadas. O que aparece no topo costuma ser serialização, expressão regular ou criptografia, e não a lógica que se suspeitava.",
+            },
+            {
+                frente: "O que fazer quando o atraso do laço de eventos está alto?",
+                verso: "Achar o trecho síncrono que domina: serialização de objeto gigante, laço sobre coleção grande, hash de senha malcalibrado ou compressão feita no processo. A correção é dividir, mover para thread de trabalho ou empurrar para a borda.",
+            },
+            {
+                frente: "Como você dimensionaria processos e instâncias de um serviço Node?",
+                verso: "Um processo por núcleo disponível, seja com cluster, seja com várias réplicas pequenas no orquestrador. Réplicas pequenas costumam ser melhores, porque o orquestrador já sabe distribuir e reiniciar. Mais processos que núcleos só aumenta troca de contexto.",
+            },
+            {
+                frente: "Quando threads de trabalho realmente valem?",
+                verso: "Quando existe cálculo pesado e frequente que precisa do resultado na mesma requisição, como processar imagem ou fazer parsing pesado. Para tarefa rara, um processo separado ou uma fila é mais simples. Elas não deixam entrada e saída mais rápida.",
+            },
+            {
+                frente: "Como você compartilharia dados entre threads de trabalho?",
+                verso: "Por mensagem, que copia, ou por buffer compartilhado quando o volume justifica evitar a cópia. Objeto comum não é compartilhado. Passar estruturas grandes de um lado para o outro toda hora pode custar mais que o cálculo que se queria acelerar.",
+            },
+            {
+                frente: "Como você lidaria com estado em memória quando o serviço tem várias instâncias?",
+                verso: "Tirando o estado do processo: cache e sessão vão para um armazenamento compartilhado, e o processo passa a ser descartável. Estado em memória sobrevive enquanto há uma instância e falha de forma intermitente quando surge a segunda, o que é pior de diagnosticar.",
+            },
+            {
+                frente: "Como você propagaria o contexto de uma requisição por chamadas assíncronas?",
+                verso: "Com o armazenamento de contexto assíncrono, que mantém o valor disponível ao longo da cadeia sem passar por parâmetro. É o que permite ter identificador de requisição no log de qualquer camada. Variável de módulo para isso mistura requisições.",
+            },
+            {
+                frente: "Como você instrumentaria rastreamento distribuído?",
+                verso: "Com a biblioteca padrão de instrumentação, que já enxerta nos módulos de HTTP e banco e propaga o contexto por cabeçalho. O trabalho manual fica para as fronteiras próprias, como consumo de fila. Sem propagação, cada serviço vira um rastro solto.",
+            },
+            {
+                frente: "Como você trataria log em volume muito alto?",
+                verso: "Reduzindo nível em produção, amostrando o que é repetitivo e mantendo cem por cento de erro. Escrita de log é trabalho síncrono na thread principal dependendo do destino, então log excessivo vira latência, além de custo de armazenamento.",
+            },
+            {
+                frente: "Como você containerizaria um serviço Node?",
+                verso: "Com build em múltiplos estágios, instalando dependências de produção na imagem final, usuário sem privilégio, e o processo Node como principal para receber os sinais. Copiar a pasta de dependências do computador quebra dependência nativa.",
+            },
+            {
+                frente: "Por que o processo Node precisa receber os sinais no contêiner?",
+                verso: "Porque é assim que ele sabe que precisa encerrar graciosamente. Se um shell for o processo principal, ele pode não repassar o sinal, e o orquestrador acaba matando à força depois do prazo, cortando requisições em andamento.",
+            },
+            {
+                frente: "Como você definiria o limite de memória de um contêiner Node?",
+                verso: "Medindo o uso real sob carga e deixando folga acima do heap, porque buffers e memória fora do heap somam. O limite do heap precisa ficar abaixo do limite do contêiner, senão o processo é morto pelo sistema antes de qualquer erro de memória do próprio Node.",
+            },
+            {
+                frente: "O que acontece quando o Node bate no limite de heap?",
+                verso: "Ele lança erro de memória esgotada e o processo morre, deixando rastro. Se o limite do contêiner for atingido antes, o sistema mata sem rastro nenhum, e o sintoma é o serviço sumindo sem log, o que engana bastante na investigação.",
+            },
+            {
+                frente: "Como você reduziria o tamanho da imagem de um serviço Node?",
+                verso: "Base enxuta, instalação só de dependências de produção, arquivos desnecessários fora com a lista de ignorados, e nada de ferramentas de build na imagem final. Imagem menor sobe mais rápido e reduz a superfície de vulnerabilidade.",
+            },
+            {
+                frente: "Como você garantiria que a esteira instala exatamente o que foi testado?",
+                verso: "Com instalação limpa a partir do arquivo de trava, que falha se ele estiver fora de sincronia com o manifesto. Somado a cache de dependências por hash do arquivo de trava. Instalação normal na esteira permite subir versão sem ninguém aprovar.",
+            },
+            {
+                frente: "Como você conduziria a migração de CommonJS para módulos ES?",
+                verso: "Por pacote e não por arquivo solto, ajustando o tipo do projeto, extensões nas importações e as variáveis de caminho. As dependências ainda em CommonJS continuam funcionando, mas o caminho contrário é o que dói: pacote só de módulo ES não é importável por require antigo.",
+            },
+            {
+                frente: "Que problemas aparecem misturando os dois formatos de módulo?",
+                verso: "Importação padrão que vem embrulhada num objeto, ausência de importação nomeada em pacote CommonJS, e ferramenta que resolve diferente do Node. O sintoma é a função existir no depurador e ser indefinida no import.",
+            },
+            {
+                frente: "Como você escolheria entre compilar TypeScript e executá-lo direto?",
+                verso: "Execução direta com remoção de tipos simplifica o ciclo e o Node moderno já faz isso, mas ela não checa nada: a checagem continua sendo um passo à parte. Compilar gera artefato previsível e mapas de origem. Os dois exigem checagem de tipos na esteira.",
+            },
+            {
+                frente: "Por que tipos não protegem a borda da aplicação?",
+                verso: "Porque eles desaparecem em tempo de execução: o corpo da requisição é declarado como um tipo e chega como qualquer coisa. A borda precisa de validação de verdade, que checa e converte. Confiar no tipo declarado é o erro mais comum em API TypeScript.",
+            },
+            {
+                frente: "Como você faria streaming de uma resposta grande?",
+                verso: "Escrevendo direto na resposta em pedaços, respeitando contrapressão, com o tipo de conteúdo correto e sem acumular tudo antes. Isso derruba o uso de memória e faz o cliente começar a receber antes. Vale também tratar o cliente que desconecta no meio.",
+            },
+            {
+                frente: "Como você serviria arquivos grandes para download?",
+                verso: "Delegando para o armazenamento com URL assinada, ou transmitindo em fluxo com suporte a faixa de bytes para permitir retomar. Ler o arquivo inteiro e enviar consome memória proporcional ao número de downloads simultâneos.",
+            },
+            {
+                frente: "Como você lidaria com conexões longas, como eventos do servidor?",
+                verso: "Contando com o custo de manter conexões abertas, com envio periódico para o intermediário não derrubar, e reconexão do lado do cliente. Um processo Node segura muitas conexões ociosas bem, mas cada uma ainda ocupa memória e descritor.",
+            },
+            {
+                frente: "Como você escalaria WebSocket em várias instâncias?",
+                verso: "Com sessão fixa ou com um barramento de mensagens entre as instâncias, porque o cliente conectado a uma não é visto pela outra. Sem isso, mensagem enviada para uma sala só chega a quem estiver na mesma réplica, e o bug parece aleatório.",
+            },
+            {
+                frente: "Como você trataria reconexão numa conexão em tempo real?",
+                verso: "Com espera crescente e aleatória do lado do cliente, e um mecanismo de retomada a partir do último evento recebido. Sem espera crescente, uma queda do servidor traz todos os clientes de volta ao mesmo tempo e impede a recuperação.",
+            },
+            {
+                frente: "Como você trataria uma fila de trabalhos que começou a crescer?",
+                verso: "Olhando primeiro se é produção acima do consumo ou consumidor travado, e só então escalando consumidores. Fila crescendo com consumidor ocioso é sinal de mensagem envenenada ou de trava. Escalar sem entender pode multiplicar o problema.",
+            },
+            {
+                frente: "Como você garantiria que um trabalho da fila não rode duas vezes?",
+                verso: "Com identificador de trabalho e registro do que já foi processado, ou desenhando o efeito para ser idempotente. Confirmar a mensagem só depois de concluir também importa, mas isso garante ao menos uma vez, e não exatamente uma vez.",
+            },
+            {
+                frente: "Como você lidaria com um trabalho que falha sempre?",
+                verso: "Limitando tentativas, com espera crescente, e mandando para uma fila de mensagens mortas com contexto suficiente para reprocessar depois. Sem esse desvio, a mensagem envenenada trava o consumo e para tudo que estava atrás dela.",
+            },
+            {
+                frente: "Como você identificaria uma consulta lenta a partir da aplicação?",
+                verso: "Instrumentando duração por consulta e registrando as que passam de um limite, com o texto e o tempo. Depois olhando o plano no banco. Sem essa medição, lentidão de banco aparece como latência da rota e leva a otimizar o lugar errado.",
+            },
+            {
+                frente: "Como você evitaria o problema de N+1 consultas com um ORM?",
+                verso: "Carregando as associações necessárias numa consulta só ou agrupando por lote. Aparece ligando o registro de consultas e vendo a mesma instrução repetida com parâmetros diferentes. É o erro de desempenho mais comum em API com ORM.",
+            },
+            {
+                frente: "Como você decidiria entre ORM e SQL escrito à mão?",
+                verso: "ORM para o trivial, que é a maior parte, e SQL para consulta analítica e atualização em massa, onde ele atrapalha. Os dois convivem no mesmo projeto. Trocar o ORM inteiro por causa de três consultas raramente compensa.",
+            },
+            {
+                frente: "Como você aplicaria migrações de schema num serviço Node?",
+                verso: "Com scripts versionados no repositório, aplicados num passo separado do deploy, e nunca editando migração já aplicada. Rodar migração na subida de cada instância cria corrida entre réplicas e trava a subida quando a migração é pesada.",
+            },
+            {
+                frente: "Como você faria deploy sem indisponibilidade?",
+                verso: "Com verificação de prontidão, subida gradual das novas instâncias e encerramento gracioso das antigas, mantendo compatibilidade de schema nos dois sentidos por uma versão. Sem encerramento gracioso, todo deploy corta requisições em andamento.",
+            },
+            {
+                frente: "Como você reduziria o tempo de subida de um serviço Node?",
+                verso: "Medindo o que demora: costuma ser importação de dependências pesadas no topo, conexão feita em série na subida e leitura de arquivo grande. Importar sob demanda o que só é usado em uma rota ajuda, e conectar em paralelo também.",
+            },
+            {
+                frente: "Como você faria um teste de carga que diga algo útil?",
+                verso: "Com carga parecida com a real em mistura de rotas e dados, subindo aos poucos até achar o ponto de saturação, e olhando latência por percentil junto com erro. Disparar mil requisições iguais em um endpoint mede o cache, e não o sistema.",
+            },
+            {
+                frente: "Como você interpretaria o resultado de um teste de carga?",
+                verso: "Procurando onde a latência começa a subir sem o rendimento acompanhar, que é a saturação. Depois identificando o recurso limitante: CPU, laço de eventos, pool de conexões ou dependente externo. Número de requisições por segundo sozinho não diz nada.",
+            },
+            {
+                frente: "Como você testaria integração com um serviço externo?",
+                verso: "Interceptando na camada HTTP com respostas gravadas, e mantendo um teste de contrato contra o ambiente real rodando fora do caminho crítico. Substituir a função do cliente esconde erro de URL, cabeçalho e serialização, que é onde a integração quebra.",
+            },
+            {
+                frente: "Como você trataria segredo de forma segura numa aplicação Node?",
+                verso: "Injetado por variável de ambiente ou lido de um cofre na subida, nunca no repositório, com rotação prevista e sem aparecer em log nem em mensagem de erro. Vale ter varredura automática no repositório, porque o vazamento costuma ser acidental.",
+            },
+            {
+                frente: "Como você reagiria a uma vulnerabilidade numa dependência?",
+                verso: "Verificando se o caminho vulnerável é realmente usado, o que define a urgência, e corrigindo pela versão. Se não houver correção, isolar o uso ou trocar a biblioteca. E registrar, porque auditoria e cliente vão perguntar depois.",
+            },
+            {
+                frente: "Como você reduziria o risco de um pacote malicioso entrar no projeto?",
+                verso: "Fixando versões pela trava, revisando dependência nova como se fosse código próprio, desligando scripts de instalação quando possível e usando verificação automática na esteira. Instalar pacote com nome parecido com o certo é um ataque comum e barato.",
+            },
+            {
+                frente: "Como você trataria dados pessoais numa API?",
+                verso: "Coletando o mínimo, cifrando em trânsito e no repouso, mascarando em log, com retenção definida e caminho para exclusão. E limitando quem consegue consultar no banco. A parte esquecida costuma ser o ambiente de homologação com cópia da produção.",
+            },
+            {
+                frente: "Como você lidaria com uma rota que precisa chamar três serviços?",
+                verso: "Disparando as chamadas independentes em paralelo, com timeout por chamada e um orçamento total para a requisição, e decidindo o que é essencial. Encadear em sequência soma as latências, e sem orçamento total a requisição fica presa pelo mais lento.",
+            },
+            {
+                frente: "Como você evitaria que a lentidão de um dependente derrube o serviço?",
+                verso: "Limitando a concorrência por destino, com timeout curto e disjuntor, e devolvendo resposta degradada. Sem limite, requisições presas se acumulam consumindo memória e conexões, e a queda de um dependente vira indisponibilidade total.",
+            },
+            {
+                frente: "Como você lidaria com um pico de tráfego repentino?",
+                verso: "Com limite de requisições na borda, fila para o que não precisa ser síncrono e escalonamento automático com folga, sabendo que subir instância leva tempo. Aceitar tudo e cair é pior que recusar parte com resposta clara.",
+            },
+            {
+                frente: "Como você trataria compressão de resposta?",
+                verso: "Deixando com o servidor de borda quando existe, porque comprimir no processo Node consome CPU da thread que atende requisições. Se for no Node, com limite de tamanho mínimo e sem comprimir o que já é comprimido, como imagem.",
+            },
+            {
+                frente: "Como você lidaria com serialização de objetos muito grandes?",
+                verso: "Evitando: paginar, projetar só os campos usados ou transmitir em fluxo. Serializar para JSON é síncrono e bloqueia o laço de eventos proporcionalmente ao tamanho, então uma resposta de dezenas de megabytes atrasa todas as outras requisições.",
+            },
+            {
+                frente: "Como você trataria erro de conexão com o banco em tempo de execução?",
+                verso: "Com repetição limitada na obtenção da conexão, verificação de prontidão refletindo o estado real e resposta de indisponibilidade em vez de erro genérico. E sem derrubar o processo a cada oscilação, senão o serviço entra em ciclo de reinício.",
+            },
+            {
+                frente: "Como você garantiria que os testes não dependem uns dos outros?",
+                verso: "Cada teste criando o próprio dado com identificadores únicos e limpando o que criou, e rodando em ordem aleatória de vez em quando para expor dependência escondida. Banco compartilhado com dado fixo é a origem clássica de teste que só passa numa ordem.",
+            },
+            {
+                frente: "Como você trataria testes que dependem de tempo?",
+                verso: "Injetando o relógio ou usando temporizadores falsos, para não haver espera real nem falha na virada do dia. Teste que espera dois segundos de verdade multiplica o tempo da suíte e ainda falha em máquina lenta.",
+            },
+            {
+                frente: "Como você mediria a cobertura sem transformar o número em meta cega?",
+                verso: "Olhando cobertura como mapa do que não é exercitado, principalmente em caminho de erro, e não como nota. Meta alta imposta produz teste que executa código sem verificar nada, o que dá falsa segurança e ainda custa manutenção.",
+            },
+            {
+                frente: "Como você organizaria a configuração de vários ambientes?",
+                verso: "Um esquema único com valores vindos do ambiente, sem arquivo por ambiente dentro do repositório, e valores padrão só para o que é seguro. Assim o que muda entre ambientes fica visível numa lista, e não espalhado em condicionais pelo código.",
+            },
+            {
+                frente: "Como você trataria a diferença de fuso entre servidor e banco?",
+                verso: "Padronizando UTC em todos os pontos e convertendo só na apresentação, com o driver configurado explicitamente. Metade dos erros de uma hora vem de servidor com fuso local e banco em UTC, ou o contrário, sem ninguém ter escolhido.",
+            },
+            {
+                frente: "Como você identificaria qual rota está consumindo mais recursos?",
+                verso: "Com métricas por rota de duração, contagem e erro, mais perfil de CPU segmentado por período. Costuma ser uma rota pouco chamada e muito cara, e não a mais popular. Sem separar por rota, o número agregado esconde o culpado.",
+            },
+            {
+                frente: "Como você trataria uma requisição que precisa de resposta rápida mas de trabalho lento?",
+                verso: "Respondendo com o que dá para responder e enfileirando o resto, com um recurso para consultar o resultado ou um aviso quando terminar. É melhor que segurar a conexão e depender de o cliente e o proxy esperarem sem desistir.",
+            },
+            {
+                frente: "Como você lidaria com clientes que fazem muitas requisições pequenas?",
+                verso: "Oferecendo um recurso que devolva o conjunto de uma vez, com cache e limite de requisições no meio tempo. Cada requisição carrega custo fixo de conexão e autenticação, então cem chamadas pequenas custam mais que uma grande bem desenhada.",
+            },
+            {
+                frente: "Como você trataria uma dependência que só falha em produção?",
+                verso: "Reproduzindo o ambiente antes do código: versão, variáveis, latência, certificado e volume de dado. Log com contexto suficiente e um cenário reproduzível valem mais que tentativa às cegas com deploy a cada hipótese.",
+            },
+            {
+                frente: "Como você trataria memória crescendo lentamente em produção?",
+                verso: "Instrumentando memória por instância, comparando com o tráfego e tirando retratos do heap periodicamente. Reiniciar por horário esconde o problema e é aceitável como medida temporária, desde que registrado com prazo para investigar.",
+            },
+            {
+                frente: "Como você decidiria entre cache em memória e cache distribuído?",
+                verso: "Cache em memória para dado pequeno, muito lido e que tolera divergir entre instâncias, sempre com limite de tamanho. Distribuído quando a coerência importa ou o volume não cabe. A conta inclui a chamada de rede a cada acesso.",
+            },
+            {
+                frente: "Como você invalidaria cache depois de uma escrita?",
+                verso: "Removendo a chave na mesma operação que escreve, ou trabalhando com vencimento curto quando dado velho por alguns segundos é aceitável. Invalidação espalhada por vários pontos é o que gera aquele dado antigo que só some quando o processo reinicia.",
+            },
+            {
+                frente: "Como você lidaria com muitas chaves de cache vencendo ao mesmo tempo?",
+                verso: "Espalhando o vencimento com uma variação aleatória e deixando só uma requisição recalcular enquanto as outras servem o valor antigo. Sem isso, a carga cai inteira no banco no mesmo segundo e derruba justamente no pico.",
+            },
+            {
+                frente: "Como você trataria autenticação entre serviços internos?",
+                verso: "Com credencial própria por serviço e verificação da identidade de quem chama, e não confiando na rede interna. Rede interna já foi considerada segura por padrão, e é assim que um serviço comprometido passa a acessar tudo.",
+            },
+            {
+                frente: "Como você faria a rotação de uma credencial em uso?",
+                verso: "Aceitando as duas por um período, trocando quem emite e só depois revogando a antiga. Sem essa sobreposição, a troca precisa ser simultânea em todos os pontos, o que sempre esquece um consumidor e vira incidente.",
+            },
+            {
+                frente: "Como você trataria requisições concorrentes que alteram o mesmo registro?",
+                verso: "Com trava otimista por versão, devolvendo conflito para o cliente refazer com o dado atual, ou com trava no banco quando o conflito é frequente. Ler, alterar em memória e gravar sem checagem é onde a atualização de um se perde.",
+            },
+            {
+                frente: "Como você lidaria com um endpoint que precisa processar um arquivo enviado?",
+                verso: "Recebendo em fluxo, gravando no armazenamento e enfileirando o processamento, devolvendo aceito. Processar no meio da requisição segura conexão, gasta memória e perde tudo se o processo reiniciar no meio.",
+            },
+            {
+                frente: "Como você garantiria que o serviço se comporta igual em todas as instâncias?",
+                verso: "Tirando estado do processo, garantindo mesma imagem e mesma configuração, e evitando comportamento dependente de tempo de subida. Diferença entre réplicas produz erro intermitente que só acontece com parte dos usuários, e é dos mais caros de achar.",
+            },
+            {
+                frente: "Como você trataria uma dependência que exige inicialização assíncrona?",
+                verso: "Inicializando na subida antes de aceitar tráfego, e refletindo isso na verificação de prontidão. Inicializar preguiçosamente na primeira requisição transforma a primeira chamada em lenta e cria corrida quando várias chegam juntas.",
+            },
+            {
+                frente: "Como você lidaria com uma biblioteca que bloqueia a thread principal?",
+                verso: "Medindo o custo dela com o atraso do laço, e movendo para thread de trabalho ou processo separado se for realmente necessária. Se existir versão assíncrona, é a primeira escolha. Biblioteca síncrona em caminho quente é um gargalo invisível no código.",
+            },
+            {
+                frente: "Como você lidaria com um serviço que precisa manter ordem de processamento?",
+                verso: "Particionando por chave, para tudo de um mesmo cliente cair no mesmo consumidor, em vez de exigir ordem global. Ordem total custa concorrência e vira gargalo. E mesmo assim é preciso tolerar reprocessamento, porque a entrega repete.",
+            },
+            {
+                frente: "Como você monitoraria se o serviço está saudável de verdade?",
+                verso: "Por sintoma do usuário: latência por percentil, taxa de erro e rendimento, mais o atraso do laço de eventos e a memória. Alerta em uso de CPU sozinho gera ruído; alerta em erro e latência aponta o que a pessoa realmente precisa olhar.",
+            },
+        ],
+        senior: [
+            {
+                frente: "Quando você não usaria Node num projeto novo?",
+                verso: "Quando o trabalho é dominado por CPU, quando o ecossistema da área é outro, como ciência de dados, ou quando o time não sustenta JavaScript no servidor. Node brilha em entrada e saída e em produtividade com o mesmo idioma do front, e não em cálculo pesado.",
+            },
+            {
+                frente: "Como você escolheria o framework HTTP de um serviço Node?",
+                verso: "Pelo que o time sustenta e pelo que o projeto precisa: maturidade do ecossistema, desempenho e quanto de estrutura você quer imposta. A escolha importa menos do que parece; o que dói depois é ter cinco serviços cada um com um framework diferente.",
+            },
+            {
+                frente: "Como você avaliaria adotar um framework opinativo com injeção de dependência?",
+                verso: "Pelo tamanho do time e pela quantidade de serviços: estrutura imposta ajuda a padronizar entre muitos times e cobra em cerimônia e curva de aprendizado. Para um serviço pequeno com duas pessoas, ele costuma entregar mais arquivo que valor.",
+            },
+            {
+                frente: "Como você avaliaria funções sem servidor contra contêineres?",
+                verso: "Pelo perfil de tráfego e pelo custo de operar. Carga esporádica e picos ganham com escala a zero; carga constante costuma sair mais barata em contêiner. A conta precisa incluir subida a frio, limite de tempo e conexões de banco por instância.",
+            },
+            {
+                frente: "Como você padronizaria a estrutura entre vários serviços Node?",
+                verso: "Com um modelo de projeto pronto que já traz log, configuração, erro, saúde e esteira, e uma biblioteca pequena para o que atravessa. Padrão em documento não sobrevive; padrão que nasce com o serviço sim.",
+            },
+            {
+                frente: "Como você definiria a política de dependências de um time?",
+                verso: "Poucas e revisadas: cada uma precisa de motivo, dono e caminho de saída. Verificação automática de vulnerabilidade e atualização contínua em vez de mutirão anual. O ecossistema Node facilita instalar demais, e é isso que produz árvore com mil pacotes.",
+            },
+            {
+                frente: "Como você conduziria a adoção de TypeScript numa base JavaScript grande?",
+                verso: "Ligando arquivo por arquivo, começando pelas bordas e pelo que é compartilhado, com regras estritas chegando aos poucos e checagem obrigatória na esteira desde o primeiro dia. Converter tudo de uma vez produz um mar de tipos frouxos que não protegem nada.",
+            },
+            {
+                frente: "Como você conduziria a atualização da versão do Node em produção?",
+                verso: "Subindo em ambiente igual ao de produção, rodando a suíte, revisando dependências nativas e mudanças de comportamento, e liberando com monitoramento por versão. O bloqueio real costuma ser dependência nativa antiga, e não o Node.",
+            },
+            {
+                frente: "Como você lidaria com um serviço rodando numa versão do Node fora de suporte?",
+                verso: "Tratando como risco de segurança com prazo, não como preferência. Primeiro subir para a versão de longo prazo mais próxima, resolvendo dependências, e depois seguir. Ficar sem correção de segurança é decisão, mesmo quando ninguém decidiu.",
+            },
+            {
+                frente: "Como você desenharia o contrato entre dois serviços?",
+                verso: "Escrito primeiro e acordado, com exemplo de sucesso e de erro, compatibilidade só aditiva e teste de contrato mantendo isso honesto. Combinar por conversa e integrar no fim é o que estoura prazo dos dois lados.",
+            },
+            {
+                frente: "Como você evitaria acoplamento entre serviços pelo banco de dados?",
+                verso: "Dando dono a cada tabela e obrigando o resto a passar por API ou evento. Serviço lendo a tabela do outro parece atalho e transforma toda migração em coordenação. Enquanto não dá para separar, ao menos escrita só pelo dono.",
+            },
+            {
+                frente: "Como você decidiria dividir um serviço Node em dois?",
+                verso: "Por escala independente ou por dono diferente, e não por estética. Se a fronteira não está clara entre módulos do mesmo projeto, ela não fica clara atravessando a rede: você ganha latência, falha parcial e deploy coordenado.",
+            },
+            {
+                frente: "Como você avaliaria uma arquitetura orientada a eventos para o seu time?",
+                verso: "Perguntando qual acoplamento ela desfaz e quem opera a fila. Ela paga com vários consumidores e picos a absorver. Sem isso, troca chamada simples por depuração distribuída, ordem duvidosa e reprocessamento que ninguém desenhou.",
+            },
+            {
+                frente: "Como você trataria consistência entre serviços sem transação distribuída?",
+                verso: "Com passos compensáveis e mensagens gravadas na mesma transação do dado, aceitando consistência eventual e deixando isso explícito para o produto. Prometer consistência forte entre serviços é o que leva a inventar transação distribuída caseira.",
+            },
+            {
+                frente: "Como você mediria a saúde de um serviço Node em produção?",
+                verso: "Latência por percentil e por rota, taxa de erro, rendimento, atraso do laço de eventos, memória e saturação do pool de conexões. Esses dois últimos são os que mais explicam incidente de latência sem culpa aparente no código.",
+            },
+            {
+                frente: "Como você decidiria o que vira alerta?",
+                verso: "O que exige alguém agir agora, ligado ao sintoma do usuário: erro e latência acima do acordado. Causa provável fica no painel. Alerta que ninguém age treina o time a ignorar, e o próximo, que era real, também passa despercebido.",
+            },
+            {
+                frente: "Como você reduziria o ruído de alertas do time?",
+                verso: "Revisando o que disparou no último mês e quantos exigiram ação, apagando o resto, agregando duplicados e agrupando por incidente. Alerta bom tem dono, ação clara e história de ser útil. Ruído é o que faz plantão virar castigo.",
+            },
+            {
+                frente: "Como você conduziria um incidente num serviço Node?",
+                verso: "Restaurando primeiro: reverter, desligar a funcionalidade nova ou reiniciar o processo que está com memória estourada. Uma pessoa coordenando e comunicando. Investigar causa raiz com o serviço fora do ar é como se perde a madrugada.",
+            },
+            {
+                frente: "Como você conduziria a análise depois do incidente?",
+                verso: "Sem procurar culpado, com linha do tempo, o que faltou detectar e o que atrasou a recuperação, e poucas ações com dono e prazo. Documento sem ação vira ritual, e o mesmo incidente volta em alguns meses com outro nome.",
+            },
+            {
+                frente: "Como você organizaria o plantão de um time pequeno?",
+                verso: "Com escala previsível, alertas enxutos e o poder de agir sem pedir permissão, incluindo reverter. Runbook curto por alerta. Plantão sem autonomia e sem alerta confiável só produz gente cansada e resposta lenta.",
+            },
+            {
+                frente: "Como você lidaria com um monólito Node que ficou grande demais?",
+                verso: "Definindo módulos com fronteira clara dentro do mesmo processo primeiro, e extraindo só o que tem escala ou dono diferente. Monólito organizado entrega quase todos os ganhos sem o custo de rede. Quebrar tudo de uma vez troca um problema por vários.",
+            },
+            {
+                frente: "Como você trataria o custo de nuvem de um serviço Node crescendo?",
+                verso: "Olhando custo por requisição e não a fatura total: instâncias superdimensionadas, log em excesso, tráfego entre zonas e chamada a serviço pago por uso. Costuma dar mais resultado cortar log e ajustar limites do que otimizar código.",
+            },
+            {
+                frente: "Como você decidiria entre escalar horizontalmente e otimizar o código?",
+                verso: "Medindo onde está a saturação. Se é CPU do processo, escalar resolve e custa dinheiro; se é banco ou trava compartilhada, escalar piora. Otimizar vale quando o gargalo é seu e a mudança é localizada. As duas coisas competem por tempo do time.",
+            },
+            {
+                frente: "Como você planejaria capacidade para um evento de pico?",
+                verso: "Medindo o que uma instância aguenta hoje, projetando com folga, testando com carga antes e definindo o plano de degradação. O gargalo raramente é o Node: costuma ser banco, pool de conexões e serviço externo com limite de taxa.",
+            },
+            {
+                frente: "Como você definiria padrão de erro e de log entre times?",
+                verso: "Como biblioteca compartilhada, com formato de resposta, catálogo de códigos e log estruturado com os mesmos nomes de campo. Assim uma consulta em incidente funciona em todos os serviços. Padrão só documentado diverge no terceiro serviço.",
+            },
+            {
+                frente: "Como você versionaria uma API pública mantida pelo seu time?",
+                verso: "Com política escrita de compatibilidade, prazo de descontinuação e métrica de uso por versão para saber quem ainda depende do quê. Sem esse número, toda remoção vira aposta e a decisão fica adiada para sempre.",
+            },
+            {
+                frente: "Como você lidaria com consumidores que não migram de versão?",
+                verso: "Medindo quem são e quanto representam, dando prazo com aviso e ajuda para migrar, e mantendo camada de compatibilidade só se poucos e importantes. Manter tudo para sempre é o que faz cada mudança futura custar três vezes mais.",
+            },
+            {
+                frente: "Como você conduziria uma migração de dados grande sem parar o serviço?",
+                verso: "Em passos compatíveis: criar o novo, escrever nos dois, preencher o histórico em lotes com controle de ritmo, ler do novo e só então remover o antigo. Cada passo reversível sozinho. Migração em lote sem controle de ritmo derruba o banco no meio.",
+            },
+            {
+                frente: "Como você trataria dívida técnica num serviço Node antigo?",
+                verso: "Traduzindo em risco e custo com número: incidentes recorrentes, tempo perdido por entrega, área que ninguém toca. Assim ela entra na mesma fila das entregas. Reservar uma fatia fixa da capacidade evita a negociação toda semana.",
+            },
+            {
+                frente: "Que dívida você atacaria primeiro numa base Node sem testes?",
+                verso: "A ausência de teste no fluxo mais alterado, com testes de rota que exercitam de ponta a ponta o caminho crítico. Com essa rede, o resto vira refatoração barata. Começar pela arquitetura sem teste é trocar a fundação com a casa cheia.",
+            },
+            {
+                frente: "Como você faria revisão de código sem virar gargalo?",
+                verso: "Limitando o tamanho do que se pede para revisar, prazo curto acordado e separando o que bloqueia do que é sugestão. Estilo e checagem óbvia ficam com a ferramenta. Revisão que volta com trinta comentários de formatação ensina o time a evitá-la.",
+            },
+            {
+                frente: "O que você olharia primeiro num PR de backend Node?",
+                verso: "Validação da entrada, tratamento de erro e o que acontece quando a dependência falha, mais transação e trabalho síncrono pesado. Depois se a rota é idempotente quando precisa ser. Nome de variável fica com o linter.",
+            },
+            {
+                frente: "Como você lidaria com um PR gigante que já está pronto?",
+                verso: "Revisando por partes acordadas com quem escreveu, priorizando risco, e combinando que os próximos serão fatiados. Recusar de saída desperdiça o trabalho feito. O problema é de processo, e ele só muda se o combinado ficar claro.",
+            },
+            {
+                frente: "Como você faria a integração de alguém novo num serviço Node?",
+                verso: "Ambiente rodando em um comando, uma tarefa real pequena na primeira semana e um mapa curto do fluxo de uma requisição. Documentar as três coisas que mais surpreendem economiza semanas de perguntas repetidas.",
+            },
+            {
+                frente: "Como você garantiria que o conhecimento não fique com uma pessoa só?",
+                verso: "Rodando quem faz o quê, revisando em par o que é crítico e escrevendo o que só existe na cabeça de alguém, principalmente operação. O teste é simples: essa pessoa consegue tirar férias sem o time travar?",
+            },
+            {
+                frente: "Como você documentaria decisões técnicas do serviço?",
+                verso: "Um registro curto por decisão, com contexto, opções, escolha e consequências, datado e no repositório. O valor está em dizer por que o outro caminho foi descartado. Sem isso, alguém desfaz a decisão sem saber o que ela evitava.",
+            },
+            {
+                frente: "Como você lidaria com um time que quer reescrever o serviço em outra tecnologia?",
+                verso: "Pedindo o que exatamente não dá para consertar como está e quem paga o período com dois sistemas. Muitas vezes a dor é ausência de teste e build lento, que não muda de linguagem. Se for mesmo o caminho, a reescrita precisa ser por fatia.",
+            },
+            {
+                frente: "Como você trataria um requisito de desempenho vago?",
+                verso: "Transformando em número antes de codificar: qual rota, em qual percentil, com quanta carga. Sem isso não existe pronto nem otimização defensável, e a discussão vira opinião na véspera da entrega.",
+            },
+            {
+                frente: "Como você negociaria prazo quando existe risco técnico conhecido?",
+                verso: "Nomeando o risco, o que acontece se ele se concretizar e qual o menor experimento que o reduz. Prazo com risco escondido vira surpresa na última semana. O que se negocia é escopo e ordem, e raramente a data.",
+            },
+            {
+                frente: "Como você lidaria com pressão para pular teste por causa de prazo?",
+                verso: "Mostrando o custo em vez de discutir princípio: o que quebra, quanto tempo leva para descobrir e para corrigir. Depois oferecendo o corte mínimo cobrindo só o caminho crítico. Dívida assumida com prazo é aceitável; escondida não.",
+            },
+            {
+                frente: "Como você definiria o que é uma entrega pronta no backend?",
+                verso: "Métrica e log, alerta, verificação de saúde, limites de recurso, migração compatível, plano de reversão e alguém de plantão. Pronto não é passar no teste local: é poder ser operado por outra pessoa às três da manhã.",
+            },
+            {
+                frente: "Como você trataria o ambiente de homologação de um serviço Node?",
+                verso: "Igual à produção no que importa: versão, configuração, volume plausível e integração com dublês fiéis. Ambiente que mente dá falsa confiança. Muitas vezes é melhor ter menos ambientes e mais chave de funcionalidade em produção.",
+            },
+            {
+                frente: "Como você usaria chaves de funcionalidade num backend?",
+                verso: "Para separar deploy de liberação, com valor padrão seguro, avaliação barata e data para a chave morrer. Sem prazo elas acumulam e viram combinações que ninguém testou. E precisam ser observáveis, para saber quem está no caminho novo.",
+            },
+            {
+                frente: "Como você decidiria reverter em vez de corrigir?",
+                verso: "Se a correção não é óbvia em minutos, reverter primeiro. Isso exige que reverter seja seguro, o que depende de migração compatível e de deploy pequeno. Times que não conseguem reverter acabam corrigindo sob pressão, que é quando se erra mais.",
+            },
+            {
+                frente: "Como você trataria uma esteira de integração lenta?",
+                verso: "Medindo por etapa: costuma ser instalação sem cache, teste de integração no caminho de todo mundo e ausência de paralelismo. Esteira de vinte minutos muda o comportamento do time, que agrupa mudanças e revisa menos.",
+            },
+            {
+                frente: "Como você garantiria que o artefato testado é o que vai para produção?",
+                verso: "Construindo a imagem uma vez, promovendo o mesmo artefato entre ambientes e configurando por variável. Reconstruir por ambiente permite que a produção rode algo que ninguém testou, mesmo com o mesmo commit.",
+            },
+            {
+                frente: "Como você trataria segredos dentro da esteira?",
+                verso: "Guardados no cofre do provedor, injetados só nos passos que precisam, mascarados no log e com escopo mínimo. Esteira costuma ter acesso a tudo, então é um dos alvos preferidos. Segredo em variável de repositório aberta é comprometido por qualquer PR.",
+            },
+            {
+                frente: "Como você conduziria a resposta a um segredo vazado?",
+                verso: "Revogando e trocando primeiro, porque o histórico já vazou e apagar commit não resolve, e depois checando uso indevido nos registros de acesso. Varredura automática para não repetir. Reescrever histórico é o último passo e o menos urgente.",
+            },
+            {
+                frente: "Como você conduziria a escolha do banco de dados de um serviço novo?",
+                verso: "Pelo formato de acesso e pelas garantias que o negócio exige, não pela moda. Relacional é o padrão que quase sempre serve. Banco especializado precisa de motivo, de quem opere e de plano quando ele virar o gargalo.",
+            },
+            {
+                frente: "Como você lidaria com um serviço que ninguém quer manter?",
+                verso: "Descobrindo por que: normalmente ambiente difícil, ausência de teste e medo de quebrar. Melhorar o ciclo muda isso mais rápido que designar dono. Se ele não é mais essencial, a melhor manutenção é desligar e reduzir superfície.",
+            },
+            {
+                frente: "Como você definiria quem é dono de cada serviço?",
+                verso: "Um time responsável por cada um, incluindo plantão, declarado no repositório. Sem dono, todo mundo é responsável e ninguém age no incidente. Dono não significa que só ele altera: significa que alguém revisa, decide e responde.",
+            },
+            {
+                frente: "Como você avaliaria construir uma biblioteca interna em vez de usar uma pronta?",
+                verso: "Pelo tanto que a pronta carrega de coisa que você não usa e pelo custo de manter a sua para sempre. Escrever trezentas linhas parece vitória até alguém precisar dar manutenção nelas por três anos. Biblioteca interna precisa de dono declarado.",
+            },
+            {
+                frente: "Como você lidaria com uma dependência crítica abandonada?",
+                verso: "Fixando a versão, isolando o uso atrás de um invólucro para baratear a troca, e avaliando substituto ou manutenção interna com prazo. Migrar às pressas depois de uma vulnerabilidade é bem pior do que planejar a saída.",
+            },
+            {
+                frente: "Como você mediria a qualidade de uma base de código Node?",
+                verso: "Por sinais de fora: tempo para entregar uma mudança pequena, defeito que volta, tempo para alguém novo produzir e quantas áreas ninguém quer tocar. Métrica interna ajuda a localizar, mas sozinha vira meta que se engana.",
+            },
+            {
+                frente: "Como você trataria um serviço com muitos testes e muitos bugs em produção?",
+                verso: "Olhando o que os testes exercitam: costumam faltar caso de erro, integração real e validação de borda. Boa parte dos defeitos de backend vem de configuração e dado, que teste unitário com dublê nunca pega.",
+            },
+            {
+                frente: "Como você definiria a estratégia de testes de um serviço Node?",
+                verso: "Muitos testes de rota rápidos com banco efêmero, poucos de contrato nas fronteiras e quase nenhum de ponta a ponta. O critério é confiança por minuto de execução, e que o vermelho seja levado a sério pelo time.",
+            },
+            {
+                frente: "Como você lidaria com testes de integração lentos numa esteira?",
+                verso: "Reaproveitando o contêiner de banco entre casos, paralelizando por arquivo com isolamento por esquema, e movendo o que não precisa de banco para teste puro. Antes disso, medir: quase sempre poucos testes dominam o tempo.",
+            },
+            {
+                frente: "Como você trataria o crescimento do tempo de instalação de dependências?",
+                verso: "Com cache por hash do arquivo de trava na esteira e revisão do que realmente precisa estar ali. Árvore de mil pacotes custa em tempo, em risco e em imagem. Cortar duas dependências grandes costuma render mais que qualquer ajuste de cache.",
+            },
+            {
+                frente: "Como você lidaria com times que usam gerenciadores de pacote diferentes?",
+                verso: "Padronizando um por repositório e travando na esteira, porque dois arquivos de trava no mesmo projeto produzem árvores diferentes e erro que só acontece na máquina de alguém. Qual deles importa menos que ser um só.",
+            },
+            {
+                frente: "Como você organizaria um monorepo de serviços Node?",
+                verso: "Com fronteiras explícitas entre pacotes, build incremental com cache e regra de quem depende de quem. Sem isso, a facilidade de importar qualquer coisa acopla tudo e a esteira passa a rodar o mundo a cada mudança de uma linha.",
+            },
+            {
+                frente: "Como você compartilharia tipos entre backend e front?",
+                verso: "Gerando a partir do contrato, ou publicando um pacote de tipos versionado, com validação em tempo de execução na borda mesmo assim. Importar tipos direto do outro projeto acopla os deploys e dá falsa sensação de segurança.",
+            },
+            {
+                frente: "Como você trataria a diferença entre o que o tipo promete e o que chega na requisição?",
+                verso: "Validando na borda com esquema e derivando o tipo dele, para não existirem duas verdades. Tipo declarado à mão sobre corpo de requisição é documentação, não proteção: em produção chega o que o cliente quiser mandar.",
+            },
+            {
+                frente: "Como você lidaria com um serviço que precisa de disponibilidade muito alta?",
+                verso: "Definindo o número com o negócio, porque cada nove multiplica custo e complexidade: redundância, multi zona, degradação e ensaio de falha. Antes disso, quase sempre há ganho maior em reduzir tempo de recuperação do que em evitar toda falha.",
+            },
+            {
+                frente: "Como você conduziria um ensaio de falha em produção?",
+                verso: "Começando pequeno e em horário combinado, com hipótese escrita, alerta armado e botão de parada. O objetivo é validar detecção e recuperação, não quebrar por esporte. Sem observabilidade confiável antes, o ensaio só gera susto.",
+            },
+            {
+                frente: "Como você decidiria entre resolver no código e resolver na infraestrutura?",
+                verso: "Pelo que fica mais fácil de operar depois. Limite de taxa, repetição e roteamento costumam ficar melhores na borda; regra de negócio nunca. O risco de empurrar tudo para fora é o comportamento sumir do repositório e ninguém achar.",
+            },
+            {
+                frente: "Como você reduziria o tempo médio de recuperação de um incidente?",
+                verso: "Deploy pequeno e reversível, alerta que aponta o sintoma certo, runbook curto e permissão para agir. A maior parte do tempo de um incidente é descobrir o que está errado e conseguir autorização, e não escrever a correção.",
+            },
+            {
+                frente: "Como você lidaria com um pico de erros logo após um deploy?",
+                verso: "Revertendo primeiro e comparando as métricas por versão para confirmar. Se a mudança estava atrás de chave, desligar é mais rápido. Investigar em produção com usuários vendo erro é o erro clássico de quem tem medo de reverter.",
+            },
+            {
+                frente: "Como você trataria a expectativa de que Node é rápido por natureza?",
+                verso: "Trocando a conversa por medição: Node atende bem muitas conexões esperando, e não faz cálculo pesado rápido. O gargalo típico é banco, serialização e trabalho síncrono. Comparações de rendimento entre frameworks quase nunca refletem o seu serviço.",
+            },
+            {
+                frente: "Como você lidaria com uma API interna que virou dependência de todo mundo?",
+                verso: "Tratando como produto: contrato estável, versionamento, prazo de descontinuação e limite de taxa mesmo para quem é de casa. Sem isso, qualquer mudança vira negociação com cinco times, e uma consulta mal feita de um deles derruba o serviço para os outros.",
+            },
+            {
+                frente: "Como você decidiria adotar uma tecnologia nova no time?",
+                verso: "Com problema medido, prova de conceito num fluxo real, prazo e critério de sucesso, e alguém que sustente em incidente. Sem caminho de volta definido, a adoção vira dívida permanente com um jeito a mais de fazer a mesma coisa.",
+            },
+        ],
+    },
+};

--- a/backend/scripts/data/entrevista/react.ts
+++ b/backend/scripts/data/entrevista/react.ts
@@ -1,0 +1,1144 @@
+import type { TopicoDeEntrevista } from "../../seed-entrevista.ts";
+
+/**
+ * Perguntas de entrevista de React.
+ *
+ * O nível segue o que a pergunta cobra, e não o assunto. Renderização aparece nos
+ * quatro níveis: em estágio é o que dispara uma nova renderização, em sênior é como
+ * o time acompanha desempenho sem transformar cada tela numa discussão de memo.
+ */
+export const react: TopicoDeEntrevista = {
+    slug: "react",
+    nome: "React",
+    position: 7,
+    perguntas: {
+        estagio: [
+            {
+                frente: "Que problema o React resolve que JavaScript puro resolvia mal?",
+                verso: "Manter a tela em sincronia com o estado. Sem ele, cada mudança de dado vira uma sequência de instruções manipulando o DOM na mão, e é onde a interface passa a mostrar coisas contraditórias. Com React você descreve o resultado e ele calcula a diferença.",
+            },
+            {
+                frente: "O que é um componente?",
+                verso: "Uma função que recebe dados e devolve a descrição de um pedaço da interface. Ele encapsula marcação, estilo e comportamento daquele trecho, e pode ser usado várias vezes com dados diferentes. É a unidade de reaproveitamento e de leitura do código.",
+            },
+            {
+                frente: "O que é JSX?",
+                verso: "Uma sintaxe que parece HTML e vira chamada de função na compilação. Não é template com linguagem própria: é JavaScript, então dentro das chaves vale qualquer expressão. É isso que permite montar a interface com map, ternário e variável sem sintaxe especial.",
+            },
+            {
+                frente: "Por que o JSX usa className em vez de class?",
+                verso: "Porque JSX vira JavaScript, e class é palavra reservada da linguagem. O mesmo vale para htmlFor no lugar de for. São detalhes de tradução para as propriedades do DOM, e não uma escolha de estilo do React.",
+            },
+            {
+                frente: "Qual a diferença entre props e estado?",
+                verso: "Props vêm de fora e o componente não altera: são a entrada dele. Estado é interno, pertence àquela instância e muda ao longo do tempo. Quando um dado precisa mudar e ser visto por vários componentes, ele sobe para o ancestral comum e desce como prop.",
+            },
+            {
+                frente: "Por que não se altera o estado diretamente?",
+                verso: "Porque o React não observa o objeto: ele compara a referência para saber se algo mudou. Alterar o array no lugar mantém a mesma referência, e a tela não atualiza. Por isso se cria um novo objeto ou array com a mudança aplicada.",
+            },
+            {
+                frente: "O que o useState devolve?",
+                verso: "Um par: o valor atual e a função que agenda a atualização. Chamar a função não muda a variável daquela renderização, e sim pede uma nova com o valor novo. É por isso que ler o estado logo depois de atualizar mostra o valor antigo.",
+            },
+            {
+                frente: "O que faz um componente renderizar de novo?",
+                verso: "Uma mudança de estado dele, uma mudança em um contexto que ele consome, ou o pai renderizar de novo. Não é o DOM que muda a cada vez: o React recalcula a descrição e aplica ao DOM só a diferença.",
+            },
+            {
+                frente: "Como você atualiza o estado a partir do valor anterior?",
+                verso: "Passando uma função para o atualizador, que recebe o valor mais recente. É o jeito certo quando a atualização depende do anterior, como um contador, porque várias chamadas seguidas usando a variável capturada acabam gravando o mesmo valor.",
+            },
+            {
+                frente: "Como você guarda um objeto no estado sem perder os outros campos?",
+                verso: "Criando um objeto novo, espalhando o anterior e sobrescrevendo o campo que mudou. Guardar o objeto alterado no lugar não dispara renderização, e substituir só com o campo novo apaga o resto. Em estado aninhado isso fica trabalhoso, o que costuma indicar estado mal dividido.",
+            },
+            {
+                frente: "Como você adiciona um item a uma lista guardada no estado?",
+                verso: "Criando um array novo com o conteúdo antigo mais o item, em vez de usar push. Push altera o mesmo array e o React não vê diferença. O mesmo vale para remover, que se faz com filter, e para trocar um item, que se faz com map.",
+            },
+            {
+                frente: "Por que uma lista renderizada precisa de key?",
+                verso: "Para o React saber qual elemento é qual entre duas renderizações, e assim mover em vez de recriar. Sem isso ele compara por posição, o que faz o estado interno de um item aparecer no lugar errado quando a lista muda de ordem.",
+            },
+            {
+                frente: "Por que usar o índice como key é arriscado?",
+                verso: "Porque o índice muda quando a lista é reordenada, filtrada ou tem item removido do meio. O React entende que o item continua o mesmo e mantém estado e foco no lugar errado. Com lista fixa e só de leitura, o índice é aceitável.",
+            },
+            {
+                frente: "Como você renderiza algo condicionalmente?",
+                verso: "Com um ternário quando há dois caminhos, ou com o e comercial duplo quando é mostrar ou não mostrar. Também dá para sair antes com um return. O cuidado com o e comercial é o valor zero, que não é falso o bastante para sumir e acaba aparecendo na tela.",
+            },
+            {
+                frente: "Como você transforma uma lista de dados em elementos?",
+                verso: "Com map, devolvendo um elemento por item e passando uma key estável, normalmente o identificador vindo do servidor. Filtrar antes evita renderizar o que não deve aparecer. Laço com push e depois render funciona, mas custa mais para ler.",
+            },
+            {
+                frente: "O que a prop children permite?",
+                verso: "Receber o conteúdo escrito entre a abertura e o fechamento do componente. É o que faz um cartão, um modal ou um layout aceitarem qualquer conteúdo dentro sem saber o que é. É a forma mais simples de composição no React.",
+            },
+            {
+                frente: "Como um componente filho avisa o pai que algo aconteceu?",
+                verso: "O pai passa uma função como prop e o filho a chama com o dado. O estado continua no pai, que é quem decide o que fazer. Esse é o fluxo de dados do React: dado desce por prop, evento sobe por função.",
+            },
+            {
+                frente: "O que é um componente de formulário controlado?",
+                verso: "Aquele em que o valor do campo vem do estado e toda digitação passa por um manipulador que atualiza esse estado. A vantagem é que o React é a fonte da verdade, o que facilita validar e formatar enquanto se digita.",
+            },
+            {
+                frente: "Quando um campo não controlado faz sentido?",
+                verso: "Quando você só precisa do valor no envio e não quer renderizar a cada tecla, ou ao integrar com código que manipula o DOM direto. Nesse caso o valor é lido por referência. Formulário grande é onde essa escolha começa a aparecer no desempenho.",
+            },
+            {
+                frente: "Como você trata o envio de um formulário?",
+                verso: "Num manipulador no elemento de formulário, chamando o método que impede o comportamento padrão para a página não recarregar. Colocar o envio no clique do botão funciona, mas perde o envio pelo Enter, que é o que a maioria dos usuários usa.",
+            },
+            {
+                frente: "Por que o evento que chega no manipulador não é o evento nativo puro?",
+                verso: "O React usa um evento sintético, com a mesma interface entre navegadores. Ele delega os ouvintes na raiz em vez de pendurar um por elemento, o que economiza memória. Se precisar do original, ele está acessível por uma propriedade.",
+            },
+            {
+                frente: "O que é um fragmento e por que ele existe?",
+                verso: "Um invólucro que agrupa elementos sem criar um nó no DOM. Serve porque um componente precisa devolver uma raiz só. Sem ele, todo agrupamento viraria uma div extra, e isso atrapalha layout com grid e flex, além de sujar a árvore.",
+            },
+            {
+                frente: "Como você aplica estilo a um componente?",
+                verso: "Com classe, que é o caminho padrão, seja com CSS comum, módulos ou utilitários. Estilo por objeto no atributo serve para valor dinâmico e pontual, e não substitui folha de estilo: ali não existe pseudoclasse, consulta de mídia nem reaproveitamento.",
+            },
+            {
+                frente: "Como você aplica uma classe condicionalmente?",
+                verso: "Montando a string da classe com template ou ternário, ou usando uma função que junta classes ignorando o que for falso. O importante é a classe base ficar separada do modificador, para não virar uma expressão ilegível dentro do JSX.",
+            },
+            {
+                frente: "Quais são as regras dos hooks?",
+                verso: "Chamar sempre no topo do componente ou de outro hook, nunca dentro de condição, laço ou função aninhada, e só a partir de componente ou hook próprio. O React associa cada hook pela ordem de chamada, então quebrar a ordem embaralha os estados.",
+            },
+            {
+                frente: "O que acontece se você chamar um hook dentro de um if?",
+                verso: "A ordem das chamadas passa a mudar entre renderizações, e o React entrega o estado de um hook para outro. O sintoma é valor aparecendo trocado ou erro dizendo que a quantidade de hooks mudou. A regra do linter existe justamente para pegar isso.",
+            },
+            {
+                frente: "Para que serve o useEffect?",
+                verso: "Para sincronizar o componente com algo de fora do React, como assinatura, temporizador ou manipulação direta do DOM. Ele roda depois da renderização. O que pode ser calculado durante a renderização não precisa de efeito nenhum.",
+            },
+            {
+                frente: "Como você limpa o que um efeito criou?",
+                verso: "Devolvendo uma função de limpeza, que o React chama antes de rodar o efeito de novo e ao desmontar. É onde se remove ouvinte, cancela temporizador e fecha conexão. Sem ela, cada renderização deixa um resíduo e o comportamento vai duplicando.",
+            },
+            {
+                frente: "Quando um efeito roda de novo?",
+                verso: "Sempre que algum valor do array de dependências mudar entre renderizações, comparado por identidade. Sem array, roda em toda renderização. Com array vazio, roda uma vez na montagem, e por isso ele costuma esconder dependência esquecida.",
+            },
+            {
+                frente: "Como você busca dados quando a tela abre?",
+                verso: "Num efeito com as dependências certas, guardando carregando, dado e erro no estado, ou usando uma biblioteca de dados que já cuida disso. O ponto que mais escapa é tratar o caso de a resposta chegar depois de o componente sair da tela.",
+            },
+            {
+                frente: "Como você mostra que a tela está carregando?",
+                verso: "Com um estado que começa verdadeiro e vira falso no fim da requisição, inclusive quando ela falha. Mostrar um esqueleto do conteúdo costuma ser melhor que um giro, porque evita a tela pular quando o conteúdo chega.",
+            },
+            {
+                frente: "Como você mostra um erro de carregamento na interface?",
+                verso: "Guardando o erro no estado e renderizando uma mensagem que diga o que houve e o que fazer, com opção de tentar de novo. Mensagem técnica crua não ajuda o usuário, e tela em branco sem explicação é o pior dos casos.",
+            },
+            {
+                frente: "O que caracteriza uma aplicação de página única?",
+                verso: "O navegador carrega a aplicação uma vez e as navegações trocam o conteúdo sem pedir uma página nova ao servidor. Isso deixa a troca de tela instantânea e cobra em carga inicial, em rota que precisa ser resolvida no cliente e em atenção com o endereço da URL.",
+            },
+            {
+                frente: "Como você navega entre telas numa aplicação React?",
+                verso: "Com o componente de link da biblioteca de rotas, que troca o endereço sem recarregar a página, ou com a função de navegação programática depois de uma ação. Usar uma âncora comum recarrega tudo e perde o estado da aplicação.",
+            },
+            {
+                frente: "Como você lê um parâmetro da URL?",
+                verso: "Com o hook da biblioteca de rotas que expõe os parâmetros do caminho, ou o que expõe a parte de consulta. Vale lembrar que tudo ali é texto e vem do usuário, então precisa ser validado antes de virar identificador numa requisição.",
+            },
+            {
+                frente: "O que é prop drilling?",
+                verso: "Passar uma prop por vários níveis só para ela chegar lá embaixo, sem os intermediários usarem. Deixa o código difícil de mexer e acopla componentes que não têm relação. As saídas são composição por children ou contexto, nessa ordem.",
+            },
+            {
+                frente: "Como você reaproveita lógica entre componentes?",
+                verso: "Extraindo um hook próprio, que é só uma função que usa outros hooks e devolve o que interessa. É o que substitui os padrões antigos de componente de ordem superior. Reaproveitar interface é outra coisa: para isso existe composição.",
+            },
+            {
+                frente: "Por que o nome de um hook próprio começa com use?",
+                verso: "Porque é essa convenção que diz ao React e às ferramentas que aquela função segue as regras dos hooks. Sem o prefixo, o linter não consegue checar dependências nem chamadas condicionais, e o erro só aparece em tempo de execução.",
+            },
+            {
+                frente: "Quando vale criar um componente novo?",
+                verso: "Quando um trecho tem nome próprio no domínio, se repete, ou quando o componente atual já não cabe na cabeça. Dividir cedo demais gera indireção sem ganho. O sinal mais confiável é precisar rolar muito para entender o que a função devolve.",
+            },
+            {
+                frente: "O que significa preferir composição a herança no React?",
+                verso: "Em vez de criar tipos que estendem outros, você monta comportamento passando componentes por children e por props. Um cartão genérico que recebe cabeçalho e corpo resolve o que herança resolveria, sem hierarquia rígida.",
+            },
+            {
+                frente: "Como você passa várias props de uma vez, e qual o risco?",
+                verso: "Espalhando um objeto no JSX. O risco é perder o controle do que está sendo passado: props indesejadas chegam ao DOM e geram aviso, e quem lê não sabe mais o que o componente recebe. Em componente de biblioteca isso é útil; em tela, costuma esconder bagunça.",
+            },
+            {
+                frente: "Como você define um valor padrão para uma prop?",
+                verso: "No próprio parâmetro da função, com valor padrão de JavaScript. É mais direto do que a forma antiga com propriedade estática e funciona bem com tipagem. Vale lembrar que o padrão só se aplica quando a prop vem indefinida, e não quando vem nula.",
+            },
+            {
+                frente: "O que acontece se você esquecer o return num componente?",
+                verso: "Ele devolve indefinido e o React reclama que um componente precisa devolver algo. O caso que mais confunde é abrir chave depois da seta em vez de parêntese, o que transforma o JSX em corpo de função sem retorno.",
+            },
+            {
+                frente: "O que acontece se você chamar uma função de estado direto no corpo do componente?",
+                verso: "Ele renderiza, chama de novo, renderiza outra vez, e entra em laço até o React interromper com erro de profundidade. O manipulador precisa ser passado como referência, e não chamado durante a renderização.",
+            },
+            {
+                frente: "Por que a atualização de estado parece não valer na hora?",
+                verso: "Porque a variável daquela renderização não muda: o React agenda a atualização e entrega o valor novo na próxima. Várias atualizações no mesmo evento são agrupadas em uma renderização só, o que evita telas intermediárias.",
+            },
+            {
+                frente: "O que o modo estrito faz em desenvolvimento?",
+                verso: "Monta, desmonta e monta de novo cada componente, e roda o efeito duas vezes, para expor efeito sem limpeza e código que não aguenta ser repetido. Só acontece em desenvolvimento. Se algo quebra por causa disso, o problema já existia.",
+            },
+            {
+                frente: "O que é o ponto de entrada de uma aplicação React?",
+                verso: "O arquivo que encontra um elemento do HTML e manda o React tomar conta dali para baixo, renderizando o componente raiz. É onde também ficam os provedores globais, como rotas e tema, que precisam envolver a árvore inteira.",
+            },
+            {
+                frente: "O que uma ferramenta como o Vite faz num projeto React?",
+                verso: "Serve o projeto em desenvolvimento com atualização rápida ao salvar, entende JSX e TypeScript, e gera o pacote otimizado para produção. Sem ela seria preciso configurar compilador, empacotador e servidor local na mão.",
+            },
+            {
+                frente: "Como você usa uma variável de ambiente no front?",
+                verso: "Declarando com o prefixo que a ferramenta exige e lendo pelo objeto que ela expõe. O valor é embutido no pacote na hora do build, então ele não muda em tempo de execução e fica visível para quem abrir o código no navegador.",
+            },
+            {
+                frente: "Por que segredo não pode ficar no código do front?",
+                verso: "Porque tudo que vai para o navegador pode ser lido por qualquer usuário, mesmo minificado. Chave de API secreta, senha e token de serviço precisam ficar no servidor, que faz a chamada e devolve só o resultado.",
+            },
+            {
+                frente: "Como você depura um componente que não mostra o que você espera?",
+                verso: "Vendo primeiro o que ele recebe e o que ele devolve, com as ferramentas do React inspecionando props e estado na árvore. Depois conferindo se o dado chegou pela rede. Sair espalhando log costuma achar o sintoma, e não o ponto onde o dado se perdeu.",
+            },
+            {
+                frente: "O que as ferramentas de desenvolvedor do React mostram?",
+                verso: "A árvore de componentes com props, estado e hooks de cada um, e quem é o pai de quem. Também dá para ver o que renderizou e por quê. É o caminho mais rápido para descobrir se o problema é dado errado ou renderização que não aconteceu.",
+            },
+            {
+                frente: "O que é uma prop booleana e como ela costuma ser escrita?",
+                verso: "Uma prop que liga ou desliga comportamento, escrita só com o nome quando é verdadeira. Muitas delas no mesmo componente costumam ser sinal de que faltou uma prop de variante, porque combinações inválidas passam a ser possíveis.",
+            },
+            {
+                frente: "Como você exibe um conteúdo só depois que os dados chegam?",
+                verso: "Saindo antes com o estado de carregamento e o de erro, e só então renderizando o conteúdo. Assim o caso feliz fica limpo. Renderizar acessando campo de um objeto que ainda é nulo é a causa mais comum de tela quebrada logo na abertura.",
+            },
+            {
+                frente: "O que acontece quando o pai renderiza de novo?",
+                verso: "Os filhos também são chamados de novo por padrão, mesmo com as mesmas props. Isso quase sempre é barato, porque o React só aplica ao DOM o que mudou. Vira problema quando a árvore é grande ou o componente faz trabalho pesado a cada chamada.",
+            },
+            {
+                frente: "Como você organizaria os arquivos de um projeto React pequeno?",
+                verso: "Por funcionalidade, com o componente, seus estilos e seus testes próximos, e uma pasta para o que é realmente compartilhado. Separar por tipo técnico espalha uma mudança simples por várias pastas, e isso piora conforme o projeto cresce.",
+            },
+            {
+                frente: "Como você lidaria com um componente que recebe dez props?",
+                verso: "Perguntando se ele não está fazendo coisas demais. Muitas vezes dá para agrupar o que anda junto num objeto, ou aceitar conteúdo por children em vez de configurar tudo por prop. Componente com dez props costuma ser dois componentes.",
+            },
+            {
+                frente: "O que muda entre exportação padrão e nomeada?",
+                verso: "A padrão pode ser importada com qualquer nome, o que facilita renomear sem querer e atrapalha a busca no projeto. A nomeada exige o nome exato e ajuda ferramentas de refatoração. Muitos times padronizam nomeada justamente por isso.",
+            },
+            {
+                frente: "Como você escreveria um texto que vem do usuário sem risco?",
+                verso: "Deixando o React renderizar como texto, que é o padrão e já escapa o conteúdo. O risco aparece ao usar a propriedade que injeta HTML cru, que só deve receber conteúdo sanitizado, e nunca algo digitado por outro usuário.",
+            },
+            {
+                frente: "Como você mostraria uma lista vazia de forma amigável?",
+                verso: "Com um estado vazio explícito, dizendo o que aconteceu e qual o próximo passo, em vez de renderizar nada. Lista vazia sem mensagem é lida como erro ou tela quebrada, e é um dos ajustes mais baratos de experiência.",
+            },
+            {
+                frente: "Como você trataria um campo de busca que filtra uma lista?",
+                verso: "Guardando o texto no estado e derivando a lista filtrada durante a renderização, sem criar outro estado para o resultado. Guardar o filtrado em estado obriga a sincronizar dois valores, e é onde a lista fica desatualizada.",
+            },
+            {
+                frente: "Qual a diferença entre renderizar e montar?",
+                verso: "Montar é a primeira vez que o componente entra na árvore, quando o estado é criado e os efeitos rodam pela primeira vez. Renderizar acontece em toda atualização. Confundir os dois é o que leva a colocar em efeito de montagem coisa que precisava rodar sempre.",
+            },
+            {
+                frente: "O que acontece com o estado quando um componente sai da tela?",
+                verso: "Ele é descartado junto com o componente, e volta ao valor inicial se ele reaparecer. Por isso estado que precisa sobreviver à navegação mora acima, na URL ou numa camada de cache, e não dentro do componente que some.",
+            },
+            {
+                frente: "Como você mostraria a mesma informação em dois lugares da tela?",
+                verso: "Subindo o dado para o ancestral comum e passando por prop para os dois, para existir uma fonte da verdade só. Duplicar o estado nos dois lados obriga a sincronizar na mão, e uma hora eles divergem.",
+            },
+            {
+                frente: "Para que serve o atributo key fora de listas?",
+                verso: "Trocar a key de um componente faz o React tratá-lo como outro e recriar o estado. É a forma mais simples de reiniciar um formulário ao mudar de registro, sem efeito nenhum limpando campo por campo.",
+            },
+            {
+                frente: "Como você trataria um clique que precisa de dois comportamentos?",
+                verso: "Escrevendo um manipulador com nome que descreva a intenção e chamando dali as duas coisas, em vez de encadear lógica no JSX. JSX com muita lógica dentro do atributo fica difícil de ler e impossível de testar isoladamente.",
+            },
+            {
+                frente: "O que significa dizer que o React tem fluxo de dados de mão única?",
+                verso: "O dado desce do pai para o filho por props, e mudanças sobem por funções. Não existe filho alterando a prop que recebeu. Isso torna previsível descobrir de onde veio um valor, que é o que mais custa em interface grande.",
+            },
+            {
+                frente: "Como você evitaria que um botão seja clicado duas vezes?",
+                verso: "Desabilitando enquanto a ação está em andamento, com um estado de envio, e não confiando só no visual. Isso evita a requisição duplicada mais comum. Do lado do servidor a proteção continua necessária, porque o cliente pode repetir de outras formas.",
+            },
+            {
+                frente: "Como você exibiria uma data para o usuário?",
+                verso: "Formatando na hora de mostrar, com a API de internacionalização do navegador e o idioma do usuário, e guardando sempre o valor bruto no estado. Formatar cedo e guardar texto formatado é o que impede ordenar e comparar depois.",
+            },
+            {
+                frente: "Como você mostraria um contador de itens selecionados numa lista?",
+                verso: "Guardando no estado só o conjunto de selecionados e calculando o total durante a renderização. Manter um estado separado para a contagem cria duas fontes da verdade, e a que esquece de atualizar é sempre a que aparece na tela.",
+            },
+        ],
+        junior: [
+            {
+                frente: "O que o array de dependências do useEffect realmente controla?",
+                verso: "Quais valores o efeito lê de fora e que, ao mudar, exigem sincronizar de novo. Não é um filtro para o efeito rodar menos vezes: omitir dependência não impede a execução, só faz o efeito trabalhar com valor velho. O linter existe para cobrar isso.",
+            },
+            {
+                frente: "O que é uma closure obsoleta dentro de um efeito?",
+                verso: "É o efeito ter capturado o valor da renderização em que foi criado e continuar usando ele depois. Aparece em temporizador e ouvinte registrados uma vez só, que enxergam sempre o estado inicial. As saídas são atualizar com função ou incluir a dependência.",
+            },
+            {
+                frente: "Como você sabe se um efeito deveria mesmo existir?",
+                verso: "Perguntando com o que ele sincroniza. Se a resposta é apenas outro estado ou uma prop, aquilo é cálculo e pertence à renderização. Efeito é para o que está fora do React: assinatura, temporizador, DOM e rede. Boa parte dos bugs de efeito são efeitos que não precisavam existir.",
+            },
+            {
+                frente: "Quando você derivaria um valor em vez de guardar outro estado?",
+                verso: "Sempre que ele puder ser calculado do que já existe, como total de uma lista ou item selecionado a partir do identificador. Estado derivado obriga a sincronizar dois valores, e o que esquece de atualizar é justamente o que aparece na tela.",
+            },
+            {
+                frente: "Como você evitaria estado duplicado numa tela?",
+                verso: "Guardando a informação uma vez só, no lugar mais alto que precisa dela, e derivando o resto. Guardar o objeto inteiro e também o identificador dele é a duplicação clássica, e depois de uma atualização os dois divergem.",
+            },
+            {
+                frente: "O que o useMemo faz, e quando ele paga?",
+                verso: "Guarda o resultado de um cálculo entre renderizações enquanto as dependências não mudarem. Paga quando o cálculo é realmente caro ou quando o resultado é usado como dependência de outro hook. Em conta simples, o próprio memo custa mais do que economiza.",
+            },
+            {
+                frente: "O que o useCallback resolve?",
+                verso: "Mantém a mesma referência de função entre renderizações, o que importa quando ela é dependência de um efeito ou prop de um filho memoizado. Sozinho ele não acelera nada: envolver toda função sem esses casos só adiciona ruído e memória.",
+            },
+            {
+                frente: "Quando envolver um componente com memo ajuda de verdade?",
+                verso: "Quando ele renderiza com frequência por causa do pai, recebe as mesmas props e faz trabalho pesado. Se alguma prop é objeto ou função criada a cada renderização, a comparação falha sempre e o memo vira custo puro sem nenhum ganho.",
+            },
+            {
+                frente: "Por que memoizar tudo é uma má ideia?",
+                verso: "Cada memo tem custo de comparação e memória, e polui o código com dependências que precisam ser mantidas. Renderização normal do React é barata. Otimização sem medição costuma resolver um problema que não existia e criar um bug de dependência que existe.",
+            },
+            {
+                frente: "O que o useRef guarda?",
+                verso: "Um objeto estável entre renderizações com uma propriedade que você pode alterar sem disparar renderização. Serve para referência a elemento do DOM e para valor mutável que a interface não mostra, como identificador de temporizador.",
+            },
+            {
+                frente: "Qual a diferença entre useRef e useState?",
+                verso: "Alterar estado renderiza de novo; alterar referência não. Estado é para o que a tela mostra, referência é para o que o componente precisa lembrar sem mostrar. Guardar em referência algo que aparece na interface deixa a tela desatualizada.",
+            },
+            {
+                frente: "Como você colocaria o foco num campo assim que a tela abre?",
+                verso: "Ligando uma referência ao elemento e chamando o foco num efeito de montagem. Vale checar se isso é bom para quem usa leitor de tela, porque mover foco sem aviso desorienta. Em modal, focar o primeiro elemento é esperado; numa página inteira, nem sempre.",
+            },
+            {
+                frente: "O que o useReducer resolve que o useState resolve mal?",
+                verso: "Estado com várias partes que mudam juntas e transições com regras, como um formulário com passos. A lógica sai dos manipuladores e vira uma função pura fácil de testar. Para um booleano ou um texto, ele só adiciona cerimônia.",
+            },
+            {
+                frente: "Quando você usaria Context?",
+                verso: "Para dado realmente global e que muda pouco, como tema, idioma e usuário logado. Ele resolve prop drilling, e não gerenciamento de estado. Estado de servidor e estado que muda a cada tecla dentro de contexto viram renderização em cascata.",
+            },
+            {
+                frente: "Por que um Context pode causar renderização em cascata?",
+                verso: "Porque todo componente que consome aquele contexto renderiza quando o valor muda, mesmo usando só um pedaço dele. Se o valor é um objeto recriado a cada renderização do provedor, isso acontece sempre, mesmo sem mudança real.",
+            },
+            {
+                frente: "Como você evitaria recriar o valor do provedor a cada renderização?",
+                verso: "Memoizando o objeto com as dependências certas, ou separando o que muda do que não muda em dois contextos: um com os dados e outro com as funções. Assim quem só dispara ações não renderiza quando o dado muda.",
+            },
+            {
+                frente: "Como você dividiria um Context que cresceu demais?",
+                verso: "Por frequência de mudança e por consumidor. Tema e usuário raramente mudam; um contador de carrinho muda a toda hora. Juntar os dois faz a árvore inteira renderizar por causa do que muda mais. Dois contextos separados custam menos que um memo elaborado.",
+            },
+            {
+                frente: "Como você buscaria dados evitando condição de corrida?",
+                verso: "Marcando a requisição como cancelada na limpeza do efeito, ou usando o sinal de aborto, e ignorando a resposta que chegar depois. Sem isso, duas buscas disparadas em sequência podem terminar fora de ordem e a tela mostra o resultado da consulta antiga.",
+            },
+            {
+                frente: "O que acontece se o componente sair da tela antes de a resposta chegar?",
+                verso: "A atualização de estado é ignorada, então não é um vazamento, mas o trabalho continua sendo feito à toa e a lógica pode seguir por um caminho inútil. O certo é abortar a requisição na limpeza, o que também libera a conexão.",
+            },
+            {
+                frente: "O que uma biblioteca de estado de servidor resolve?",
+                verso: "Cache por chave, revalidação, deduplicação de requisições iguais, estados de carregando e erro e reaproveitamento entre telas. É tudo que se reescreve mal em cada efeito de busca. O ganho maior é sumir com dezenas de efeitos parecidos.",
+            },
+            {
+                frente: "Qual a diferença entre estado de servidor e estado de cliente?",
+                verso: "Estado de servidor é cópia de um dado que pertence a outro lugar, pode estar velho e precisa ser revalidado. Estado de cliente é só seu, como o que está aberto e o que foi digitado. Tratar os dois com a mesma ferramenta é o que gera cache inconsistente.",
+            },
+            {
+                frente: "Como você atualizaria a lista depois de criar um item?",
+                verso: "Invalidando a consulta daquela lista para ela ser buscada de novo, ou inserindo o item no cache com o que o servidor devolveu. Confiar só no que o formulário tinha ignora campos calculados no servidor, e a tela fica diferente do banco.",
+            },
+            {
+                frente: "Como você faria uma busca que só dispara quando o usuário para de digitar?",
+                verso: "Com um atraso que reinicia a cada tecla, cancelando o anterior na limpeza do efeito. Isso corta a maior parte das requisições. Vale também não buscar com menos de dois ou três caracteres, e cancelar a requisição em voo quando o texto muda.",
+            },
+            {
+                frente: "Como você trataria paginação numa listagem?",
+                verso: "Guardando a página na URL, para o usuário poder compartilhar e voltar, e mantendo o conteúdo anterior visível enquanto a próxima carrega. Trocar a lista por um giro a cada página faz a tela piscar e perde a posição da rolagem.",
+            },
+            {
+                frente: "Como você implementaria rolagem infinita?",
+                verso: "Observando um elemento sentinela no fim da lista e pedindo a próxima página quando ele aparece. É preciso cuidar de não disparar duas vezes, e de oferecer um caminho alternativo por teclado, porque rolagem infinita costuma quebrar acessibilidade e rodapé.",
+            },
+            {
+                frente: "O que é um limite de erro e o que ele pega?",
+                verso: "Um componente que captura erro de renderização da sua subárvore e mostra uma interface de reserva em vez de derrubar a aplicação inteira. Ele não pega erro dentro de manipulador de evento nem de código assíncrono, que continuam sendo responsabilidade do seu try.",
+            },
+            {
+                frente: "O que acontece com um erro lançado dentro de um efeito?",
+                verso: "Se for síncrono, o limite de erro captura. Se for uma promessa rejeitada sem tratamento, ele passa direto e vira erro no console, sem afetar a tela. Por isso toda busca precisa de tratamento explícito e de um estado de erro visível.",
+            },
+            {
+                frente: "Para que serve um portal?",
+                verso: "Renderizar um componente noutro ponto do DOM mantendo a posição na árvore do React, então contexto e eventos continuam funcionando. É o que resolve modal e dica de contexto que seriam cortados por overflow ou por empilhamento do pai.",
+            },
+            {
+                frente: "O que um modal acessível precisa ter?",
+                verso: "Fechar no Escape, devolver o foco para quem o abriu, prender o foco enquanto está aberto, ter rótulo e ser anunciado como diálogo. Fechar ao clicar fora é esperado, mas não substitui o teclado. O elemento nativo de diálogo já entrega boa parte disso.",
+            },
+            {
+                frente: "Como você tornaria um componente interativo acessível por teclado?",
+                verso: "Usando o elemento certo antes de tudo: botão é botão, link é link. Se realmente for preciso um elemento genérico, ele precisa de papel, de participação na ordem de tabulação e de manipulador para Enter e espaço. Div com clique é invisível para quem não usa mouse.",
+            },
+            {
+                frente: "Quando usar atributos de acessibilidade é sinal de problema?",
+                verso: "Quando eles estão remendando um elemento errado. Anunciar uma div como botão exige recriar foco, teclado e estado na mão. A regra é preferir o elemento nativo e usar os atributos para o que o HTML não expressa, como estado expandido ou região viva.",
+            },
+            {
+                frente: "Como você associa um rótulo a um campo de formulário?",
+                verso: "Com o elemento de rótulo apontando para o identificador do campo, o que também faz o clique focar o campo. Texto solto ao lado não cria relação nenhuma, e o leitor de tela anuncia o campo sem dizer o que ele é.",
+            },
+            {
+                frente: "Por que um formulário controlado grande pode ficar lento?",
+                verso: "Porque cada tecla atualiza o estado no topo e renderiza a árvore inteira. Em formulário com dezenas de campos isso aparece como atraso na digitação. As saídas são isolar o estado por campo, usar campos não controlados ou uma biblioteca que assina só o que mudou.",
+            },
+            {
+                frente: "Como você validaria um formulário sem irritar o usuário?",
+                verso: "Validando no envio e, depois do primeiro erro, ao sair do campo, em vez de acusar a cada tecla. Mensagem perto do campo, associada a ele para o leitor de tela, e foco no primeiro erro. Validar tudo enquanto digita mostra erro em campo que ainda não terminou.",
+            },
+            {
+                frente: "O que é carregamento preguiçoso de componente?",
+                verso: "Adiar o download do código de um componente até ele ser necessário, com importação dinâmica. O React aceita isso com um invólucro que suspende enquanto o pedaço chega, e o Suspense mostra o conteúdo de espera. É como se divide o pacote por rota.",
+            },
+            {
+                frente: "Como você dividiria o pacote de uma aplicação por rota?",
+                verso: "Carregando cada rota por importação dinâmica, para o usuário baixar só a tela que abriu. Vale medir antes: às vezes o peso está numa dependência única usada em um lugar, e mover ela resolve mais do que dividir dez rotas.",
+            },
+            {
+                frente: "Como você descobriria o que está pesando no pacote?",
+                verso: "Gerando um relatório de tamanho por módulo com a ferramenta de build e olhando o que ocupa mais. Costuma ser biblioteca de data, de ícones importada inteira ou dependência duplicada em duas versões. Só então vale falar em dividir por rota.",
+            },
+            {
+                frente: "Como você evitaria que a tela pule quando as imagens carregam?",
+                verso: "Reservando o espaço com largura e altura ou proporção definidas, para o navegador saber o tamanho antes de baixar. Isso evita deslocamento de layout, que é a mudança que faz o usuário clicar no lugar errado.",
+            },
+            {
+                frente: "Como você renderizaria uma lista com milhares de itens?",
+                verso: "Renderizando só o que aparece na tela, com virtualização, e mantendo altura previsível para o cálculo funcionar. Antes disso vale perguntar se a lista precisa mesmo ter milhares de itens visíveis, porque paginar ou filtrar costuma ser melhor para o usuário.",
+            },
+            {
+                frente: "Quando você guardaria estado na URL?",
+                verso: "Quando ele precisa sobreviver a um recarregamento, ser compartilhado por link ou funcionar com o botão voltar, como filtro, busca e página. O custo é serializar e validar o que vem de lá, porque a URL é entrada do usuário como qualquer outra.",
+            },
+            {
+                frente: "Como você protegeria uma rota que exige login?",
+                verso: "Com um componente que checa a sessão e redireciona para a tela de entrada guardando o destino, para voltar depois de autenticar. O importante é lembrar que isso é experiência, não segurança: a proteção de verdade está na API.",
+            },
+            {
+                frente: "Onde você guardaria o token de autenticação no front?",
+                verso: "De preferência num cookie de sessão marcado como inacessível ao JavaScript, deixando o navegador enviar. Guardar no armazenamento local é simples e fica exposto a qualquer script injetado. A escolha depende do modelo do backend, e precisa ser deliberada.",
+            },
+            {
+                frente: "O que você testaria num componente, e o que não vale testar?",
+                verso: "O comportamento que o usuário percebe: renderizou o que devia, o clique fez o que promete, o erro aparece. Não vale testar detalhe interno como nome de estado ou quantas vezes renderizou, porque isso quebra em toda refatoração sem indicar defeito.",
+            },
+            {
+                frente: "Como você buscaria elementos num teste de componente?",
+                verso: "Por papel e nome acessível, que é como o usuário e o leitor de tela enxergam. Buscar por classe ou por identificador de teste acopla o teste à implementação e não verifica se o elemento é anunciado corretamente.",
+            },
+            {
+                frente: "Como você testaria um componente que faz requisição?",
+                verso: "Interceptando na camada de rede, com um servidor falso, em vez de substituir a função de busca. Assim o teste exercita o mesmo caminho da produção, inclusive erro e código de status, e não quebra ao trocar o cliente HTTP.",
+            },
+            {
+                frente: "O que costuma tornar um teste de front instável?",
+                verso: "Esperar por tempo fixo em vez de esperar pelo elemento aparecer, depender de ordem entre testes, e estado global que sobra de um caso para o outro. Animação e temporizador reais também entram nessa conta, e por isso costumam ser controlados no teste.",
+            },
+            {
+                frente: "Como você reiniciaria o estado de um componente ao trocar de registro?",
+                verso: "Passando o identificador do registro como key, o que faz o React descartar a instância e criar outra. É mais confiável do que um efeito limpando campo por campo, que sempre esquece um e deixa dado do registro anterior na tela.",
+            },
+            {
+                frente: "Quando o estado deve subir para o componente pai?",
+                verso: "Quando dois irmãos precisam do mesmo dado ou quando o pai precisa reagir a ele. O dado sobe até o ancestral comum mais próximo, e não mais alto que isso. Subir demais transforma o topo da árvore num depósito de estado que renderiza tudo.",
+            },
+            {
+                frente: "Como você compartilharia estado entre dois componentes irmãos?",
+                verso: "Guardando no pai comum e passando valor e função de atualização. Se a distância for grande, contexto ou uma camada de estado resolvem melhor. O que não funciona é cada um manter a sua cópia e tentar sincronizar por efeito.",
+            },
+            {
+                frente: "Como você evitaria que o pai renderize a cada mudança de um filho?",
+                verso: "Mantendo o estado no componente mais baixo que precisa dele. Se o estado mora no topo só porque foi mais fácil, toda a árvore paga. Outra saída é passar conteúdo por children, que não renderiza de novo quando o pai renderiza por estado próprio.",
+            },
+            {
+                frente: "Como você lidaria com um efeito que precisa rodar só na primeira vez?",
+                verso: "Perguntando primeiro se ele deveria ser efeito. Se for mesmo, dependências vazias com limpeza correta resolvem, e o modo estrito vai executá-lo duas vezes em desenvolvimento de propósito. Guardar uma referência para pular a segunda execução mascara o problema.",
+            },
+            {
+                frente: "Como você mostraria o resultado de duas requisições que carregam juntas?",
+                verso: "Disparando as duas em paralelo e tratando os estados separadamente, mostrando o que já chegou. Encadear a segunda depois da primeira sem necessidade cria uma cascata que dobra o tempo de espera sem nenhum motivo.",
+            },
+            {
+                frente: "O que é uma cascata de requisições no front?",
+                verso: "Cada componente só descobrir o que precisa buscar depois que o pai terminou, o que enfileira chamadas que poderiam ser simultâneas. Aparece como tela carregando em etapas. A saída é buscar no nível da rota ou pré-carregar o que já se sabe que virá.",
+            },
+            {
+                frente: "Como você trataria uma tela que depende de vários dados, e um deles falha?",
+                verso: "Decidindo o que é essencial: sem o principal, a tela mostra erro; sem o secundário, ela renderiza sem aquela parte, indicando o que faltou. Bloquear a tela inteira por um bloco lateral que falhou é pior para o usuário do que a informação parcial.",
+            },
+            {
+                frente: "Como você faria uma atualização otimista?",
+                verso: "Aplicando a mudança na interface antes da resposta e guardando o valor anterior para desfazer se falhar, com aviso claro. Vale quando a ação quase sempre dá certo e a espera incomoda, como curtir. Não vale onde o erro é comum ou o efeito é irreversível.",
+            },
+            {
+                frente: "Como você lidaria com data e fuso na interface?",
+                verso: "Recebendo instante em UTC do servidor e formatando na hora de mostrar, com o fuso e o idioma do navegador. Guardar texto já formatado impede ordenar e comparar, e montar data a partir de partes soltas é onde aparece o erro de um dia.",
+            },
+            {
+                frente: "Como você formataria número e moeda para o usuário?",
+                verso: "Com a API de internacionalização do navegador, passando idioma e moeda, que já cuida de separador e posição do símbolo. Formatar na mão com substituição de ponto por vírgula quebra assim que a aplicação atende outro país.",
+            },
+            {
+                frente: "O que muda no código ao preparar a aplicação para outro idioma?",
+                verso: "Texto sai do JSX e vira chave traduzida, plural e ordem de palavras deixam de ser montados por concatenação, e o layout precisa aguentar texto mais longo. Data, número e moeda passam a depender do idioma, não de constante.",
+            },
+            {
+                frente: "Como você depuraria uma renderização que acontece mais do que deveria?",
+                verso: "Com o perfilador das ferramentas do React, que mostra o que renderizou e por qual motivo, se foi estado, contexto ou pai. Isso costuma apontar direto para um valor recriado a cada renderização, e economiza horas de tentativa.",
+            },
+            {
+                frente: "Como você lidaria com um componente que precisa medir o próprio tamanho?",
+                verso: "Com uma referência e um observador de redimensionamento, guardando a medida em estado só se ela for usada na renderização. Medir dentro do efeito e ajustar layout em seguida causa um quadro visível de piscada, então às vezes CSS resolve melhor.",
+            },
+            {
+                frente: "Como você trataria uma assinatura de eventos em tempo real num componente?",
+                verso: "Abrindo no efeito e fechando na limpeza, com dependências que reflitam o canal assinado. Sem a limpeza, cada renderização abre mais uma conexão e o mesmo evento passa a ser tratado várias vezes, o que aparece como duplicação estranha na tela.",
+            },
+            {
+                frente: "Como você guardaria uma preferência do usuário no navegador?",
+                verso: "Lendo o valor guardado na inicialização do estado, e não num efeito depois, para a tela não piscar o padrão. Toda leitura e escrita dentro de try, porque o armazenamento pode estar bloqueado, e a preferência nunca pode derrubar a aplicação.",
+            },
+            {
+                frente: "Como você trataria um erro de rede sem deixar o usuário travado?",
+                verso: "Mostrando o que falhou, oferecendo tentar de novo e preservando o que ele já digitou. Formulário que apaga tudo depois do erro é o pior resultado possível. Se a falha é temporária, uma repetição automática antes de mostrar erro melhora bastante.",
+            },
+            {
+                frente: "Quando você usaria uma referência para chamar algo dentro de um filho?",
+                verso: "Em ações imperativas que não cabem em estado, como focar, rolar até um ponto ou tocar uma mídia. É exceção: se o pai precisa comandar o filho o tempo todo, o que faltou foi mover o estado, e não expor mais métodos.",
+            },
+            {
+                frente: "Como você organizaria o código de uma tela que ficou grande?",
+                verso: "Separando o que busca e transforma dado num hook próprio, e deixando o componente com a estrutura visual. Depois quebrando blocos com nome de domínio. Dividir só por tamanho, sem nome que signifique algo, troca um arquivo grande por cinco confusos.",
+            },
+            {
+                frente: "Como você trataria estilos que começam a colidir entre telas?",
+                verso: "Com escopo, seja por módulos de CSS, utilitários ou componentes estilizados, para a classe não vazar. Nome global genérico é o que gera colisão. O importante é o time escolher uma abordagem e manter, porque três convivendo é pior do que qualquer uma delas.",
+            },
+            {
+                frente: "Como você lidaria com animação de entrada e saída de um elemento?",
+                verso: "A entrada é simples com CSS; a saída exige manter o elemento montado até a transição terminar, o que costuma pedir um estado de saindo. É por isso que existem bibliotecas para isso, e por isso animação de saída feita na mão sempre esquece um caso.",
+            },
+            {
+                frente: "Como você evitaria requisições repetidas quando dois componentes pedem o mesmo dado?",
+                verso: "Elevando a busca para um nível acima e passando por prop, ou usando cache por chave, que junta as chamadas iguais numa só. Dois efeitos independentes buscando o mesmo recurso é uma das causas mais comuns de tráfego duplicado no front.",
+            },
+            {
+                frente: "Como você trataria um botão que dispara ação demorada?",
+                verso: "Mostrando estado de carregando no próprio botão, desabilitando durante a ação e avisando ao terminar. Se passar de alguns segundos, vale explicar o que está acontecendo. Ação sem retorno visual leva o usuário a clicar de novo.",
+            },
+            {
+                frente: "Como você lidaria com um componente de terceiros que manipula o DOM?",
+                verso: "Isolando num componente próprio, com referência ao nó, inicializando no efeito e destruindo na limpeza. O React não pode disputar aquele pedaço da árvore. Sem essa fronteira, o componente vira fonte de bug estranho a cada renderização.",
+            },
+        ],
+        pleno: [
+            {
+                frente: "Como você investigaria uma interface que ficou lenta?",
+                verso: "Medindo antes de mexer: perfilar a interação lenta, ver quantos componentes renderizam e quanto tempo cada um leva, e separar lentidão de renderização de lentidão de rede. Otimizar por suposição costuma espalhar memo pela base sem mover o número.",
+            },
+            {
+                frente: "O que o perfilador do React mostra que o console não mostra?",
+                verso: "Quais componentes renderizaram em cada atualização, quanto tempo levaram e por que renderizaram. Isso separa o caso de renderizar demais do caso de renderizar poucas vezes e caro, que pedem correções bem diferentes.",
+            },
+            {
+                frente: "Qual é o custo real de uma renderização no React?",
+                verso: "Executar as funções dos componentes e comparar a árvore, o que é barato. O que pesa é trabalho pesado dentro do componente, muitos nós no DOM e efeito colateral disparado a cada renderização. Renderizar de novo não é sinônimo de tocar no DOM.",
+            },
+            {
+                frente: "Como você resolveria uma lista que trava enquanto o usuário digita no filtro?",
+                verso: "Separando o campo do resultado, para digitar não renderizar a lista inteira, e marcando a atualização da lista como não urgente com uma transição. Virtualizar a lista resolve o resto. Só memoizar a linha raramente basta quando são milhares.",
+            },
+            {
+                frente: "O que o useTransition resolve?",
+                verso: "Marca uma atualização como não urgente, deixando o React interromper aquele trabalho para responder ao que o usuário está fazendo agora. É o que mantém a digitação fluida enquanto uma lista pesada recalcula, e dá um sinalizador de pendente para mostrar na interface.",
+            },
+            {
+                frente: "Quando o useDeferredValue é melhor que uma transição?",
+                verso: "Quando você não controla quem dispara a atualização, e sim consome um valor que muda rápido. Ele deixa a parte cara renderizar com o valor atrasado enquanto a parte leve acompanha o atual. É a mesma ideia aplicada do lado de quem lê.",
+            },
+            {
+                frente: "O que é renderização concorrente, na prática?",
+                verso: "O React poder começar, pausar e retomar uma renderização em vez de fazer tudo de uma vez bloqueando a tela. Isso permite priorizar interação sobre trabalho pesado. Na prática você não controla isso direto: usa transições e Suspense.",
+            },
+            {
+                frente: "Como o React decide o que atualizar na tela?",
+                verso: "Comparando a árvore nova com a anterior no mesmo lugar. Mesmo tipo, ele mantém a instância e atualiza props; tipo diferente, descarta a subárvore e monta de novo. Em listas, a key é o que diz qual item é qual.",
+            },
+            {
+                frente: "O que acontece se você declarar um componente dentro de outro?",
+                verso: "Ele é recriado a cada renderização, então o React vê um tipo diferente e desmonta a subárvore inteira, perdendo estado e foco e refazendo efeitos. É um dos bugs mais confusos de diagnosticar, e a correção é mover a definição para fora.",
+            },
+            {
+                frente: "Como você evitaria perder o estado de um componente ao reorganizar a árvore?",
+                verso: "Mantendo a posição e o tipo estáveis. Trocar entre dois ramos de um ternário no mesmo lugar recria o componente; renderizar sempre o mesmo componente e mudar as props preserva. Quando o reset é intencional, a key é a forma explícita de pedir.",
+            },
+            {
+                frente: "O que é hidratação?",
+                verso: "O navegador recebe o HTML já renderizado no servidor e o React anexa os ouvintes e o estado a essa marcação existente, em vez de recriá-la. Até a hidratação terminar, a página aparece mas não responde, e é aí que mora boa parte da percepção de lentidão.",
+            },
+            {
+                frente: "O que causa erro de incompatibilidade na hidratação?",
+                verso: "O HTML do servidor sair diferente do que o cliente renderiza na primeira passada, o que acontece com data, número aleatório, largura da janela ou leitura de armazenamento local. A saída é renderizar igual e ajustar depois, num efeito.",
+            },
+            {
+                frente: "Quando renderizar no servidor vale a pena?",
+                verso: "Quando importam a primeira pintura em conexão ruim, indexação por buscadores ou compartilhamento com prévia. O custo é infraestrutura para rodar servidor, cuidado com o que só existe no navegador e complexidade de cache. Para painel interno atrás de login, raramente paga.",
+            },
+            {
+                frente: "O que muda quando um componente roda no servidor?",
+                verso: "Ele não tem estado, efeito nem acesso ao navegador, e pode buscar dado direto da fonte sem expor credencial. O que precisa de interação vira componente de cliente. O ganho é enviar menos JavaScript; o cuidado é onde traçar essa fronteira.",
+            },
+            {
+                frente: "Como você decidiria o que fica no servidor e o que vai para o cliente?",
+                verso: "Empurrando a fronteira para as folhas: a página busca e compõe no servidor, e só os pedaços interativos são de cliente. Marcar um componente alto como de cliente arrasta toda a subárvore junto e apaga o ganho.",
+            },
+            {
+                frente: "Como você mediria a experiência real dos usuários no front?",
+                verso: "Com métricas de campo, não só de laboratório: tempo até o maior conteúdo aparecer, resposta à interação e deslocamento de layout, coletadas dos navegadores reais e olhadas por percentil. Teste sintético numa máquina boa esconde justamente quem sofre.",
+            },
+            {
+                frente: "O que costuma piorar a resposta à interação numa aplicação React?",
+                verso: "Trabalho síncrono longo na thread principal ao clicar ou digitar: renderização de árvore grande, cálculo pesado sem memo, e script de terceiros. A correção passa por dividir o trabalho, adiar o não urgente e cortar o que não é do produto.",
+            },
+            {
+                frente: "Como você reduziria o JavaScript enviado ao navegador?",
+                verso: "Medindo por módulo, removendo dependência que faz pouco, importando só o necessário em vez do pacote inteiro, e dividindo por rota. Depois avaliando o que pode virar HTML estático. Cortar cem kilobytes de biblioteca vale mais que dez memos.",
+            },
+            {
+                frente: "Como você trataria uma dependência pesada usada em uma tela só?",
+                verso: "Carregando sob demanda no ponto de uso, para ela não entrar no pacote inicial. Se ela é usada em muitas telas, vale procurar substituto menor ou implementar o pedaço que você realmente usa. Editor de texto e biblioteca de gráfico são os casos clássicos.",
+            },
+            {
+                frente: "Como você organizaria o estado de uma aplicação React grande?",
+                verso: "Separando estado de servidor, com cache e revalidação, de estado de interface, que é local sempre que possível, e de estado global de verdade, que é pouca coisa. A maior parte dos problemas vem de tratar dado do servidor como estado global.",
+            },
+            {
+                frente: "Quando adotar uma biblioteca de estado global compensa?",
+                verso: "Quando existe estado de cliente compartilhado por muitas telas com regras próprias, como um editor ou um carrinho complexo. Se o que dói é dado do servidor, a ferramenta certa é cache de requisição, e a biblioteca global só vai duplicar o que a API já sabe.",
+            },
+            {
+                frente: "Como você estruturaria as pastas de um projeto React grande?",
+                verso: "Por domínio, com cada funcionalidade dona dos seus componentes, hooks e serviços, e uma camada compartilhada pequena e disciplinada. Pastas por tipo técnico crescem até ninguém achar nada, e toda mudança passa a tocar quatro lugares.",
+            },
+            {
+                frente: "Como você definiria a fronteira de um componente reutilizável?",
+                verso: "Pelo que ele promete, não pelo que ele desenha hoje. Ele recebe dados e emite eventos, sem saber de rota, requisição ou regra de negócio. No momento em que ele importa um serviço da aplicação, deixou de ser reutilizável e virou uma tela.",
+            },
+            {
+                frente: "Como você evitaria que um componente vire dez props booleanas?",
+                verso: "Trocando combinações por uma prop de variante com valores nomeados, e aceitando conteúdo por children em vez de configurar cada pedaço. Booleana solta permite combinações que não existem no design, e é ali que aparecem os estados impossíveis.",
+            },
+            {
+                frente: "Como você garantiria acessibilidade num time que não pensa nisso?",
+                verso: "Colocando no caminho: componentes base acessíveis por padrão, verificação automática no build e um roteiro curto de teste por teclado na revisão. Depender de alguém lembrar não escala, e auditoria no fim do projeto sempre chega tarde.",
+            },
+            {
+                frente: "O que uma verificação automática de acessibilidade não pega?",
+                verso: "Ordem de foco confusa, rótulo que existe mas não faz sentido, mudança de conteúdo não anunciada e armadilha de teclado. As ferramentas pegam contraste e atributo faltando. O resto exige navegar com teclado e ouvir um leitor de tela.",
+            },
+            {
+                frente: "Quando um teste de ponta a ponta paga o custo?",
+                verso: "Nos poucos fluxos que geram receita ou que quebram tudo se falharem, como entrar, comprar e publicar. Eles são lentos e mais frágeis, então cobrir a aplicação inteira com eles cria uma suíte em que ninguém confia e todo mundo reexecuta.",
+            },
+            {
+                frente: "Como você lidaria com testes de interface que falham de vez em quando?",
+                verso: "Tratando como defeito e olhando a causa: espera por tempo fixo, animação, dado compartilhado entre casos e requisição não interceptada. Reexecutar até passar treina o time a ignorar vermelho, e o teste deixa de proteger qualquer coisa.",
+            },
+            {
+                frente: "Como você depuraria um erro que só acontece em produção?",
+                verso: "Com monitoramento capturando o erro, a versão e o rastro de ações do usuário, e mapas de origem no servidor de erros para a pilha ficar legível. Sem isso sobra reproduzir no escuro. E o dado da sessão precisa ser suficiente para reproduzir, sem vazar informação pessoal.",
+            },
+            {
+                frente: "Como você usaria mapas de origem sem expor o código-fonte?",
+                verso: "Gerando os mapas e enviando para a ferramenta de erros no build, sem publicá-los junto do site. Assim a pilha fica legível para o time e o navegador do usuário não baixa nada a mais. Publicar mapa em produção entrega o código inteiro.",
+            },
+            {
+                frente: "O que você monitoraria numa aplicação React em produção?",
+                verso: "Taxa de erro por versão e por rota, métricas de experiência do usuário, tempo das chamadas de API vistas do cliente e falhas de carregamento de pedaços. Esse último costuma ser o sintoma de deploy que apagou os arquivos antigos.",
+            },
+            {
+                frente: "Como você trataria o cache do navegador entre deploys?",
+                verso: "Com nomes de arquivo versionados por conteúdo e cache longo, e o HTML sem cache. Isso permite trocar tudo sem servir mistura de versões. E é preciso manter os arquivos antigos por um tempo, para quem está com a página aberta não quebrar ao navegar.",
+            },
+            {
+                frente: "Como você lidaria com um usuário que está com a versão antiga aberta há horas?",
+                verso: "Detectando que existe versão nova, por checagem periódica ou por falha ao carregar um pedaço, e oferecendo recarregar num aviso discreto. Recarregar sozinho no meio de um formulário é pior que a versão velha, então isso precisa ser combinado com o produto.",
+            },
+            {
+                frente: "Como você faria uma mudança de interface chegar aos poucos?",
+                verso: "Atrás de uma chave de funcionalidade avaliada no servidor ou por porcentagem, com métrica comparando os dois grupos e desligamento rápido. O código precisa aguentar os dois caminhos por um tempo, e a chave precisa ter data para morrer.",
+            },
+            {
+                frente: "Como você trataria estado que precisa funcionar sem conexão?",
+                verso: "Guardando localmente a fila de ações e reconciliando quando a rede volta, com regra clara de conflito. É bem mais caro do que parece, então vale checar se o produto precisa mesmo disso ou se basta avisar que está offline e preservar o formulário.",
+            },
+            {
+                frente: "Como você lidaria com duas abas da mesma aplicação abertas?",
+                verso: "Tratando o armazenamento compartilhado como fonte de eventos, ouvindo mudanças para sincronizar sessão e cache. O caso que mais dói é sair em uma aba e a outra continuar achando que está logada, disparando requisições que falham em série.",
+            },
+            {
+                frente: "Como você faria upload com barra de progresso?",
+                verso: "Usando uma API que expõe eventos de progresso, com cancelamento, e enviando direto para o armazenamento quando possível, com URL assinada. Passar arquivo grande pela sua API custa banda e memória do servidor sem entregar nada ao usuário.",
+            },
+            {
+                frente: "Como você lidaria com um WebSocket dentro de uma aplicação React?",
+                verso: "Com uma conexão só, num provedor acima das telas, e componentes assinando os eventos que lhes interessam. Abrir conexão dentro de componente multiplica sockets a cada montagem. Reconexão com espera crescente e estado de conexão visível são parte do trabalho.",
+            },
+            {
+                frente: "Como você migraria componentes de classe para hooks?",
+                verso: "Aos poucos, começando pelos que mudam com frequência, e sem tentar traduzir método por método: os ciclos de vida viram sincronizações, não um efeito por método. Componente de classe estável e sem bug pode ficar como está por bastante tempo.",
+            },
+            {
+                frente: "Como você conduziria a atualização de uma versão maior do React?",
+                verso: "Lendo o guia de mudanças, subindo em uma branch e rodando a suíte, com atenção a bibliotecas do ecossistema, que costumam ser o bloqueio real. Ativar avisos de descontinuação antes ajuda a preparar. Adotar recurso novo vem depois, não junto.",
+            },
+            {
+                frente: "Como você faria a revisão de um PR de React?",
+                verso: "Olhando onde o estado mora, se algum efeito é desnecessário, se as keys são estáveis, se as props criam estado impossível e se o componente é acessível por teclado. Estilo fica com a ferramenta. O que rende mais é perguntar por que aquele estado existe.",
+            },
+            {
+                frente: "Que sinais indicam que um componente ficou grande demais?",
+                verso: "Vários estados que mudam juntos, efeitos com muitas dependências, condicionais aninhadas no JSX e a necessidade de rolar para entender o retorno. Antes de quebrar, vale ver se o problema é dado mal modelado, porque dividir não conserta isso.",
+            },
+            {
+                frente: "Como você extrairia um hook próprio sem abstrair cedo demais?",
+                verso: "Esperando o terceiro uso parecido e extraindo o que é igual de verdade, mantendo os pontos de variação como parâmetro. Hook criado no primeiro uso costuma nascer com opções demais, e depois ninguém consegue mudar sem quebrar alguém.",
+            },
+            {
+                frente: "Como você trataria regra de negócio que apareceu no componente?",
+                verso: "Movendo para uma função pura fora do React, que dá para testar sem renderizar, e deixando o componente decidir só o que mostrar. Regra dentro do JSX se duplica na próxima tela, e as duas cópias divergem na primeira mudança de requisito.",
+            },
+            {
+                frente: "Como você lidaria com muitos estados de carregamento na mesma tela?",
+                verso: "Agrupando por região com esqueletos, para a página não virar um mosaico de giros, e definindo o que bloqueia e o que carrega depois. Suspense ajuda a coordenar isso. O objetivo é o layout não mudar de forma quando cada parte chega.",
+            },
+            {
+                frente: "Como você faria pré-carregamento de dados de uma rota?",
+                verso: "Disparando a busca ao passar o mouse ou ao focar o link, e carregando o código da rota junto. Assim o clique encontra dado e pedaço já em cache. É uma das melhorias mais perceptíveis, e custa pouco quando o cache já existe.",
+            },
+            {
+                frente: "Como você evitaria que o front repita a validação do servidor de forma divergente?",
+                verso: "Compartilhando o esquema de validação quando os dois lados são JavaScript, ou gerando o do cliente a partir do contrato. O front valida para dar retorno rápido, e o servidor valida porque é ele quem protege. Duas regras escritas à mão sempre divergem.",
+            },
+            {
+                frente: "Como você trataria uma API que devolve o formato errado para a tela?",
+                verso: "Adaptando na borda, num módulo de serviço que traduz para o modelo da interface, em vez de espalhar o formato do servidor pelos componentes. Assim, quando a API mudar, um arquivo muda. E fica claro qual campo a tela realmente usa.",
+            },
+            {
+                frente: "Como você lidaria com paginação e filtros que precisam sobreviver ao voltar?",
+                verso: "Guardando na URL como parâmetros de consulta e lendo de lá como fonte da verdade. Assim compartilhar link funciona e o botão voltar faz o esperado. Guardar em estado local obriga a recriar tudo, e o usuário perde o lugar.",
+            },
+            {
+                frente: "Como você trataria animações sem atrapalhar o desempenho?",
+                verso: "Animando propriedades que o navegador compõe, como transformação e opacidade, evitando animar layout. E respeitando a preferência de menos movimento do sistema, que existe por acessibilidade e é ignorada com frequência.",
+            },
+            {
+                frente: "Como você mediria o impacto de uma otimização no front?",
+                verso: "Comparando o mesmo cenário antes e depois, com número: tempo da interação no perfilador e métricas de campo depois do deploy. Sem isso, otimização vira crença. E vale conferir se o ganho aparece no dispositivo fraco, que é onde ele importa.",
+            },
+            {
+                frente: "Como você lidaria com script de terceiros pesando na página?",
+                verso: "Carregando depois do conteúdo, isolando quando der, e medindo o custo de cada um. Vale exigir dono e justificativa para cada script novo. Ferramenta de análise e chat costumam custar mais que a aplicação inteira, e ninguém revisa isso depois de instalado.",
+            },
+            {
+                frente: "Como você trataria conteúdo vindo do usuário que precisa ser renderizado como HTML?",
+                verso: "Sanitizando no servidor com uma lista do que é permitido, e só então injetando. Sanitizar apenas no cliente não protege quem consome a mesma API por outro caminho. Se der para evitar HTML e usar formato controlado, melhor ainda.",
+            },
+            {
+                frente: "Como você lidaria com um formulário de vários passos?",
+                verso: "Com o estado do formulário acima dos passos, validação por passo e possibilidade de voltar sem perder o que foi preenchido. Guardar rascunho ajuda em formulário longo. O passo atual costuma ficar na URL, para recarregar não jogar tudo fora.",
+            },
+            {
+                frente: "Como você trataria um componente que precisa saber se está visível na tela?",
+                verso: "Com o observador de interseção, que avisa quando o elemento entra e sai da janela, em vez de ouvir rolagem e calcular posição. Serve para carregar sob demanda, medir visualização e disparar rolagem infinita, com custo bem menor.",
+            },
+            {
+                frente: "Como você organizaria a camada que fala com a API?",
+                verso: "Num módulo por recurso, com tipos de entrada e saída, tratamento de erro padronizado e nada de JSX. Componente chamando fetch direto espalha URL e cabeçalho pela base, e trocar autenticação vira caçada por arquivo.",
+            },
+            {
+                frente: "Como você trataria tokens expirando durante o uso?",
+                verso: "Renovando de forma transparente na camada de rede, com uma fila para não disparar várias renovações ao mesmo tempo, e caindo para a tela de entrada quando falhar. Deixar cada componente tratar 401 gera comportamento diferente em cada tela.",
+            },
+            {
+                frente: "Como você garantiria que o front não quebre quando a API muda?",
+                verso: "Com tipos gerados do contrato ou validação do formato na borda, falhando de forma clara em vez de espalhar indefinido pela árvore. Teste de contrato ajuda a pegar cedo. Confiar que a resposta tem o campo é como surge tela branca em produção.",
+            },
+            {
+                frente: "Como você lidaria com estados impossíveis na interface?",
+                verso: "Modelando o estado como união de casos, como carregando, erro e conteúdo, em vez de três booleanas independentes. Assim carregando e erro ao mesmo tempo deixa de ser representável, e a renderização vira um switch simples.",
+            },
+            {
+                frente: "Como você trataria uma tela que precisa de dado que só existe depois do login?",
+                verso: "Resolvendo a sessão acima, num provedor, e deixando a tela assumir que o usuário existe. Cada componente checando se há usuário espalha condicional e cria o intervalo em que a tela renderiza vazia e depois pula.",
+            },
+            {
+                frente: "Como você reduziria o tempo até a primeira tela útil?",
+                verso: "Enviando menos JavaScript, buscando o dado essencial junto com a navegação em vez de depois da montagem, e mostrando esqueleto no lugar da tela em branco. Fonte e imagem entram na conta, e costumam ser esquecidas.",
+            },
+            {
+                frente: "Como você trataria uma dependência que quebra no modo estrito?",
+                verso: "Verificando se ela é mantida e se existe versão compatível, e isolando o uso num invólucro enquanto isso. Desligar o modo estrito para calar o aviso esconde um problema real de efeito sem limpeza, e ele reaparece na próxima versão do React.",
+            },
+            {
+                frente: "Como você lidaria com um bug que só acontece num navegador?",
+                verso: "Reproduzindo nele com as ferramentas próprias, e checando suporte da API usada antes de culpar o React. Costuma ser diferença de eventos, foco ou layout. Ter ao menos um teste rodando nesse navegador impede a regressão voltar.",
+            },
+            {
+                frente: "Como você garantiria que o componente funciona em telas pequenas?",
+                verso: "Desenhando primeiro para a tela pequena e crescendo com consultas de mídia, testando com teclado virtual aberto e com texto ampliado. Emulador ajuda, mas dispositivo real revela toque, rolagem e desempenho que o navegador esconde.",
+            },
+            {
+                frente: "Como você trataria imagens em várias resoluções?",
+                verso: "Servindo tamanhos diferentes com o atributo que descreve as fontes, em formato moderno, com dimensão reservada e carregamento adiado fora da primeira dobra. Enviar a imagem original para todo mundo é o desperdício mais comum de banda em front.",
+            },
+            {
+                frente: "Como você mediria se vale a pena remover uma biblioteca?",
+                verso: "Pelo peso que ela adiciona, por quanto do que ela faz você realmente usa e pelo custo de manter a substituição. Trocar uma biblioteca inteira por trezentas linhas próprias parece vitória até alguém precisar dar manutenção nelas.",
+            },
+            {
+                frente: "Como você lidaria com um componente compartilhado que cada time quer diferente?",
+                verso: "Separando o que é comportamento do que é aparência, expondo pontos de composição em vez de acumular props. Se as necessidades divergem de verdade, dois componentes honestos custam menos que um configurável demais que ninguém entende.",
+            },
+            {
+                frente: "Como você trataria a primeira renderização que depende de algo do navegador?",
+                verso: "Renderizando o mesmo que o servidor renderizaria e ajustando depois de montar, com um estado que só vira verdadeiro no cliente. Ler largura da janela ou armazenamento durante a renderização inicial é o caminho direto para erro de hidratação.",
+            },
+            {
+                frente: "Como você lidaria com um efeito que dispara em cascata outros efeitos?",
+                verso: "Puxando o cálculo para a renderização ou para o evento que originou a mudança, em vez de encadear efeitos que reagem uns aos outros. Cadeia de efeitos gera renderizações intermediárias visíveis e é quase impossível de acompanhar depois de três elos.",
+            },
+            {
+                frente: "Como você trataria o crescimento do tempo de build do front?",
+                verso: "Medindo por etapa antes de trocar de ferramenta: costuma ser checagem de tipos junto do empacotamento, plugin caro ou ausência de cache. Build lento muda o comportamento do time, que passa a agrupar mudanças e a testar menos.",
+            },
+        ],
+        senior: [
+            {
+                frente: "Como você escolheria entre uma aplicação de página única e um framework com servidor?",
+                verso: "Pelo produto: conteúdo público que precisa ser indexado e abrir rápido em conexão ruim pede servidor. Painel atrás de login vive bem como página única e evita operar infraestrutura de renderização. A pergunta seguinte é quem mantém isso de pé às três da manhã.",
+            },
+            {
+                frente: "Quando você não usaria React num projeto novo?",
+                verso: "Quando a página é conteúdo com pouca interação, quando o time não conhece e o prazo é curto, ou quando o produto é um widget que precisa pesar pouco dentro do site de outra pessoa. Escolher pela familiaridade do time costuma render mais que escolher pela tecnologia.",
+            },
+            {
+                frente: "Como você avaliaria adotar componentes de servidor num projeto existente?",
+                verso: "Pelo problema que resolvem ali: peso de JavaScript e cascata de requisições. A conta inclui migrar padrão de dados, rever autenticação e treinar o time numa fronteira nova. Adotar por rota, começando pelas mais pesadas, permite medir antes de comprometer tudo.",
+            },
+            {
+                frente: "Como você conduziria a atualização de uma versão maior do React num produto grande?",
+                verso: "Levantando as dependências que travam, subindo numa branch com a suíte inteira rodando e ligando os avisos antes. Depois liberando por partes, com monitoramento de erro por versão. O risco raro não está no React: está nas bibliotecas do ecossistema.",
+            },
+            {
+                frente: "Como você definiria a estratégia de estado para vários times?",
+                verso: "Padronizando a divisão, não a biblioteca: estado de servidor com cache, estado de interface local e o pouco que é global de verdade. Com uma escolha padrão para cada caixa e liberdade justificada para sair dela. Sem isso, cada tela inventa a sua e ninguém consegue revisar.",
+            },
+            {
+                frente: "Como você evitaria que cada time escolha uma biblioteca diferente para a mesma coisa?",
+                verso: "Com um conjunto padrão documentado, um modelo de projeto que já vem com ele e um caminho claro para propor mudança. Proibir não funciona; facilitar o padrão sim. E toda escolha nova precisa dizer quem mantém e o que sai em troca.",
+            },
+            {
+                frente: "Como você conduziria a criação de um design system?",
+                verso: "Começando pelos componentes que já se repetem e pelos tokens de cor, espaço e tipografia, entregando junto com uma tela real. Design system criado antes do uso vira catálogo bonito e ignorado. Adoção se mede em telas migradas, não em componentes publicados.",
+            },
+            {
+                frente: "Como você lidaria com times que copiam e alteram o componente do design system?",
+                verso: "Perguntando o que faltava, porque cópia é sintoma de rigidez ou de dificuldade de contribuir. A correção costuma ser abrir pontos de composição e facilitar o processo de proposta. Bloquear a cópia sem resolver a causa só empurra a divergência para dentro do CSS.",
+            },
+            {
+                frente: "Como você versionaria uma biblioteca de componentes interna?",
+                verso: "Com versão semântica levada a sério, mudança visual tratada como quebra quando altera layout de quem usa, e um registro de mudanças que diga o que fazer. Prazo e caminho de migração para o que sai. Sem isso os times congelam a versão e você mantém três.",
+            },
+            {
+                frente: "Como você definiria metas de desempenho para o front?",
+                verso: "Em número de campo e por percentil, ligado ao que o usuário sente: tempo até a tela útil e resposta à interação, no dispositivo mediano do seu público. Meta sem dispositivo e sem percentil é opinião, e some na primeira negociação de prazo.",
+            },
+            {
+                frente: "Como você impediria que o tamanho do pacote cresça sem controle?",
+                verso: "Com um limite verificado na esteira, que falha quando passa, e o número visível no PR. Assim a discussão acontece quando a dependência entra, e não seis meses depois. Sem trava automática, o pacote só cresce, porque cada aumento parece pequeno.",
+            },
+            {
+                frente: "Como você avaliaria adotar micro frontends?",
+                verso: "Pelo problema organizacional: times que precisam publicar sem coordenar. Se o motivo é técnico, quase sempre existe solução mais barata. O custo é duplicar dependência, unificar autenticação e estilo, e depurar uma tela que ninguém é dono inteiro.",
+            },
+            {
+                frente: "Quando micro frontends claramente não valem?",
+                verso: "Com um time só, ou com times que já publicam juntos sem dor. Ali eles trocam um build simples por orquestração, versões divergentes e desempenho pior para o usuário, que baixa React duas vezes. A vantagem é organizacional, e sem esse problema não há ganho.",
+            },
+            {
+                frente: "Como você organizaria um monorepo de front?",
+                verso: "Com fronteiras explícitas entre pacotes, build incremental com cache e regra de quem pode depender de quem. Sem isso, monorepo vira uma bola de barro com build de vinte minutos, e a facilidade de importar qualquer coisa acopla tudo.",
+            },
+            {
+                frente: "Como você conduziria a migração de uma base legada de front?",
+                verso: "Por rota ou por pedaço de tela, com as duas tecnologias convivendo atrás do mesmo domínio, começando pelo que muda mais. Reescrita completa perde regra que ninguém documentou e passa meses sem entregar. Migrar por fatia deixa o produto vivo o tempo todo.",
+            },
+            {
+                frente: "Como você trataria a dívida de efeitos espalhados por uma base antiga?",
+                verso: "Atacando por categoria e não por arquivo: os que só derivam estado, os que buscam dado sem cancelamento e os que sincronizam com o DOM. Os dois primeiros somem trocando padrão, e é aí que está a maior parte dos bugs de renderização.",
+            },
+            {
+                frente: "Como você ensinaria hooks a um time que vem de componentes de classe?",
+                verso: "Pelo modelo mental, não pela tabela de equivalência: a renderização descreve a tela para aquele estado, e efeito é sincronização com o mundo de fora. A tradução direta de ciclo de vida para efeito é o que produz a dívida que depois custa caro.",
+            },
+            {
+                frente: "Que padrões você exigiria numa revisão de código de front?",
+                verso: "Onde o estado mora, ausência de efeito desnecessário, key estável, acessibilidade por teclado e camada de rede isolada. O resto é sugestão. Lista longa de exigência transforma revisão em ritual, e o que importa passa despercebido no meio.",
+            },
+            {
+                frente: "Como você encerraria uma discussão recorrente de estilo de código?",
+                verso: "Automatizando: formatador e linter decidem, e ninguém mais discute em revisão. Onde a ferramenta não alcança, uma decisão escrita e datada. O custo de manter a discussão viva toda semana é maior que o de qualquer escolha razoável.",
+            },
+            {
+                frente: "Como você mediria a qualidade do front além de teste passando?",
+                verso: "Erros por sessão em produção, métricas de experiência do usuário, tempo para entregar uma mudança pequena e quantas telas o time evita tocar. Cobertura sozinha diz pouco, e vira meta que se engana com teste sem asserção.",
+            },
+            {
+                frente: "Como você definiria a estratégia de testes de uma aplicação React?",
+                verso: "Muitos testes de componente rápidos sobre comportamento, poucos de ponta a ponta nos fluxos de receita, e verificação visual só onde regressão de layout dói. O critério é confiança por minuto de execução, e uma suíte em que o vermelho é levado a sério.",
+            },
+            {
+                frente: "Como você trataria requisito de suporte a navegador antigo?",
+                verso: "Buscando o dado de uso real do seu público antes de aceitar a exigência, porque manter compatibilidade custa em pacote e em tempo. Se for necessário, isolar o custo com carregamento condicional em vez de rebaixar a aplicação inteira.",
+            },
+            {
+                frente: "Como você trataria usuários em conexões ruins e aparelhos fracos?",
+                verso: "Medindo com o dispositivo mediano do público e não com o notebook do time, cortando JavaScript, adiando o que não é essencial e mostrando conteúdo antes da interatividade. É onde renderização no servidor costuma justificar o custo.",
+            },
+            {
+                frente: "Como você trataria SEO numa aplicação React?",
+                verso: "Entregando HTML com o conteúdo, seja renderizando no servidor ou gerando estático, com título, descrição e endereço canônico por rota. Página que só monta no cliente pode até ser indexada, mas concorre em desvantagem, e prévia em rede social não funciona.",
+            },
+            {
+                frente: "Como você mediria o custo de infraestrutura de renderizar no servidor?",
+                verso: "Custo por requisição renderizada, incluindo CPU, memória e o que o cache absorve. Muita coisa que se renderiza a cada acesso podia ser gerada uma vez. Se quase tudo cai no cache, o custo é pequeno; se nada cai, ele cresce com o tráfego.",
+            },
+            {
+                frente: "Como você faria o deploy do front sem quebrar quem está com a página aberta?",
+                verso: "Mantendo os arquivos da versão anterior disponíveis por um tempo, versionando por conteúdo e detectando falha ao carregar um pedaço para oferecer recarregar. Apagar tudo a cada deploy quebra navegação de quem já estava dentro.",
+            },
+            {
+                frente: "Como você conduziria um incidente causado por uma entrega de front?",
+                verso: "Voltando para a versão anterior primeiro, porque no front isso costuma ser rápido, e só então investigando. Se a mudança está atrás de uma chave, desligar é ainda mais rápido. Investigar com usuários vendo tela quebrada é o erro clássico.",
+            },
+            {
+                frente: "Como você mediria o impacto de uma mudança de interface?",
+                verso: "Definindo antes qual comportamento deveria mudar e como isso aparece nos números, com grupo de comparação quando dá. Sem hipótese anterior, todo resultado vira confirmação do que se queria acreditar, e a mudança fica mesmo quando piorou.",
+            },
+            {
+                frente: "Como você trabalharia com design quando o desenho não cabe no componente existente?",
+                verso: "Trazendo o custo para a conversa cedo, com opções: aproximar do que existe, estender o componente para todos, ou aceitar a exceção documentada. Implementar em silêncio uma variação nova é como o design system começa a divergir.",
+            },
+            {
+                frente: "Como você estimaria uma tela complexa?",
+                verso: "Quebrando em partes com risco identificado: estados, integração, casos de erro e acessibilidade, que é o que costuma ficar de fora. Comparando com telas parecidas já entregues. Estimativa que só conta o caso feliz erra por um fator conhecido.",
+            },
+            {
+                frente: "Como você decidiria entre usar um componente pronto e construir o seu?",
+                verso: "Pelo quanto ele carrega de coisa que você não usa, pelo custo de customizar e por quem mantém. Data, tabela e seleção com busca costumam valer a compra, porque acessibilidade e casos de borda são caros. Botão e cartão quase nunca.",
+            },
+            {
+                frente: "Como você avaliaria uma biblioteca de front antes de adotar?",
+                verso: "Peso, manutenção ativa, quantas dependências arrasta, acessibilidade e qual o caminho de saída se ela morrer. Depois quem no time sustenta. Biblioteca que só uma pessoa entende vira dívida no dia em que ela troca de time.",
+            },
+            {
+                frente: "Como você lidaria com uma dependência importante que foi abandonada?",
+                verso: "Fixando a versão e isolando o uso atrás de um invólucro para reduzir o custo da troca, enquanto avalia substituto ou manutenção interna. Migrar às pressas depois de uma vulnerabilidade é bem pior do que planejar a saída com calma.",
+            },
+            {
+                frente: "Como você garantiria segurança numa aplicação React?",
+                verso: "Não injetando HTML de terceiros sem sanitizar, cuidando de onde o token vive, definindo política de conteúdo e revisando dependências. O front não protege dado: ele protege o usuário do próprio navegador. A autorização de verdade continua no servidor.",
+            },
+            {
+                frente: "Como você trataria autenticação no front de forma segura?",
+                verso: "Preferindo sessão em cookie inacessível ao JavaScript, com renovação transparente e saída que limpa tudo. O front trata isso como experiência, não como barreira. Toda rota protegida precisa da checagem no servidor, porque o cliente é editável.",
+            },
+            {
+                frente: "Como você lidaria com chaves de funcionalidade no front?",
+                verso: "Avaliando no servidor ou na entrega, com valor padrão seguro e data para a chave morrer. Sem prazo, elas acumulam e viram combinações que ninguém testou. Também precisam ser observáveis, para saber quem está vendo o quê num incidente.",
+            },
+            {
+                frente: "Como você conduziria um teste A/B sem estragar a experiência?",
+                verso: "Com o grupo decidido antes da renderização para não piscar entre variantes, tamanho de amostra e duração definidos antes, e uma métrica principal. Rodar até dar o resultado que se queria é o erro mais comum, e ele passa despercebido.",
+            },
+            {
+                frente: "Como você trataria telemetria sem virar coleta abusiva?",
+                verso: "Coletando o que responde a uma pergunta concreta, sem dado pessoal desnecessário, com retenção definida e respeitando consentimento. Evento coletado por via das dúvidas vira custo, risco jurídico e painel que ninguém abre.",
+            },
+            {
+                frente: "Como você lidaria com internacionalização em escala?",
+                verso: "Tirando texto do código desde o começo, com chaves organizadas por domínio, plural e formatação resolvidos pela biblioteca, e traduções carregadas por idioma. Adicionar idioma depois de dois anos de texto embutido é um dos refactors mais caros do front.",
+            },
+            {
+                frente: "Como você faria a integração de alguém novo no front?",
+                verso: "Ambiente rodando em um comando, uma tarefa real pequena na primeira semana e um mapa curto de como o projeto se divide e por quê. Documentar as três decisões que mais surpreendem economiza semanas de perguntas repetidas.",
+            },
+            {
+                frente: "Como você documentaria componentes de forma que alguém use?",
+                verso: "Com exemplos executáveis ao lado do código, mostrando os estados reais e o que não fazer. Documentação separada do repositório envelhece em semanas. E o melhor documento continua sendo a interface do componente ser difícil de usar errado.",
+            },
+            {
+                frente: "Como você lidaria com um time que quer reescrever o front do zero?",
+                verso: "Pedindo o que exatamente não dá para consertar de forma incremental e quem paga o período de dois sistemas. Muitas vezes a dor é build lento e ausência de teste, que se resolve sem reescrita. Se a reescrita for mesmo o caminho, ela precisa ser por fatia.",
+            },
+            {
+                frente: "Como você priorizaria melhorias de desempenho?",
+                verso: "Pelo que afeta mais gente no percentil ruim, começando pelo que tem número: peso do pacote, cascata de requisições e interação travando. Otimização de renderização isolada costuma render menos do que remover uma dependência ou corrigir a busca de dados.",
+            },
+            {
+                frente: "Como você lidaria com um front acoplado a uma API ruim?",
+                verso: "Isolando a tradução numa camada só, para o resto do código falar o idioma da interface, e levando os problemas medidos para o time da API: número de chamadas por tela, campos faltando, latência. Sem número, a conversa vira reclamação.",
+            },
+            {
+                frente: "Quando uma camada intermediária para o front se justifica?",
+                verso: "Quando a tela precisa juntar várias chamadas, esconder detalhe de serviços internos ou entregar exatamente o que aquela interface usa. O custo é mais um serviço para operar e versionar, e ele precisa de dono claro, senão vira terra de ninguém.",
+            },
+            {
+                frente: "Como você negociaria mudança de contrato com o time de backend?",
+                verso: "Trazendo o custo do lado do usuário com dado, propondo o formato e combinando compatibilidade nos dois sentidos durante a transição. Contrato acertado por conversa e integrado no fim é o que estoura prazo dos dois lados.",
+            },
+            {
+                frente: "Como você evitaria que a interface espelhe o modelo do banco?",
+                verso: "Modelando o estado pelo que a tela precisa mostrar e decidir, e adaptando o que vem da API na borda. Quando o componente conhece o formato do banco, cada mudança de coluna vira mudança de tela, e a linguagem do produto some do código.",
+            },
+            {
+                frente: "Como você decidiria o que validar no cliente e o que validar no servidor?",
+                verso: "Tudo é validado no servidor, sempre, porque é ele que protege. O cliente valida para dar retorno rápido e evitar ida e volta. A regra precisa ter uma fonte só, senão as duas divergem e o usuário vê mensagens diferentes para o mesmo erro.",
+            },
+            {
+                frente: "Como você trataria performance percebida, e não só medida?",
+                verso: "Mostrando resposta imediata ao clique, esqueleto no lugar de tela vazia, e atualização otimista onde faz sentido. Uma ação que responde em duzentos milissegundos parece mais rápida que outra em cem sem retorno visual nenhum.",
+            },
+            {
+                frente: "Como você definiria o que é uma entrega de front pronta?",
+                verso: "Funciona nos estados de carregando, vazio e erro, é acessível por teclado, responde em tela pequena, tem os textos revisados e não regrediu desempenho. Pronto não é a tela funcionar no caminho feliz na máquina de quem escreveu.",
+            },
+            {
+                frente: "Como você lidaria com uma tela que ninguém do time quer mexer?",
+                verso: "Descobrindo o motivo: costuma ser estado espalhado, ausência de teste e medo de quebrar. Adicionar teste de comportamento antes de tocar transforma o medo em trabalho normal. Se ela quase não é usada, a melhor manutenção é remover.",
+            },
+            {
+                frente: "Como você trataria duplicação de lógica entre web e aplicativo móvel?",
+                verso: "Extraindo o que é regra pura para um pacote compartilhado, sem componente nem navegação. Tentar compartilhar interface entre plataformas costuma render o pior dos dois lados. O que compartilha bem é validação, formatação e cliente de API.",
+            },
+            {
+                frente: "Como você mediria se o design system está sendo adotado?",
+                verso: "Contando telas migradas, importações do pacote contra CSS próprio, e quantos componentes locais duplicam algo que já existe. Número de componentes publicados não diz nada. E é preciso perguntar aos times por que não usaram, sem tom de cobrança.",
+            },
+            {
+                frente: "Como você lidaria com pressão para entregar sem acessibilidade?",
+                verso: "Mostrando que boa parte do custo é escolher o elemento certo, o que não muda prazo, e separando o que é obrigação legal do que é melhoria. Deixar para depois significa refazer, porque acessibilidade não é camada que se aplica no fim.",
+            },
+            {
+                frente: "Como você trataria o crescimento do tempo de checagem de tipos no front?",
+                verso: "Medindo o que domina, quebrando em projetos com referências e evitando tipos genéricos muito complexos em código compartilhado. Rodar a checagem em paralelo com o build ajuda no ciclo local, mas não resolve o custo de um tipo que explode.",
+            },
+            {
+                frente: "Como você garantiria que o front continue funcionando quando um serviço cai?",
+                verso: "Definindo o que é essencial por tela, degradando o resto com estado claro em vez de bloquear tudo, e com timeout em toda chamada. Uma tela que não abre porque o bloco lateral de recomendações caiu é uma decisão de projeto, e quase sempre errada.",
+            },
+            {
+                frente: "Como você lidaria com requisitos que mudam no meio da implementação?",
+                verso: "Entregando em fatias para a mudança pegar menos código pronto, e deixando explícito o custo do que já foi feito. Se muda toda semana, o problema é anterior ao front: falta decidir o produto, e nenhuma arquitetura conserta isso.",
+            },
+            {
+                frente: "Como você decidiria remover uma funcionalidade da interface?",
+                verso: "Medindo uso real, avisando quem depende e removendo o código junto, e não só o botão. Funcionalidade escondida mas viva continua custando manutenção e ainda quebra em silêncio, porque ninguém testa o que ninguém vê.",
+            },
+            {
+                frente: "Como você equilibraria consistência visual e autonomia dos times?",
+                verso: "Fixando os tokens e os componentes de base, e deixando composição livre. A consistência que importa é a que o usuário percebe: espaçamento, cor, tipografia e comportamento. Padronizar estrutura de pasta rende discussão e nenhum ganho para quem usa.",
+            },
+            {
+                frente: "Como você lidaria com um componente crítico que só uma pessoa entende?",
+                verso: "Documentando junto com ela, revisando em par as próximas mudanças e cobrindo com teste de comportamento. É risco de operação, não questão de organização. O teste é simples: essa pessoa consegue tirar férias sem o time travar?",
+            },
+            {
+                frente: "Como você trataria erro que o usuário vê mas não reporta?",
+                verso: "Instrumentando erro de renderização e falha de requisição com contexto suficiente, e olhando por rota e por versão. A maioria dos usuários abandona em silêncio. Sem telemetria, o time acredita que está tudo bem porque ninguém reclamou.",
+            },
+            {
+                frente: "Como você decidiria entre corrigir na interface e corrigir na origem do dado?",
+                verso: "Perguntando quantos consumidores existem. Se são vários, remendar em cada um multiplica a divergência, e a correção certa é na origem. Remendo na tela é aceitável como medida temporária, desde que registrado com prazo.",
+            },
+            {
+                frente: "Como você avaliaria adotar TypeScript num front que ainda não usa?",
+                verso: "Ligando por arquivo, começando pelas bordas e pelos módulos compartilhados, com regras estritas chegando aos poucos. O ganho aparece cedo em contrato de API e props. Tentar converter tudo de uma vez produz um mar de tipos frouxos que não protegem nada.",
+            },
+            {
+                frente: "Como você lidaria com o front dependendo de dados que chegam por várias fontes?",
+                verso: "Definindo uma fonte da verdade por informação e um lugar para reconciliar, em vez de cada componente escolher. Quando cache local, resposta de mutação e evento em tempo real convivem, é preciso decidir quem vence, senão a tela mostra três versões.",
+            },
+            {
+                frente: "Como você faria a transição de um padrão antigo para um novo sem parar o produto?",
+                verso: "Deixando os dois conviverem com fronteira clara, escrevendo o novo só a partir de agora e migrando o antigo quando a tela for mexida. Mutirão de migração compete com entrega e sempre perde. O que não pode é ficar sem data e sem responsável.",
+            },
+            {
+                frente: "Como você trataria uma tela que carrega rápido mas parece lenta?",
+                verso: "Olhando o que acontece entre pintar e responder: hidratação longa, fonte que troca, imagem que empurra o layout e interação que trava. Percepção é sobre estabilidade e retorno imediato, e não sobre o número total de milissegundos.",
+            },
+            {
+                frente: "Como você definiria quem é dono de cada parte do front?",
+                verso: "Por domínio de produto, com dono declarado no repositório e revisão obrigatória do dono no que é sensível. Código sem dono acumula remendo de gente de passagem, e no incidente ninguém sabe quem chamar.",
+            },
+            {
+                frente: "Como você decidiria o que renderizar no servidor numa aplicação já em produção?",
+                verso: "Pelas rotas onde a primeira pintura e a indexação importam, medindo antes e depois. Rota atrás de login com muita interação raramente ganha. Migrar tudo por coerência custa infraestrutura e uma classe nova de bug, sem melhorar o que o usuário sente.",
+            },
+            {
+                frente: "Como você lidaria com um time que evita escrever teste de front?",
+                verso: "Entendendo o motivo antes de cobrar: costuma ser teste frágil que já frustrou, ou componente difícil de testar. Começar pelo bug recém corrigido, com teste de comportamento que falha antes, mostra valor rápido. Meta de cobertura imposta produz teste sem asserção.",
+            },
+            {
+                frente: "Como você reduziria o risco de uma entrega grande de interface?",
+                verso: "Colocando em produção desligada atrás de uma chave desde cedo, integrando toda semana e liberando para uma fatia de usuários. Entrega de três meses que vai ao ar de uma vez concentra o risco na pior noite possível.",
+            },
+        ],
+    },
+};

--- a/backend/scripts/data/entrevista/system-design.ts
+++ b/backend/scripts/data/entrevista/system-design.ts
@@ -1,0 +1,1147 @@
+import type { TopicoDeEntrevista } from "../../seed-entrevista.ts";
+
+/**
+ * Perguntas de entrevista de System Design.
+ *
+ * O nível segue o que a pergunta cobra, e não o assunto. Cache aparece nos quatro
+ * níveis: em estágio é o que ele é e onde fica, em sênior é decidir com o produto
+ * quanto dado velho o negócio aceita e quem paga quando ele aparece.
+ *
+ * Complementa a trilha avulsa de System Design sem repetir o texto das aulas: lá o
+ * conteúdo ensina o mecanismo, aqui a pergunta cobra o raciocínio em voz alta.
+ */
+export const systemDesign: TopicoDeEntrevista = {
+    slug: "system-design",
+    nome: "System Design",
+    position: 10,
+    perguntas: {
+        estagio: [
+            {
+                frente: "O que é System Design, e o que ele não é?",
+                verso: "É decidir como as peças de um sistema se organizam para atender requisitos de escala, disponibilidade e custo: onde o dado mora, como as partes conversam e o que acontece quando algo falha. Não é desenho de tela, e não é escolher framework.",
+            },
+            {
+                frente: "Por que perguntar requisitos antes de começar a desenhar?",
+                verso: "Porque o mesmo produto pede desenhos opostos conforme o volume, a tolerância a atraso e o que não pode falhar. Desenhar sem perguntar é resolver outro problema. Na entrevista, pular essa etapa é um dos motivos mais comuns de reprovação.",
+            },
+            {
+                frente: "Qual a diferença entre requisito funcional e não funcional?",
+                verso: "O funcional diz o que o sistema faz, como encurtar uma URL e redirecionar. O não funcional diz como ele precisa se comportar: quanto tráfego aguenta, em quanto tempo responde e quanto pode ficar fora do ar. É o segundo tipo que define a arquitetura.",
+            },
+            {
+                frente: "O que significa escalar verticalmente e horizontalmente?",
+                verso: "Vertical é pôr mais CPU e memória na mesma máquina, simples e com teto. Horizontal é acrescentar máquinas e dividir o trabalho entre elas, o que exige que a aplicação não guarde estado em cada uma. Quase todo sistema começa vertical e cresce horizontal.",
+            },
+            {
+                frente: "Qual a diferença entre latência e vazão?",
+                verso: "Latência é quanto tempo uma requisição leva. Vazão é quantas requisições o sistema atende por segundo. Uma não garante a outra: agrupar trabalho aumenta a vazão e piora a latência de cada item, e é por isso que as duas precisam de meta própria.",
+            },
+            {
+                frente: "O que é disponibilidade, e como ela é medida?",
+                verso: "É a fração do tempo em que o sistema atende corretamente, normalmente expressa em porcentagem. Ela se mede pelo que o usuário sente, como requisições bem-sucedidas, e não pelo processo estar de pé. Servidor ligado devolvendo erro não está disponível.",
+            },
+            {
+                frente: "O que significa ter três noves de disponibilidade?",
+                verso: "Estar disponível 99,9% do tempo, o que permite perto de 43 minutos de falha por mês. Cada nove a mais divide esse tempo por dez e multiplica o custo, porque exige redundância, automação de recuperação e gente sabendo operar tudo isso.",
+            },
+            {
+                frente: "Qual a diferença entre SLA e SLO?",
+                verso: "O SLO é a meta interna de confiabilidade que o time persegue. O SLA é o compromisso com o cliente, normalmente com multa. O SLA fica mais frouxo que o SLO de propósito, para existir margem de erro antes de o descumprimento virar custo.",
+            },
+            {
+                frente: "O que é um ponto único de falha?",
+                verso: "Um componente cuja queda derruba o sistema inteiro, como um banco sem réplica ou um balanceador sozinho. Achar esses pontos é uma das primeiras coisas a fazer num desenho. Nem todo precisa ser eliminado, mas todo precisa ser uma escolha consciente.",
+            },
+            {
+                frente: "O que é redundância, e o que ela não resolve sozinha?",
+                verso: "É ter mais de uma cópia de um componente para o sistema seguir quando uma falha. Ela não resolve se as cópias falham juntas, como duas instâncias na mesma zona, nem se o erro é de dado, porque réplica copia o dado errado com a mesma eficiência.",
+            },
+            {
+                frente: "O que acontece, em linhas gerais, quando alguém acessa um site?",
+                verso: "O navegador descobre o endereço pelo DNS, abre uma conexão, negocia a criptografia e envia a requisição HTTP. Ela costuma passar por CDN, balanceador e servidor de aplicação, que consulta cache e banco antes de responder. Cada salto soma latência e é um ponto de falha.",
+            },
+            {
+                frente: "O que o DNS resolve?",
+                verso: "Traduz um nome, como o domínio do site, no endereço de rede de um servidor. Como a resposta fica em cache por um tempo definido, trocar um endereço não é instantâneo. Também pode ser usado para distribuir tráfego entre regiões, com a limitação desse cache.",
+            },
+            {
+                frente: "O que é uma CDN, e que problema ela resolve?",
+                verso: "Uma rede de servidores espalhados que guarda cópia do conteúdo perto do usuário. Resolve a distância física, que nenhum código otimiza, e tira carga da origem. Serve muito bem para arquivo estático, e com cuidado para resposta dinâmica que pode ficar em cache.",
+            },
+            {
+                frente: "O que um balanceador de carga faz?",
+                verso: "Distribui as requisições entre várias instâncias e deixa de enviar para as que não respondem. É o que permite escalar horizontalmente e trocar máquina sem o usuário perceber. Ele próprio precisa ser redundante, senão vira o novo ponto único de falha.",
+            },
+            {
+                frente: "O que é um proxy reverso?",
+                verso: "Um servidor na frente da aplicação que recebe as requisições e repassa. Ele concentra criptografia, compressão, cache e limite de requisições num lugar só, e esconde a estrutura interna. Balanceador de carga costuma ser um proxy reverso com essa função a mais.",
+            },
+            {
+                frente: "O que é um API gateway?",
+                verso: "A porta de entrada única para vários serviços, que cuida de roteamento, autenticação, limite de requisições e versão. Tira essas preocupações de cada serviço. O risco é virar um lugar onde regra de negócio se acumula e todo time depende dele para publicar.",
+            },
+            {
+                frente: "Por que um servidor sem estado facilita escalar?",
+                verso: "Porque qualquer instância consegue atender qualquer requisição, então dá para acrescentar e remover máquinas à vontade. O estado não some: ele vai para banco, cache ou armazenamento compartilhado. Sessão guardada na memória do servidor é o que impede isso.",
+            },
+            {
+                frente: "Onde pode ficar a sessão do usuário num sistema com vários servidores?",
+                verso: "Num armazenamento compartilhado, como um cache distribuído, ou no próprio cliente, num token assinado. Na memória de um servidor só funciona enquanto existe um servidor. A escolha troca facilidade de revogar a sessão por dispensar a consulta a cada requisição.",
+            },
+            {
+                frente: "O que é um cache, e onde ele pode ficar?",
+                verso: "Uma cópia de dado guardada num lugar mais rápido para evitar refazer trabalho. Pode ficar no navegador, na CDN, na memória da aplicação, num cache distribuído ou no próprio banco. Cada camada acelera um trecho e acrescenta a chance de servir dado velho.",
+            },
+            {
+                frente: "O que é o TTL de um cache?",
+                verso: "O tempo de vida de uma entrada antes de ela ser descartada e buscada de novo. TTL curto mantém o dado mais fresco e alivia menos a origem; TTL longo alivia mais e aceita dado velho por mais tempo. A escolha depende de quanto atraso o negócio tolera.",
+            },
+            {
+                frente: "Quando um banco relacional serve bem?",
+                verso: "Quando o dado tem relações claras, a consistência importa e as consultas variam, como pedido, pagamento e estoque. Transação, restrição de integridade e SQL resolvem muita coisa que em outro modelo vira código. É o ponto de partida razoável para quase todo sistema.",
+            },
+            {
+                frente: "Quando um banco não relacional faz sentido?",
+                verso: "Quando o formato de acesso é simples e conhecido, o volume é enorme ou o dado não tem estrutura fixa, como sessão, evento e catálogo flexível. Ele troca consulta variada e transação ampla por escala e flexibilidade. Escolher por moda costuma sair caro depois.",
+            },
+            {
+                frente: "O que é um índice num banco de dados?",
+                verso: "Uma estrutura extra que permite achar linhas sem ler a tabela inteira, como o índice remissivo de um livro. Acelera muito a leitura e cobra em cada escrita, que precisa atualizá-lo, e em espaço. Índice certo é o que acompanha as consultas reais.",
+            },
+            {
+                frente: "O que é replicação de banco de dados?",
+                verso: "Manter cópias do banco em outras máquinas, normalmente com uma recebendo escrita e as outras seguindo. Serve para aguentar mais leitura e para ter para onde ir se a principal cair. A réplica costuma ficar um pouco atrasada, e isso aparece para o usuário.",
+            },
+            {
+                frente: "Por que replicação não substitui backup?",
+                verso: "Porque a réplica copia tudo, inclusive o erro: uma tabela apagada por engano some das réplicas em segundos. Backup é uma fotografia de um momento anterior, guardada à parte. Backup que nunca foi restaurado em teste é só uma esperança.",
+            },
+            {
+                frente: "O que é armazenamento de objetos?",
+                verso: "Um serviço para guardar arquivos inteiros acessados por chave, como imagem, vídeo e backup, com durabilidade alta e custo baixo. Não é sistema de arquivos nem banco: não se altera um pedaço do arquivo. É onde vão os arquivos enviados pelos usuários.",
+            },
+            {
+                frente: "Onde você guardaria os arquivos enviados pelos usuários?",
+                verso: "No armazenamento de objetos, com o banco guardando só a referência e os metadados. Guardar no disco do servidor impede escalar e perde tudo junto com a máquina; guardar dentro do banco incha backup e replicação sem ganho nenhum.",
+            },
+            {
+                frente: "O que é uma fila de mensagens?",
+                verso: "Um intermediário onde um produtor deixa trabalho e um consumidor pega quando puder. Ela desacopla o ritmo dos dois lados, absorve picos e permite reprocessar quando algo falha. O custo é o trabalho deixar de ser imediato e passar a exigir tratamento de repetição.",
+            },
+            {
+                frente: "Qual a diferença entre comunicação síncrona e assíncrona entre serviços?",
+                verso: "Na síncrona quem chama espera a resposta, então a falha e a lentidão do outro lado viram suas. Na assíncrona a mensagem é entregue e cada lado segue no seu ritmo. A síncrona é mais simples de entender; a assíncrona aguenta melhor pico e queda parcial.",
+            },
+            {
+                frente: "O que é publicar e assinar?",
+                verso: "Um modelo em que quem produz um evento publica num tópico sem saber quem vai consumir, e cada interessado assina e recebe a sua cópia. Permite acrescentar consumidores sem mexer no produtor. A conta chega em rastrear o que acontece depois de um evento.",
+            },
+            {
+                frente: "O que é um webhook?",
+                verso: "Uma chamada HTTP que um sistema faz para outro quando algo acontece, em vez de o outro ficar perguntando. É comum em pagamento e integração. Quem recebe precisa verificar a origem, responder rápido e tolerar a mesma notificação chegando mais de uma vez.",
+            },
+            {
+                frente: "O que é polling, e qual o custo dele?",
+                verso: "É o cliente perguntar de tempos em tempos se há novidade. É simples e funciona em qualquer lugar, mas gasta requisição quando nada mudou e ainda entrega com atraso de até um intervalo. Com muitos clientes, o custo de perguntar à toa domina.",
+            },
+            {
+                frente: "Quando usar WebSocket em vez de requisições comuns?",
+                verso: "Quando o servidor precisa enviar dados ao cliente com frequência e com pouco atraso, como chat e placar ao vivo. A conexão fica aberta nos dois sentidos. O custo é manter muitas conexões abertas e cuidar de reconexão e de escalar entre servidores.",
+            },
+            {
+                frente: "O que um contrato de API define?",
+                verso: "Os recursos, os formatos de entrada e saída, os códigos de erro e o que muda de versão para versão. É o que permite dois times trabalharem em paralelo. Contrato combinado por conversa diverge, e a diferença aparece na integração.",
+            },
+            {
+                frente: "Por que os códigos de status HTTP importam para quem integra?",
+                verso: "Porque é por eles que o cliente decide o que fazer: repetir, corrigir a requisição ou desistir. Devolver sucesso com uma mensagem de erro no corpo obriga cada consumidor a inventar a própria checagem, e o erro passa despercebido em monitoramento.",
+            },
+            {
+                frente: "Por que uma API de listagem precisa de paginação?",
+                verso: "Porque a tabela cresce e uma resposta com tudo pesa na memória do servidor, na rede e no cliente. A rota que devolve tudo funciona por meses e derruba o sistema no dia em que os dados crescem. Paginar desde o começo custa quase nada.",
+            },
+            {
+                frente: "O que é limite de requisições, e por que ele existe?",
+                verso: "É restringir quantas requisições um cliente faz num intervalo. Protege o sistema de abuso, de erro de integração em laço e de um cliente consumir a capacidade dos outros. A resposta precisa dizer quando tentar de novo, senão o cliente insiste e piora.",
+            },
+            {
+                frente: "Por que toda chamada a outro serviço precisa de timeout?",
+                verso: "Porque sem ele uma chamada presa segura thread e conexão indefinidamente, e poucas dessas esgotam o serviço inteiro. Com timeout, a lentidão do outro vira um erro controlado que você decide como tratar. É a proteção mais barata de todas.",
+            },
+            {
+                frente: "Quando repetir uma chamada que falhou ajuda, e quando atrapalha?",
+                verso: "Ajuda em falha passageira, como uma instância reiniciando. Atrapalha quando a operação não pode ser repetida sem efeito duplicado, e quando todos repetem ao mesmo tempo durante uma queda, o que multiplica a carga sobre quem está tentando se recuperar.",
+            },
+            {
+                frente: "O que é idempotência, em uma frase?",
+                verso: "É poder executar a mesma operação várias vezes com o mesmo resultado de executar uma vez só. Importa porque em rede a repetição acontece sozinha: cliente reenvia, proxy repete, usuário clica duas vezes. Sem ela, uma cobrança pode sair em dobro.",
+            },
+            {
+                frente: "Qual a diferença entre consistência forte e consistência eventual?",
+                verso: "Na forte, toda leitura enxerga a última escrita confirmada. Na eventual, as cópias convergem com o tempo, e por um intervalo uma leitura pode trazer valor antigo. A forte custa latência e disponibilidade; a eventual exige que o produto aceite esse atraso.",
+            },
+            {
+                frente: "O que o teorema CAP diz, em linhas gerais?",
+                verso: "Que durante uma partição de rede um sistema distribuído precisa escolher entre responder com dado possivelmente desatualizado ou recusar para manter consistência. Não é escolher dois de três no dia a dia: a escolha só é forçada quando a rede se parte.",
+            },
+            {
+                frente: "O que é particionar dados, na ideia?",
+                verso: "Dividir um conjunto grande em pedaços guardados em máquinas diferentes, com uma chave decidindo onde cada registro fica. Resolve o limite de uma máquina só. O custo é consulta que atravessa partições, rebalanceamento e a escolha da chave, que é difícil de desfazer.",
+            },
+            {
+                frente: "Onde o hashing aparece num sistema distribuído?",
+                verso: "Para decidir em qual partição ou servidor um dado fica, para detectar arquivo repetido, para verificar integridade e para gerar identificador curto. A propriedade que interessa é espalhar bem e ser determinístico: a mesma entrada cai sempre no mesmo lugar.",
+            },
+            {
+                frente: "Por que um identificador sequencial do banco pode virar problema?",
+                verso: "Porque ele depende de um ponto central que gera o próximo número, o que atrapalha com vários bancos ou partições. Também expõe volume e permite adivinhar identificadores vizinhos. Em sistema distribuído se usa identificador gerado sem coordenação.",
+            },
+            {
+                frente: "Qual a diferença entre autenticação e autorização?",
+                verso: "Autenticação é provar quem você é. Autorização é decidir o que você pode fazer. Confundir as duas produz o erro clássico de verificar que o usuário está logado e esquecer de verificar se aquele recurso é dele.",
+            },
+            {
+                frente: "Por que todo tráfego deveria usar HTTPS?",
+                verso: "Porque sem criptografia qualquer ponto no caminho lê e altera o que passa, inclusive senha e token. Também garante que o cliente fala com o servidor certo. O custo de desempenho hoje é pequeno, e rede interna também não é confiável por padrão.",
+            },
+            {
+                frente: "O que é um monólito?",
+                verso: "Uma aplicação implantada como uma unidade só, com todas as funcionalidades no mesmo processo. É simples de desenvolver, testar e operar, e escala bem por muito tempo. O problema aparece quando muitos times precisam publicar ao mesmo tempo sem se atrapalhar.",
+            },
+            {
+                frente: "O que é um microsserviço?",
+                verso: "Um serviço pequeno, com responsabilidade própria, dados próprios e publicação independente. Resolve principalmente o problema de muitos times trabalhando em paralelo. Cobra em rede, falha parcial, observabilidade e coordenação de contrato.",
+            },
+            {
+                frente: "O que é uma arquitetura em camadas?",
+                verso: "Separar o sistema em níveis com responsabilidades distintas, como apresentação, regra de negócio e acesso a dados, com a dependência seguindo um sentido só. Facilita trocar e testar cada parte. Camada demais vira código que só repassa chamada.",
+            },
+            {
+                frente: "O que é uma verificação de saúde?",
+                verso: "Um ponto que o orquestrador ou o balanceador consulta para saber se a instância pode receber tráfego. A de vivacidade diz se o processo travou; a de prontidão diz se ele consegue atender. Checagem que só devolve OK sem olhar nada não prova coisa alguma.",
+            },
+            {
+                frente: "O que é escalonamento automático?",
+                verso: "Acrescentar ou remover instâncias conforme uma métrica, como uso de CPU ou tamanho de fila. Economiza fora do pico e absorve crescimento. Ele não é instantâneo, porque subir instância leva tempo, então pico repentino ainda precisa de folga ou de fila.",
+            },
+            {
+                frente: "O que são região e zona de disponibilidade na nuvem?",
+                verso: "Região é uma localização geográfica com vários centros de dados. Zona é um desses centros, isolado dos outros em energia e rede. Espalhar instâncias por zonas protege de falha de um prédio; sobreviver à queda de uma região inteira exige muito mais.",
+            },
+            {
+                frente: "Por que a distância física importa para a latência?",
+                verso: "Porque a luz na fibra tem velocidade finita, e ir de um continente a outro custa dezenas de milissegundos em cada sentido, sem contar os saltos. Nenhuma otimização de código resolve isso. É por isso que existem CDN e réplicas perto do usuário.",
+            },
+            {
+                frente: "O que é uma estimativa de capacidade numa entrevista?",
+                verso: "Uma conta aproximada de volume, armazenamento, banda e memória a partir de poucas premissas ditas em voz alta. O objetivo não é acertar o número, e sim descobrir a ordem de grandeza que decide o desenho, como caber numa máquina ou não.",
+            },
+            {
+                frente: "Como você estima requisições por segundo a partir de usuários diários?",
+                verso: "Multiplicando usuários ativos por ações por usuário e dividindo pelos segundos do dia, perto de cem mil. Depois aplicando um fator de pico, porque o tráfego não é uniforme. Arredondar sem medo é parte do método: o que importa é a ordem de grandeza.",
+            },
+            {
+                frente: "Por que dimensionar pela média do tráfego falha?",
+                verso: "Porque o sistema cai no pico, e não na média. Tráfego se concentra em horários, dias e eventos, e o pico costuma ser várias vezes a média. Dimensionar pela média garante que o sistema funciona justamente nos momentos em que ninguém está usando.",
+            },
+            {
+                frente: "Por que se trabalha com ordem de grandeza nas estimativas?",
+                verso: "Porque a decisão de desenho muda por fator de dez, e não por vinte por cento. Saber se são cem ou cem mil requisições por segundo decide se um banco basta ou se é preciso particionar. Precisão maior que isso gasta tempo sem mudar a resposta.",
+            },
+            {
+                frente: "O que é um sistema de leitura intensiva, e por que isso muda o desenho?",
+                verso: "Um sistema em que se lê muito mais do que se escreve, como um catálogo ou uma rede social. Isso favorece cache, réplicas de leitura e dado pré-calculado. Num sistema de escrita intensiva, como coleta de métricas, a prioridade vira gravar rápido e em lote.",
+            },
+            {
+                frente: "O que é degradação graciosa?",
+                verso: "O sistema continuar oferecendo o essencial quando uma parte falha, em vez de cair inteiro. Uma loja que perde as recomendações ainda vende; uma que trava a página por causa delas não. Exige decidir antes o que é essencial e o que pode sumir.",
+            },
+            {
+                frente: "O que são logs, e para que eles servem numa investigação?",
+                verso: "Registros de eventos com horário e contexto, gravados pelo sistema enquanto roda. Servem para reconstruir o que aconteceu com uma requisição específica. Sem um identificador que ligue as linhas de uma mesma requisição, a investigação vira adivinhação.",
+            },
+            {
+                frente: "O que você monitoraria primeiro num sistema novo?",
+                verso: "O que o usuário sente: taxa de erro, latência e volume de requisições, mais a saturação dos recursos principais. Isso responde se está funcionando e se está perto do limite. Métrica interna detalhada vem depois, quando se sabe o que investigar.",
+            },
+            {
+                frente: "O que é uma tarefa agendada, e que cuidado ela exige?",
+                verso: "Um trabalho que roda num horário, como gerar relatório ou limpar dados antigos. Com várias instâncias, ele roda em todas se ninguém coordenar. E precisa poder rodar de novo sem estrago, porque algum dia vai falhar no meio ou executar duas vezes.",
+            },
+            {
+                frente: "O que é versionar uma API?",
+                verso: "Manter versões diferentes do contrato para mudar sem quebrar quem já usa. O melhor versionamento é o que quase nunca é preciso: acrescentar campo sem mudar significado dispensa versão nova. Versão nova exige prazo para desligar a antiga.",
+            },
+            {
+                frente: "Por que um contador de visualizações é mais difícil do que parece?",
+                verso: "Porque somar um no banco a cada acesso gera escrita demais e disputa pela mesma linha em página popular. As saídas são acumular em memória e gravar em lote, ou aceitar contagem aproximada. A pergunta real é quanto atraso e quanta imprecisão o produto aceita.",
+            },
+            {
+                frente: "O que é compressão na rede, e quando ela ajuda?",
+                verso: "Reduzir o tamanho do que trafega, trocando CPU por banda. Ajuda muito em texto, como HTML e JSON, e quase nada em imagem e vídeo, que já vêm comprimidos. Em conexão lenta, a economia de banda costuma valer bem mais que o custo de processar.",
+            },
+            {
+                frente: "Por que banda é um custo que precisa entrar na estimativa?",
+                verso: "Porque tráfego de saída da nuvem é cobrado e cresce com cada usuário, principalmente com vídeo e imagem. Um sistema pode caber tranquilo em servidores e ficar caro em transferência. É um dos motivos de CDN e de servir arquivos em tamanhos adequados.",
+            },
+            {
+                frente: "O que é um deploy, e por que ele é um momento de risco?",
+                verso: "É colocar uma versão nova em produção. É quando a maior parte dos incidentes começa, porque código e configuração mudam de uma vez. Por isso se publica em partes pequenas, aos poucos e com forma rápida de voltar para a versão anterior.",
+            },
+            {
+                frente: "O que é um token de acesso?",
+                verso: "Uma credencial que o cliente apresenta a cada requisição depois de autenticado, em vez de mandar a senha. Pode ser opaco, consultado no servidor, ou autocontido e assinado. Precisa expirar, e o autocontido é difícil de revogar antes do prazo.",
+            },
+            {
+                frente: "O que é consistência eventual do ponto de vista do usuário?",
+                verso: "É postar um comentário e, por alguns segundos, uma outra tela ainda não mostrar. Na maioria dos produtos isso é aceitável se a pessoa enxerga a própria ação na hora. O desenho precisa decidir onde esse atraso é tolerável e onde ele vira reclamação.",
+            },
+        ],
+        junior: [
+            {
+                frente: "Como você conduziria os primeiros minutos de uma entrevista de design?",
+                verso: "Perguntando o que o sistema precisa fazer, para quantos usuários, com que tolerância a atraso e o que não pode falhar, e escrevendo as respostas. Depois uma estimativa rápida e um desenho de alto nível. Só então aprofundar a parte que o entrevistador achar mais interessante.",
+            },
+            {
+                frente: "Como você transformaria um requisito vago em números?",
+                verso: "Assumindo valores razoáveis em voz alta e pedindo confirmação: usuários ativos por dia, ações por usuário, tamanho de cada registro, proporção entre leitura e escrita. Um número combinado, mesmo aproximado, vale mais que um adjetivo como grande ou rápido.",
+            },
+            {
+                frente: "Como você estimaria o armazenamento de um serviço de fotos?",
+                verso: "Fotos enviadas por dia vezes o tamanho médio, somando as versões redimensionadas, vezes os dias de retenção e o fator de réplica. Os metadados entram à parte, e costumam ser pequenos perto das imagens. A conta mostra logo que as fotos vão para armazenamento de objetos.",
+            },
+            {
+                frente: "Como você estimaria a memória necessária para um cache?",
+                verso: "Pela regra de que uma pequena fração dos itens recebe a maior parte dos acessos: estimar quantos itens são quentes, multiplicar pelo tamanho de cada um e somar a sobrecarga da estrutura. Cachear tudo raramente é necessário e quase nunca cabe.",
+            },
+            {
+                frente: "Como funciona o padrão em que a aplicação consulta o cache antes do banco?",
+                verso: "A aplicação procura no cache; se não encontra, lê do banco e grava no cache para as próximas. É o padrão mais comum e simples. O custo é a primeira leitura depois de expirar ser lenta, e a janela em que o banco já mudou e o cache ainda não.",
+            },
+            {
+                frente: "Qual a diferença entre atualizar o cache junto com o banco e depois dele?",
+                verso: "Atualizando junto, o cache fica coerente e cada escrita paga duas gravações. Gravando só no cache e persistindo depois em lote, a escrita fica rapidíssima e um problema no cache perde dado ainda não gravado. A segunda só serve onde perder um pouco é aceitável.",
+            },
+            {
+                frente: "Por que invalidar cache é difícil?",
+                verso: "Porque o mesmo dado aparece em várias chaves, a escrita e a invalidação não acontecem no mesmo instante, e duas requisições concorrentes podem regravar o valor antigo depois da limpeza. É por isso que TTL costuma ser a rede de segurança mesmo com invalidação explícita.",
+            },
+            {
+                frente: "Como você invalidaria o cache depois de uma escrita?",
+                verso: "Apagando a chave depois de gravar no banco, em vez de tentar atualizar o valor, e mantendo um TTL como garantia. Apagar força a próxima leitura a buscar o dado certo. Atualizar o cache com o valor novo é onde a corrida entre escritas deixa o antigo vencer.",
+            },
+            {
+                frente: "O que é uma política de despejo como LRU?",
+                verso: "A regra que decide o que sai quando o cache enche. LRU remove o item usado há mais tempo, apostando que o recente volta a ser pedido. Funciona bem para acesso com popularidade que muda; para popularidade estável, contar frequência pode acertar mais.",
+            },
+            {
+                frente: "Quando ler de uma réplica causa problema para o usuário?",
+                verso: "Quando a réplica está atrasada e a pessoa não encontra o que acabou de salvar, ou vê um valor voltar ao anterior ao recarregar. Para tela de listagem geral isso quase nunca incomoda. Para o próprio perfil logo depois de editar, incomoda sempre.",
+            },
+            {
+                frente: "Como você garantiria que o usuário veja o que acabou de escrever?",
+                verso: "Lendo da principal por um curto período depois de uma escrita daquele usuário, ou lendo da principal tudo que é dele. Outra saída é o cliente guardar a versão escrita e exigir uma réplica pelo menos tão atualizada. O resto das leituras continua nas réplicas.",
+            },
+            {
+                frente: "Qual a diferença entre replicação síncrona e assíncrona?",
+                verso: "Na síncrona a escrita só confirma depois de a réplica gravar, então nada se perde se a principal cair, e cada escrita fica mais lenta. Na assíncrona a confirmação é imediata e a réplica segue depois, o que é rápido e pode perder as últimas escritas numa falha.",
+            },
+            {
+                frente: "O que pode dar errado quando o banco principal cai e uma réplica assume?",
+                verso: "Perder escritas que ainda não tinham chegado à réplica, a antiga principal voltar achando que ainda manda e as duas aceitarem escrita, e clientes continuarem apontando para o endereço velho. Troca automática precisa de proteção contra duas principais ao mesmo tempo.",
+            },
+            {
+                frente: "Como você escolheria entre banco relacional e não relacional num caso concreto?",
+                verso: "Olhando as consultas que o sistema precisa fazer e as garantias exigidas. Consulta variada, relação entre entidades e transação apontam para relacional. Acesso sempre pela mesma chave, volume enorme e formato flexível apontam para não relacional. Na dúvida, relacional.",
+            },
+            {
+                frente: "Quando desnormalizar dados compensa?",
+                verso: "Quando uma leitura muito frequente paga junção cara e o dado repetido muda pouco, como o nome do autor guardado junto do post. O custo é manter as cópias coerentes a cada mudança. Desnormalizar sem medir a leitura só troca um problema por outro.",
+            },
+            {
+                frente: "Como a ordem das colunas importa num índice composto?",
+                verso: "O índice é ordenado pela primeira coluna, depois pela segunda dentro dela, e assim por diante. Ele serve para filtros que começam pela primeira coluna, e não para quem filtra só pela segunda. Colocar primeiro a coluna de igualdade e depois a de intervalo costuma render mais.",
+            },
+            {
+                frente: "Por que índice demais atrapalha a escrita?",
+                verso: "Porque cada inserção e cada alteração precisa atualizar todos os índices da tabela, o que multiplica o trabalho e o espaço. Índice que nenhuma consulta usa é custo puro. Vale revisar periodicamente quais índices são de fato lidos.",
+            },
+            {
+                frente: "Por que paginação por cursor escala melhor que por deslocamento?",
+                verso: "Porque com deslocamento o banco percorre e descarta todas as linhas anteriores, e a página cem fica muito mais lenta que a primeira. Com cursor ele parte do último item visto pelo índice. Também evita pular ou repetir item quando algo é inserido no meio.",
+            },
+            {
+                frente: "Como você implementaria um limitador de requisições simples?",
+                verso: "Com um contador por cliente num armazenamento compartilhado, somado a cada requisição e expirando no fim da janela, recusando quando passar do limite. Com várias instâncias, o contador precisa ser compartilhado, senão o limite real vira o limite vezes o número de servidores.",
+            },
+            {
+                frente: "Qual a diferença entre balde de fichas e janela fixa num limitador?",
+                verso: "A janela fixa conta requisições por intervalo e permite o dobro do limite na virada entre duas janelas. O balde de fichas repõe fichas num ritmo constante e permite rajada até a capacidade do balde. O balde controla melhor o ritmo e ainda tolera pico curto.",
+            },
+            {
+                frente: "Onde você colocaria o limitador de requisições?",
+                verso: "Na borda, no gateway ou no proxy, para barrar abuso antes de gastar recurso, e com limite por identidade autenticada quando possível. Limite só por endereço de rede pune quem compartilha rede e é contornado trocando de endereço.",
+            },
+            {
+                frente: "Como você geraria identificadores únicos em vários servidores?",
+                verso: "Sem coordenação central: identificador aleatório de tamanho suficiente para colisão ser desprezível, ou um formato que combina tempo, identificador da máquina e sequência local. Pedir o próximo número a um serviço central funciona e cria um ponto único de falha.",
+            },
+            {
+                frente: "Qual o custo de usar identificador aleatório como chave primária?",
+                verso: "Ocupa mais espaço que um número e, por ser aleatório, cada inserção cai num ponto diferente do índice, fragmentando e piorando o cache do banco. Em tabela pequena isso não aparece. Em tabela enorme, identificador ordenado no tempo evita o problema.",
+            },
+            {
+                frente: "Como funciona um identificador ordenável no tempo?",
+                verso: "Os bits mais altos guardam o instante da criação, depois vem um identificador da máquina e uma sequência local. Assim ele é único sem coordenação e fica em ordem de criação, o que ajuda o índice. O cuidado é o relógio de uma máquina voltar no tempo.",
+            },
+            {
+                frente: "Quando você usaria uma fila em vez de uma chamada síncrona?",
+                verso: "Quando quem pediu não precisa do resultado na hora, quando o trabalho é demorado ou quando o destino pode ficar indisponível. A fila absorve pico e permite reprocessar. Se o usuário precisa da resposta para seguir, a chamada síncrona continua sendo o certo.",
+            },
+            {
+                frente: "O que a entrega ao menos uma vez exige do consumidor?",
+                verso: "Que ele tolere receber a mesma mensagem mais de uma vez sem repetir o efeito. Isso se resolve com operação idempotente ou com registro das mensagens já processadas. É o padrão da maioria das filas, então duplicata é comportamento esperado, e não exceção.",
+            },
+            {
+                frente: "Para que serve uma fila de mensagens mortas?",
+                verso: "Para onde vai a mensagem que falhou depois de um número de tentativas, guardada com o motivo para análise e reprocessamento. Sem ela, uma mensagem que sempre quebra trava o consumo ou some sem ninguém saber. Ela também precisa de alerta, senão vira um cemitério.",
+            },
+            {
+                frente: "Qual a diferença entre fila e tópico?",
+                verso: "Na fila, cada mensagem é processada por um consumidor só, e vários consumidores dividem o trabalho. No tópico, cada assinante recebe a sua cópia. Fila distribui tarefa; tópico espalha evento para vários interessados.",
+            },
+            {
+                frente: "O que é contrapressão num sistema?",
+                verso: "É o componente sobrecarregado conseguir sinalizar para quem envia que desacelere, em vez de acumular trabalho até cair. Pode ser recusar com erro de sobrecarga, limitar a fila ou pausar o produtor. Sem isso, a lentidão vira falta de memória e queda.",
+            },
+            {
+                frente: "Como você faria novas tentativas sem piorar uma queda?",
+                verso: "Com poucas tentativas, espera crescente entre elas e um sorteio no tempo para os clientes não repetirem juntos. Só para erro passageiro, nunca para erro de validação, e com um orçamento de repetições por serviço. Repetição sem controle multiplica a carga do dependente.",
+            },
+            {
+                frente: "O que é um disjuntor numa chamada entre serviços?",
+                verso: "Um mecanismo que para de chamar um dependente depois de muitas falhas seguidas, devolvendo erro ou resposta de reserva na hora. De tempos em tempos deixa passar uma tentativa para ver se ele voltou. Protege quem chama e dá fôlego para o dependente se recuperar.",
+            },
+            {
+                frente: "O que é um orçamento de latência numa cadeia de chamadas?",
+                verso: "É dividir o tempo total que a requisição pode levar entre os passos que ela percorre, e passar o prazo restante adiante. Assim um serviço no fim da cadeia não continua trabalhando numa resposta que o cliente já desistiu de esperar.",
+            },
+            {
+                frente: "Como você escolheria entre polling, long polling, eventos do servidor e WebSocket?",
+                verso: "Polling para atualização rara e simples. Long polling quando não dá para manter conexão especial. Eventos do servidor para fluxo só do servidor ao cliente, como notificações. WebSocket quando os dois lados enviam com frequência, como chat e jogo.",
+            },
+            {
+                frente: "Como você desenharia um encurtador de URL?",
+                verso: "Uma rota que recebe a URL longa, gera um código e grava a relação, e outra que busca o código e redireciona. A leitura domina de longe, então o redirecionamento passa por cache. A parte interessante é gerar código curto sem colisão e contar cliques sem atrasar.",
+            },
+            {
+                frente: "Como você geraria o código curto de um encurtador?",
+                verso: "Convertendo um identificador único numérico para uma base com letras e números, o que dá códigos curtos e sem colisão. Hash da URL truncado é mais simples e colide, exigindo checagem. Identificador sequencial exposto permite enumerar todos os links.",
+            },
+            {
+                frente: "Redirecionamento permanente ou temporário num encurtador, e por quê?",
+                verso: "O permanente fica em cache no navegador, alivia o servidor e faz os cliques seguintes não passarem por você, então somem das estatísticas. O temporário passa sempre pelo servidor, o que custa mais e permite contar cada clique e mudar o destino.",
+            },
+            {
+                frente: "Como você contaria cliques sem atrasar o redirecionamento?",
+                verso: "Redirecionando imediatamente e publicando o evento de clique numa fila, que um processo separado agrega e grava. O usuário não espera pela escrita da estatística. A contagem fica alguns segundos atrasada, o que é aceitável para esse tipo de número.",
+            },
+            {
+                frente: "Token assinado ou sessão guardada no servidor: qual o trade-off?",
+                verso: "O token assinado dispensa consulta a cada requisição e escala fácil, e é difícil de revogar antes de expirar. A sessão no servidor exige consulta a um armazenamento e pode ser encerrada na hora. É comum combinar token de acesso curto com renovação controlada no servidor.",
+            },
+            {
+                frente: "Como você faria upload de arquivos grandes?",
+                verso: "Com o cliente enviando direto para o armazenamento de objetos por uma URL assinada, em partes que podem ser retomadas, e a API só registrando o resultado. Passar o arquivo pela aplicação ocupa banda e memória do servidor sem entregar nada ao usuário.",
+            },
+            {
+                frente: "Como você serviria imagens em vários tamanhos?",
+                verso: "Gerando as variações depois do upload, de forma assíncrona, ou sob demanda na primeira requisição com o resultado guardado na CDN. O cliente pede o tamanho que precisa. Mandar a imagem original para um celular desperdiça banda e deixa a página lenta.",
+            },
+            {
+                frente: "Como você invalidaria conteúdo numa CDN?",
+                verso: "Preferindo nunca precisar: nome de arquivo com a versão ou o hash do conteúdo, e cache longo. Assim publicar é mudar o nome, e o antigo expira sozinho. Pedir limpeza de cache funciona e demora a propagar, então fica para emergência.",
+            },
+            {
+                frente: "Qual a diferença entre balanceamento na camada de transporte e na de aplicação?",
+                verso: "Na camada de transporte o balanceador repassa conexões sem olhar o conteúdo, o que é rápido e simples. Na de aplicação ele lê a requisição HTTP e pode rotear por caminho, cabeçalho ou cookie, e terminar a criptografia. A segunda é mais flexível e custa mais processamento.",
+            },
+            {
+                frente: "Por que afinidade de sessão no balanceador costuma ser evitada?",
+                verso: "Porque ela prende o usuário a uma instância, então a carga fica desigual, escalar não redistribui quem já está conectado e a queda daquela instância derruba as sessões dela. Na maioria dos casos ela esconde estado que deveria estar num armazenamento compartilhado.",
+            },
+            {
+                frente: "Que estratégias de distribuição um balanceador usa?",
+                verso: "Revezamento simples, menor número de conexões ativas, peso por capacidade e hash de um atributo, como o cliente. Revezamento serve quando as requisições são parecidas. Menos conexões ativas serve quando elas variam muito de duração.",
+            },
+            {
+                frente: "Qual a diferença entre verificação de vivacidade e de prontidão?",
+                verso: "A de vivacidade responde se o processo travou e deve ser reiniciado. A de prontidão responde se ele consegue atender agora e deve receber tráfego. Misturar as duas faz o orquestrador reiniciar uma instância só porque uma dependência oscilou.",
+            },
+            {
+                frente: "Como você publicaria uma versão nova sem derrubar o sistema?",
+                verso: "Trocando instâncias aos poucos, cada nova só recebendo tráfego depois de pronta e cada antiga terminando as requisições em andamento antes de sair. Com canário, uma fatia pequena recebe a versão nova primeiro. E banco compatível com as duas versões durante a troca.",
+            },
+            {
+                frente: "Como uma chave de funcionalidade ajuda no deploy?",
+                verso: "Separa publicar o código de ligar o comportamento. O código vai para produção desligado, é ativado para uma fatia de usuários e desligado na hora se der problema, sem novo deploy. O custo é o caminho duplo no código e chaves que precisam ser removidas depois.",
+            },
+            {
+                frente: "Como você evoluiria uma API sem quebrar os clientes?",
+                verso: "Só acrescentando: campo novo opcional, nunca removendo nem mudando o significado de um existente. Os clientes precisam ignorar o que não conhecem. Quando a quebra é inevitável, uma versão nova convive com a antiga por um prazo anunciado.",
+            },
+            {
+                frente: "Como você enviaria uma notificação para milhões de usuários?",
+                verso: "Separando a decisão do envio: um processo gera as tarefas em lotes numa fila, e trabalhadores enviam respeitando o limite de cada provedor. Com registro do que já foi enviado, para uma falha no meio não reenviar para todo mundo.",
+            },
+            {
+                frente: "Por que busca por texto com curinga no banco não serve para busca de verdade?",
+                verso: "Porque curinga no começo impede o uso do índice e obriga a ler a tabela inteira, e ainda não entende plural, acento, sinônimo nem relevância. Funciona em tabela pequena. Busca de verdade usa um índice invertido, no próprio banco ou num motor de busca.",
+            },
+            {
+                frente: "O que é um índice invertido?",
+                verso: "Uma estrutura que, para cada termo, guarda a lista de documentos em que ele aparece, como o índice remissivo de um livro. Buscar vira cruzar essas listas em vez de ler cada documento. É a base dos motores de busca, junto com a normalização dos termos.",
+            },
+            {
+                frente: "Como você implementaria o autocompletar de uma busca?",
+                verso: "Com uma estrutura de prefixos guardando as consultas mais populares por prefixo já calculadas, servida de memória e atualizada periodicamente. Cada tecla precisa responder em poucas dezenas de milissegundos, então calcular popularidade na hora não serve.",
+            },
+            {
+                frente: "Como você contaria usuários únicos em volume muito alto?",
+                verso: "Com uma estrutura probabilística que estima a quantidade de elementos distintos usando pouca memória fixa, aceitando erro pequeno. Guardar o identificador de cada usuário para contar exatamente custa memória proporcional ao total, e o produto raramente precisa dessa exatidão.",
+            },
+            {
+                frente: "O que é um filtro de Bloom, e onde ele ajuda?",
+                verso: "Uma estrutura compacta que responde se um elemento talvez esteja no conjunto ou certamente não está. Nunca dá falso negativo, pode dar falso positivo. Serve para evitar consulta cara quando a resposta mais comum é não, como checar se uma URL já foi visitada.",
+            },
+            {
+                frente: "Qual a diferença entre métricas, logs e rastros?",
+                verso: "Métricas são números agregados no tempo, baratos e bons para alerta. Logs são eventos individuais com detalhe, bons para investigar um caso. Rastros seguem uma requisição por vários serviços e mostram onde o tempo foi gasto. Cada um responde uma pergunta diferente.",
+            },
+            {
+                frente: "Que métricas você colocaria em qualquer serviço?",
+                verso: "Taxa de requisições, taxa de erros e duração por percentil, que dizem o que o usuário sente, mais a saturação dos recursos principais, como CPU, memória, conexões e fila. Com essas quatro dá para responder se está funcionando e o quanto falta para o limite.",
+            },
+            {
+                frente: "Por que olhar percentil de latência e não a média?",
+                verso: "Porque a média esconde a cauda: com a maioria rápida e uma parcela muito lenta, a média parece boa enquanto um em cada cem usuários espera segundos. E uma página que faz várias chamadas quase sempre esbarra na cauda de alguma delas.",
+            },
+            {
+                frente: "O que é o orçamento de erro, e como ele muda decisões?",
+                verso: "É a falha permitida pelo SLO num período, como os minutos de indisponibilidade aceitos por mês. Enquanto sobra orçamento, o time arrisca publicar mais. Quando acaba, a prioridade vira estabilidade. Transforma a briga entre velocidade e estabilidade numa regra combinada.",
+            },
+            {
+                frente: "Como você evitaria que uma tarefa agendada rode duas vezes?",
+                verso: "Com uma trava compartilhada com dono e validade, adquirida antes de rodar, ou com um agendador que já coordena entre instâncias. E desenhando a tarefa para ser idempotente, porque a trava pode expirar no meio de uma execução lenta.",
+            },
+            {
+                frente: "Como você lidaria com fuso horário num sistema usado em vários países?",
+                verso: "Guardando instantes em UTC, convertendo para o fuso do usuário só na apresentação e guardando o fuso quando a regra depende dele, como um lembrete às nove da manhã local. Horário de verão e mudança de fuso por lei são o que quebra conversão feita na mão.",
+            },
+            {
+                frente: "Onde você guardaria contadores atualizados o tempo todo?",
+                verso: "Num armazenamento em memória com incremento atômico, gravando no banco em lote de tempos em tempos. Incrementar direto no banco a cada evento gera disputa pela mesma linha. O risco é perder o intervalo não gravado numa falha, o que precisa ser aceitável.",
+            },
+            {
+                frente: "Como você processaria um arquivo logo depois do upload?",
+                verso: "Com o armazenamento avisando que o arquivo chegou, uma mensagem numa fila e trabalhadores processando e registrando o resultado. O usuário vê o estado em processamento. Processar dentro da requisição de upload prende a conexão e perde tudo se o servidor reiniciar.",
+            },
+            {
+                frente: "Quando um intermediário de conexões com o banco ajuda?",
+                verso: "Quando há muitas instâncias ou funções abrindo conexão e o banco não aguenta tantas, porque cada conexão custa memória nele. O intermediário mantém um conjunto pequeno e reaproveita entre clientes. É comum com funções sem servidor e com escalonamento agressivo.",
+            },
+            {
+                frente: "Como você aliviaria uma consulta cara feita por muitos usuários?",
+                verso: "Primeiro otimizando a consulta com índice e plano. Se continuar cara e o resultado puder ficar um pouco velho, guardando o resultado pronto num cache ou numa tabela pré-calculada atualizada de tempos em tempos. Calcular a mesma coisa mil vezes por minuto é desperdício.",
+            },
+            {
+                frente: "O que é uma visão materializada, e quando ela ajuda?",
+                verso: "O resultado de uma consulta guardado como tabela e atualizado periodicamente ou por evento. Ajuda em relatório e painel com agregação pesada lida muitas vezes. O custo é o dado ficar tão atrasado quanto o intervalo de atualização, e a atualização em si pesar.",
+            },
+            {
+                frente: "Como você guardaria o histórico de alterações de um registro?",
+                verso: "Numa tabela de histórico com a versão anterior, quem alterou e quando, gravada na mesma transação da alteração. Assim não existe alteração sem registro. Guardar só o estado atual e tentar reconstruir o passado por log de aplicação não funciona na hora de uma auditoria.",
+            },
+            {
+                frente: "Como você desenharia a exclusão dos dados de um usuário?",
+                verso: "Mapeando todos os lugares onde o dado vive, inclusive cache, busca, backup e sistemas parceiros, e executando a exclusão por um processo assíncrono rastreável. Apagar a linha principal e esquecer as cópias é o erro mais comum, e é o que aparece numa auditoria.",
+            },
+            {
+                frente: "Como você desenharia um sistema simples de comentários?",
+                verso: "Tabela de comentários ligada ao conteúdo, ordenada por data com paginação por cursor, cache das primeiras páginas do conteúdo popular e contagem mantida à parte. Moderação e resposta aninhada mudam o desenho, então vale perguntar se existem antes de desenhar.",
+            },
+            {
+                frente: "Como você tornaria idempotente a criação de um pedido?",
+                verso: "Com uma chave única enviada pelo cliente em cada tentativa e uma restrição de unicidade no banco. Se a mesma chave chegar de novo, devolve-se o pedido já criado em vez de criar outro. A chave precisa ser gerada antes do primeiro envio, e não a cada nova tentativa.",
+            },
+            {
+                frente: "Como você decidiria o que colocar em cache numa página de produto?",
+                verso: "Separando o que muda pouco, como descrição e imagens, do que muda muito, como preço e estoque. O primeiro vai para cache longo e CDN; o segundo tem cache curto ou é consultado na hora, porque mostrar estoque errado vira pedido que não pode ser atendido.",
+            },
+        ],
+        pleno: [
+            {
+                frente: "Como você escolheria a chave de particionamento?",
+                verso: "Pela consulta mais frequente, para ela cair numa partição só, e por uma distribuição que não concentre carga. Identificador do cliente costuma servir bem; data costuma ser péssima, porque todo tráfego novo cai na mesma partição. E ela é cara de trocar depois.",
+            },
+            {
+                frente: "O que é uma chave quente, e como você a trataria?",
+                verso: "Uma chave que recebe uma fração desproporcional do tráfego, como a conta de uma celebridade, e sobrecarrega a partição onde mora. As saídas são espalhar a chave com um sufixo e juntar na leitura, cachear na frente e tratar esses casos à parte.",
+            },
+            {
+                frente: "Que problema o hashing consistente resolve?",
+                verso: "Com a divisão simples pelo número de servidores, acrescentar um servidor muda o destino de quase todas as chaves e esvazia o cache inteiro. No hashing consistente, servidores e chaves ficam num anel, e mudar um servidor move só as chaves vizinhas dele.",
+            },
+            {
+                frente: "Por que o hashing consistente usa nós virtuais?",
+                verso: "Porque com poucos pontos no anel a distribuição fica desigual e, quando um servidor sai, toda a carga dele cai num único vizinho. Cada servidor ocupando muitos pontos espalha melhor as chaves e divide a carga de quem saiu entre vários. Também permite dar peso por capacidade.",
+            },
+            {
+                frente: "Como você rebalancearia partições sem parar o sistema?",
+                verso: "Copiando os dados da partição de origem para a nova em segundo plano, acompanhando as escritas que chegam durante a cópia, e virando o roteamento só quando as duas estiverem iguais. Com limite de ritmo, para a migração não disputar recurso com o tráfego normal.",
+            },
+            {
+                frente: "O que o PACELC acrescenta ao CAP?",
+                verso: "Diz que, mesmo sem partição de rede, existe uma escolha entre latência e consistência, porque esperar a confirmação das réplicas custa tempo. É uma descrição mais útil do dia a dia, já que partição é rara e a troca entre rapidez e consistência acontece em toda escrita.",
+            },
+            {
+                frente: "Como funciona leitura e escrita por quórum?",
+                verso: "Com N cópias, a escrita confirma depois de W delas e a leitura consulta R. Se R mais W passar de N, toda leitura encontra ao menos uma cópia com a escrita mais recente. Ajustar os números troca latência de escrita por latência de leitura, e disponibilidade por consistência.",
+            },
+            {
+                frente: "O que é a divisão de cérebro num cluster, e como evitar?",
+                verso: "É uma partição de rede fazer dois lados acreditarem que são o líder e aceitarem escritas conflitantes. Evita-se exigindo maioria para eleger líder, por isso clusters usam número ímpar de nós, e com um número de mandato que faz o líder antigo ter as escritas recusadas.",
+            },
+            {
+                frente: "Onde a eleição de líder aparece, e o que ela exige?",
+                verso: "Em banco com réplica principal, em fila e em qualquer tarefa que só uma instância deve executar. Exige consenso da maioria, tempo de mandato e garantia de que o líder deposto não continue agindo. Implementar na mão é arriscado; usa-se um serviço de coordenação.",
+            },
+            {
+                frente: "Por que o relógio da máquina não serve para ordenar eventos distribuídos?",
+                verso: "Porque relógios de máquinas diferentes divergem e podem até voltar no tempo ao sincronizar. Dois eventos com poucos milissegundos de diferença podem aparecer invertidos. Para ordem causal se usam relógios lógicos ou uma sequência atribuída por um único ponto.",
+            },
+            {
+                frente: "Como você resolveria conflito de escrita entre réplicas?",
+                verso: "A última escrita vence é o mais simples, e perde dado sem avisar. Guardar as versões conflitantes e resolver na aplicação preserva tudo e dá trabalho. Estruturas que se fundem sozinhas resolvem casos como contador e lista colaborativa. A escolha depende do custo de perder uma escrita.",
+            },
+            {
+                frente: "O que é o padrão de caixa de saída, e que problema resolve?",
+                verso: "Gravar o evento numa tabela na mesma transação do dado, e um processo separado publicar essa tabela na fila. Resolve a janela em que o banco confirmou e a publicação falhou, ou o contrário. O evento pode sair duas vezes, então o consumidor continua precisando ser idempotente.",
+            },
+            {
+                frente: "O que é uma saga, e quando ela substitui transação distribuída?",
+                verso: "Uma sequência de transações locais em serviços diferentes, cada uma com uma ação que desfaz o efeito se um passo posterior falhar. Serve quando a operação atravessa serviços e bancos distintos. O custo é conviver com estados intermediários visíveis e desenhar bem as compensações.",
+            },
+            {
+                frente: "Por que o commit em duas fases costuma ser evitado?",
+                verso: "Porque ele trava recursos em todos os participantes enquanto espera o coordenador, e se o coordenador cai no meio os participantes ficam presos sem saber se confirmam. Isso acopla a disponibilidade de todos. Em sistemas com serviços independentes, saga e idempotência escalam melhor.",
+            },
+            {
+                frente: "Por que exatamente uma vez, na prática, é efeito idempotente?",
+                verso: "Porque a entrega da rede não garante isso: uma confirmação perdida sempre obriga a reenviar. O que dá para garantir é que processar a mesma mensagem de novo não repita o efeito, com chave de deduplicação ou operação idempotente. O resultado visível é o de uma vez só.",
+            },
+            {
+                frente: "Como você implementaria chave de idempotência numa API de pagamento?",
+                verso: "O cliente gera uma chave por intenção de pagamento e envia em cada tentativa. O servidor grava a chave com a resposta, com restrição de unicidade, e devolve a mesma resposta nas repetições. Precisa tratar a chamada ainda em andamento e expirar a chave depois de um prazo.",
+            },
+            {
+                frente: "Quando vale separar o modelo de leitura do modelo de escrita?",
+                verso: "Quando leitura e escrita têm exigências muito diferentes, como escrita normalizada e consistente e leitura em formatos variados e muito volumosos. A escrita publica eventos que alimentam visões de leitura. O custo é atraso entre os dois e mais peças para operar.",
+            },
+            {
+                frente: "Qual o custo de guardar eventos como fonte da verdade?",
+                verso: "O estado atual precisa ser reconstruído a partir da sequência, o que exige fotografias periódicas. Mudar o formato de um evento antigo é difícil, porque ele não pode ser reescrito. Em troca, há histórico completo e a possibilidade de reprocessar. Vale em domínio que já pensa em eventos.",
+            },
+            {
+                frente: "Num feed social, você montaria na escrita ou na leitura?",
+                verso: "Na escrita, cada post é copiado para o feed de cada seguidor, e a leitura fica rapidíssima com escrita cara. Na leitura, o feed é montado na hora juntando quem a pessoa segue, com leitura cara. Como se lê muito mais que se escreve, montar na escrita costuma ser a base.",
+            },
+            {
+                frente: "Como você trataria contas com milhões de seguidores num feed?",
+                verso: "Sem copiar o post delas para milhões de feeds, o que atrasaria tudo. O feed pré-montado cobre as contas comuns, e os posts das contas gigantes são buscados na hora da leitura e misturados. É o modelo híbrido, e a fronteira entre os dois grupos é um número a calibrar.",
+            },
+            {
+                frente: "Como você desenharia um chat em tempo real?",
+                verso: "Clientes conectados por WebSocket a servidores de conexão, um serviço que grava cada mensagem e um barramento que entrega para o servidor onde o destinatário está conectado. A mensagem é persistida antes de ser confirmada. Presença e entrega a quem está offline são peças à parte.",
+            },
+            {
+                frente: "Como você garantiria a ordem das mensagens num chat?",
+                verso: "Com uma sequência por conversa atribuída no servidor, e não pelo relógio do cliente, e o cliente ordenando e detectando lacunas por ela. Ordem global entre conversas não é necessária e seria um gargalo. Particionar por conversa mantém a ordem onde ela importa.",
+            },
+            {
+                frente: "Como você mostraria quem está online em escala?",
+                verso: "Com batidas periódicas do cliente atualizando um registro com validade em memória, e a pessoa aparecendo offline quando a validade vence. Espalhar cada mudança para todos os contatos é caro, então se envia só para quem está com a conversa aberta, e com algum atraso aceitável.",
+            },
+            {
+                frente: "Como você entregaria mensagens para quem está offline?",
+                verso: "Gravando a mensagem e deixando pendente de entrega, disparando uma notificação pelo provedor do celular e sincronizando as pendentes quando o cliente reconectar, a partir da última sequência que ele tem. A notificação é só um aviso: o conteúdo vem da sincronização.",
+            },
+            {
+                frente: "Como você desenharia upload e reprodução de vídeo?",
+                verso: "Upload direto para o armazenamento, uma fila disparando a conversão para várias resoluções em pedaços curtos, e distribuição pela CDN. O reprodutor escolhe a qualidade conforme a conexão. A conversão é a parte cara e lenta, então roda assíncrona e em paralelo por pedaço.",
+            },
+            {
+                frente: "O que é streaming com qualidade adaptativa?",
+                verso: "O vídeo é dividido em pedaços de poucos segundos em várias qualidades, e um arquivo de índice lista as opções. O reprodutor mede a própria conexão e escolhe a qualidade de cada pedaço. Assim a reprodução não trava quando a rede piora; ela só perde definição.",
+            },
+            {
+                frente: "Como você desenharia o rastreamento de localização em tempo real?",
+                verso: "O aplicativo envia a posição a cada poucos segundos, o servidor guarda só a mais recente de cada um em memória, indexada por região, e o histórico vai para armazenamento barato em lote. Quem acompanha recebe atualização por conexão aberta, e não perguntando o tempo todo.",
+            },
+            {
+                frente: "Como você encontraria os motoristas mais próximos de um passageiro?",
+                verso: "Dividindo o mapa em células por um código geográfico em que prefixo comum indica proximidade, buscando na célula do passageiro e nas vizinhas, e ordenando os candidatos pela distância real. Buscar calculando distância para todos os motoristas não escala.",
+            },
+            {
+                frente: "Como você desenharia um limitador de requisições distribuído?",
+                verso: "Com contadores num armazenamento em memória compartilhado, atualizados por operação atômica para duas instâncias não lerem o mesmo valor. Para evitar uma ida à rede por requisição, cada instância pode reservar uma cota local e sincronizar, aceitando pequena imprecisão.",
+            },
+            {
+                frente: "Como você desenharia notificações por vários canais?",
+                verso: "Um serviço recebe o pedido, consulta as preferências do usuário, e publica uma tarefa por canal em filas separadas, cada uma com trabalhadores e limites do provedor. Assim a lentidão do SMS não atrasa o email. Com deduplicação e registro de entrega por notificação.",
+            },
+            {
+                frente: "Como você desenharia um contador de curtidas com alta concorrência?",
+                verso: "Registrando cada curtida como linha única por usuário e conteúdo, o que impede duplicar, e mantendo o total num contador em memória atualizado de forma atômica e gravado em lote. A tela mostra o contador aproximado; o total exato vem da contagem quando precisar.",
+            },
+            {
+                frente: "Como você desenharia um ranking em tempo real?",
+                verso: "Com um conjunto ordenado em memória, que atualiza a pontuação e responde posição e vizinhos em tempo logarítmico, com o banco como registro permanente. Para milhões de jogadores, particionar por região ou temporada e aceitar posição aproximada fora do topo.",
+            },
+            {
+                frente: "Como você manteria o índice de busca sincronizado com o banco?",
+                verso: "Capturando as mudanças do banco e aplicando no índice por uma fila, em vez de a aplicação escrever nos dois lugares. Escrita dupla na aplicação perde atualização quando uma das duas falha. E ter um jeito de reconstruir o índice inteiro, porque um dia ele vai divergir.",
+            },
+            {
+                frente: "Para que serve capturar mudanças direto do log do banco?",
+                verso: "Para transformar cada alteração confirmada em evento, lendo o registro de transações do banco, sem mudar o código da aplicação. Alimenta busca, cache, análise e integração com a garantia de que só vira evento o que foi de fato gravado.",
+            },
+            {
+                frente: "Como você desenharia um coletor de páginas da web?",
+                verso: "Uma fronteira de URLs a visitar, priorizada e dividida por domínio para respeitar o limite de cada site, trabalhadores que baixam e extraem links, e deduplicação de URL e de conteúdo. As regras de acesso de cada site são obedecidas, e armadilhas de links infinitos precisam de limite.",
+            },
+            {
+                frente: "Como você desenharia um agendador de tarefas distribuído?",
+                verso: "Tarefas gravadas com o horário de execução num armazenamento indexado por tempo, um processo que periodicamente move as vencidas para uma fila e trabalhadores que executam. Com trava por tarefa e reentrega se o trabalhador sumir, e tarefas desenhadas para rodar mais de uma vez sem estrago.",
+            },
+            {
+                frente: "Como você evitaria que muitas requisições recalculem o mesmo item quando o cache expira?",
+                verso: "Deixando só uma requisição recalcular, com uma trava pela chave, enquanto as outras esperam ou recebem o valor antigo. Também renovando antes de expirar e espalhando o vencimento com aleatoriedade. Sem isso, um item popular expirado derruba o banco no mesmo segundo.",
+            },
+            {
+                frente: "Como você aqueceria um cache antes de receber tráfego?",
+                verso: "Carregando os itens mais acessados a partir do histórico recente, ou espelhando uma fração do tráfego real para a instância nova antes de ela entrar em rotação. Cache frio depois de um deploy ou de uma queda despeja toda a carga no banco no pior momento.",
+            },
+            {
+                frente: "Como você lidaria com várias camadas de cache mostrando dados diferentes?",
+                verso: "Definindo o TTL de cada camada de fora para dentro, com as externas mais curtas ou versionadas, e invalidando a partir da origem. Sem uma regra, o navegador, a CDN e o cache da aplicação guardam versões diferentes e o dado velho volta depois de corrigido.",
+            },
+            {
+                frente: "Como você desenharia um armazenamento chave-valor distribuído?",
+                verso: "Particionamento por hashing consistente, réplicas em nós diferentes, escrita e leitura por quórum configurável, detecção de falha entre os nós e reparo das réplicas que divergirem. Cada escolha troca consistência por disponibilidade, e o desenho precisa dizer qual lado preferiu.",
+            },
+            {
+                frente: "Como você responderia uma consulta que junta dados de vários serviços?",
+                verso: "Se é tela, uma camada de composição chama os serviços em paralelo e junta, com timeout e resposta parcial. Se é relatório ou filtro combinado, uma visão de leitura alimentada pelos eventos de cada serviço. Consulta cruzada direto nos bancos dos outros cria acoplamento.",
+            },
+            {
+                frente: "Como você migraria dados entre bancos com o sistema no ar?",
+                verso: "Escrevendo nos dois, copiando o histórico em lotes, comparando os dois lados até baterem, passando a ler do novo aos poucos e só então desligando o antigo. Cada etapa tem volta. A comparação é a parte que se pula e é a que garante que nada se perdeu.",
+            },
+            {
+                frente: "Como você decidiria promover um deploy canário?",
+                verso: "Comparando a fatia nova com a antiga no mesmo período, por taxa de erro, latência e métrica de negócio, com critério definido antes. Olhar o painel e achar que está bom não é critério. Tráfego pequeno demais também engana, porque não expõe o caso raro.",
+            },
+            {
+                frente: "Como você desenharia um sistema multirregião ativo-passivo?",
+                verso: "Uma região atende e replica os dados para a outra, que fica pronta com a infraestrutura de pé ou recriável. Na falha, o tráfego é desviado e a réplica promovida. Perde-se o que não tinha replicado, e a troca precisa ser ensaiada, senão falha no dia real.",
+            },
+            {
+                frente: "O que muda num sistema ativo-ativo em várias regiões?",
+                verso: "As duas regiões aceitam escrita, então aparecem conflitos de escrita concorrente, e é preciso decidir quem vence ou particionar os usuários por região. A latência e a disponibilidade melhoram. O custo é complexidade de dados muito maior, e nem todo domínio tolera.",
+            },
+            {
+                frente: "Como você definiria RPO e RTO?",
+                verso: "O RPO é quanto dado o negócio aceita perder, medido em tempo; o RTO é quanto tempo aceita ficar fora. Os dois vêm do negócio, e não da tecnologia, e cada minuto a menos custa caro. Eles decidem entre backup diário, replicação contínua e região pronta para assumir.",
+            },
+            {
+                frente: "Como você planejaria a recuperação de um desastre?",
+                verso: "Começando pelo RPO e RTO de cada sistema, definindo onde estão as cópias e como restaurar, escrevendo o passo a passo e ensaiando de verdade com periodicidade. Plano nunca ensaiado falha em detalhe esquecido, como a credencial que só existia na região que caiu.",
+            },
+            {
+                frente: "Como você limitaria o raio de explosão de uma falha?",
+                verso: "Isolando recursos por dependência e por cliente, com pools separados, limites por inquilino e publicação por partes. Uma consulta ruim de um cliente não pode esgotar as conexões de todos. A pergunta de desenho é quantos usuários uma única falha consegue atingir.",
+            },
+            {
+                frente: "O que é uma arquitetura baseada em células?",
+                verso: "Replicar a pilha inteira em células independentes, cada uma atendendo um grupo de clientes, com uma camada fina de roteamento na frente. Uma falha ou deploy ruim atinge só uma célula. O custo é operar muitas cópias e mover clientes entre células quando elas enchem.",
+            },
+            {
+                frente: "Como você manteria uma loja vendendo num pico que o sistema não aguenta?",
+                verso: "Protegendo o caminho da compra e desligando o que é secundário, como recomendação e avaliações. Uma fila de entrada controla quantos entram no checkout por vez, e o catálogo vem de cache mesmo que um pouco atrasado. Recusar parte com clareza é melhor que cair para todos.",
+            },
+            {
+                frente: "Como você faria um teste de carga que represente produção?",
+                verso: "Com a mesma mistura de operações, dados em volume realista e cache em estado parecido, subindo a carga aos poucos até achar onde a latência dispara. Testar uma rota só, com dado vazio e cache quente, mede um sistema que não existe.",
+            },
+            {
+                frente: "Como você encontraria o gargalo de um sistema lento?",
+                verso: "Seguindo o tempo de uma requisição pelos rastros até o trecho que domina, e olhando a saturação de cada recurso: CPU, conexões, fila e travas. Gargalo costuma ser um recurso compartilhado cheio, e acrescentar servidores na frente dele só aumenta a disputa.",
+            },
+            {
+                frente: "Como você lidaria com uma fila que cresce sem parar?",
+                verso: "Descobrindo antes se a produção aumentou ou o consumo travou. Consumidor ocioso com fila crescendo indica mensagem que falha sempre ou dependência lenta. Se é volume real, escalar consumidores até o limite do destino. E alertar pela idade da mensagem mais antiga.",
+            },
+            {
+                frente: "Como você dimensionaria os consumidores de uma fila?",
+                verso: "Pela taxa de chegada no pico dividida pelo que cada consumidor processa, com folga, e limitado pelo que o destino aguenta. Consumidor a mais sobre um banco saturado só piora. Escalar pela idade da mensagem mais antiga reflete melhor o atraso sentido que pelo tamanho.",
+            },
+            {
+                frente: "Como você garantiria ordem por chave num sistema de mensagens particionado?",
+                verso: "Publicando com a chave de negócio, como o identificador da conta, para todas as mensagens dela caírem na mesma partição, que é consumida em ordem. A ordem vale só dentro da chave. Mudar o número de partições embaralha as chaves, então isso precisa ser planejado.",
+            },
+            {
+                frente: "Como você desenharia um sistema de pagamentos confiável?",
+                verso: "Com chave de idempotência em toda operação, estado explícito de cada pagamento, registro contábil imutável de débito e crédito, webhook do provedor tratado como possivelmente repetido e reconciliação periódica. Nada é apagado ou sobrescrito: correção vira novo lançamento.",
+            },
+            {
+                frente: "Como você reconciliaria seus dados com um sistema externo?",
+                verso: "Comparando periodicamente o que você registrou com o relatório do outro lado, por identificador e valor, e tratando cada divergência como caso a investigar. Webhook perdido e resposta que nunca chegou acontecem, e a reconciliação é a rede que pega o que escapou.",
+            },
+            {
+                frente: "Como você desenharia a API de inferência de um modelo de IA?",
+                verso: "Com fila na frente dos servidores de GPU, limite por cliente, resposta em fluxo para o texto aparecer aos poucos, timeout e cancelamento quando o cliente desiste. GPU é o recurso caro e escasso, então o desenho gira em aproveitá-la ao máximo sem estourar a latência.",
+            },
+            {
+                frente: "Como você lidaria com fila de GPU e agrupamento dinâmico de requisições?",
+                verso: "Juntando as requisições que chegam num intervalo curto num mesmo lote, porque a GPU processa lote quase pelo custo de uma. O intervalo troca latência por vazão. Separar filas por tamanho de entrada e prioridade evita que uma requisição enorme segure as pequenas.",
+            },
+            {
+                frente: "Como você desenharia recuperação de contexto para um modelo em escala?",
+                verso: "Documentos divididos em trechos, transformados em vetores e indexados, com busca aproximada por similaridade combinada com filtro por permissão e busca por palavra. A etapa de ingestão é assíncrona. O controle de acesso precisa estar na busca, senão o modelo vaza documento alheio.",
+            },
+            {
+                frente: "Como você avaliaria e monitoraria um sistema com modelo de linguagem?",
+                verso: "Com um conjunto de casos com resposta esperada, rodado a cada mudança de prompt ou modelo, e em produção com amostragem de conversas, retorno do usuário, taxa de recusa, custo e latência. Resposta de modelo varia, então sem avaliação automática toda mudança é aposta.",
+            },
+            {
+                frente: "Como você controlaria o custo por token num produto com IA?",
+                verso: "Medindo custo por funcionalidade e por cliente, cortando contexto desnecessário, usando modelo menor onde ele basta, cacheando respostas e prefixos repetidos e impondo limite de uso por plano. Sem medida por funcionalidade, o custo cresce sem ninguém saber de onde.",
+            },
+            {
+                frente: "Como você armazenaria logs em volume muito alto?",
+                verso: "Coletando de forma assíncrona, com um buffer que aguenta pico, indexando só os campos consultados e movendo o antigo para armazenamento barato com retenção definida. Amostrando o que é repetitivo e mantendo todos os erros. Indexar tudo para sempre é a conta que cresce mais rápido.",
+            },
+            {
+                frente: "Como você rastrearia uma requisição que passa por uma fila?",
+                verso: "Levando o contexto do rastro dentro da mensagem, como metadado, e retomando no consumidor como continuação ligada à requisição original. Sem isso, o rastro termina na publicação e o processamento aparece solto, sem como saber qual pedido o originou.",
+            },
+            {
+                frente: "Como você desenharia a análise de cliques de um encurtador em escala?",
+                verso: "Eventos de clique publicados num fluxo particionado, agregados por janela de tempo e gravados num banco colunar ou em contadores pré-calculados por link e período. As consultas leem os agregados, e os eventos brutos vão para armazenamento barato para reprocessar.",
+            },
+            {
+                frente: "Como você desenharia reservas sem vender o mesmo lugar duas vezes?",
+                verso: "Com uma reserva temporária do lugar com validade, feita por escrita condicional ou trava no registro, e confirmação só depois do pagamento. Se o pagamento não vier a tempo, a reserva expira e o lugar volta. A garantia fica no banco, e não numa checagem antes de gravar.",
+            },
+            {
+                frente: "Como você lidaria com estoque numa venda relâmpago?",
+                verso: "Tirando a disputa do banco principal: estoque decrementado de forma atômica em memória, fila de entrada limitando quem chega ao checkout e gravação assíncrona dos pedidos. Checar se há estoque e depois baixar em dois passos vende mais do que existe.",
+            },
+            {
+                frente: "Como você armazenaria métricas em séries temporais?",
+                verso: "Num banco feito para série temporal, que agrupa pontos por tempo e comprime bem, com retenção em camadas: resolução alta por poucos dias e agregada por meses. O cuidado principal é a cardinalidade dos rótulos, que multiplica séries e derruba o armazenamento.",
+            },
+            {
+                frente: "Como você desenharia a sincronização de arquivos entre dispositivos?",
+                verso: "Arquivos divididos em blocos identificados por hash, enviando só os blocos que mudaram, metadados com versão por arquivo e um serviço que avisa os outros dispositivos. Conflito de edição simultânea vira cópia com os dois conteúdos, porque escolher um lado perde trabalho.",
+            },
+            {
+                frente: "Como você garantiria que um sistema de mensagens não perca dados quando um nó cai?",
+                verso: "Confirmando a publicação só depois de a mensagem estar gravada em mais de uma réplica, e o consumidor confirmando só depois de processar. Com isso a queda de um nó não apaga nada. O preço é latência maior na publicação e reprocessamento de algumas mensagens.",
+            },
+        ],
+        senior: [
+            {
+                frente: "Como você conduziria uma sessão de design com requisitos ambíguos?",
+                verso: "Transformando a ambiguidade em premissas explícitas, escritas e confirmadas, e mostrando onde cada uma muda o desenho. Quando ninguém sabe a resposta, desenhar para o cenário provável e apontar o que teria de mudar se ele não se confirmar. Ambiguidade escondida vira retrabalho.",
+            },
+            {
+                frente: "Como você decidiria o que deixar fora do escopo de um desenho?",
+                verso: "Pelo que não muda a arquitetura agora e pode entrar depois sem refazer a base, dizendo isso em voz alta. O que não pode ficar fora é o que é caro de acrescentar depois, como particionamento, isolamento entre clientes e trilha de auditoria.",
+            },
+            {
+                frente: "Como você explicaria um trade-off técnico para alguém de produto?",
+                verso: "Pelo efeito que o usuário e o negócio sentem, e não pelo mecanismo: o que ganha, o que perde, quanto custa e em que situação o risco aparece. Com duas ou três opções e uma recomendação. Explicar replicação assíncrona não ajuda; dizer que um comentário pode sumir por segundos ajuda.",
+            },
+            {
+                frente: "Como você decidiria entre monólito e microsserviços para um time novo?",
+                verso: "Monólito bem dividido por módulos, na grande maioria dos casos. Microsserviço resolve problema de muitos times publicando em paralelo e de partes com escala muito diferente, e cobra rede, falha parcial e operação. Um time pequeno paga todo o custo sem ter o problema que ele resolve.",
+            },
+            {
+                frente: "Como você definiria as fronteiras entre serviços?",
+                verso: "Por capacidade de negócio e por dono do dado, de forma que um serviço consiga mudar sem coordenar com outros na maior parte das entregas. Serviço que precisa de outro para quase toda operação está com a fronteira errada. Fronteira por camada técnica é quase sempre errada.",
+            },
+            {
+                frente: "Como você lidaria com um sistema que tem microsserviços demais?",
+                verso: "Mapeando quais sempre mudam e publicam juntos, quais só repassam chamada e quais têm o mesmo dono, e juntando esses de volta. Consolidar não é retroceder: é corrigir fronteira que custa latência e coordenação sem trazer independência nenhuma.",
+            },
+            {
+                frente: "Como você decidiria o alvo de disponibilidade de um sistema?",
+                verso: "Pelo que o negócio perde quando ele fica fora, pelo que os dependentes realmente oferecem e pelo que o time consegue operar. Prometer mais disponibilidade que a do banco ou do provedor de nuvem que você usa é prometer o impossível. Cada nove precisa pagar a própria conta.",
+            },
+            {
+                frente: "Como você usaria o orçamento de erro para negociar entrega e estabilidade?",
+                verso: "Combinando antes a regra: com orçamento sobrando, o time publica no ritmo normal; esgotado, as entregas param e o esforço vai para confiabilidade até recuperar. Assim a decisão deixa de ser opinião na hora do incidente e vira um acordo que produto e engenharia assinaram.",
+            },
+            {
+                frente: "Como você avaliaria o custo total de um desenho?",
+                verso: "Somando infraestrutura, tráfego, licenças, e principalmente o tempo de gente para construir, operar e manter de plantão. Um desenho mais barato em servidor e que exige três pessoas a mais para operar é o mais caro. Custo por usuário ou por transação ajuda a comparar.",
+            },
+            {
+                frente: "Como você reduziria o custo de infraestrutura sem piorar a confiabilidade?",
+                verso: "Começando pelo desperdício medido: recurso ocioso, instância superdimensionada, dado quente que podia estar em armazenamento frio, log demais e tráfego entre regiões. Esses cortes não mexem em redundância. Cortar réplica e margem de pico economiza até o próximo incidente.",
+            },
+            {
+                frente: "Como você decidiria entre construir e contratar um componente de infraestrutura?",
+                verso: "Contratando o que é igual para todo mundo, como fila, banco gerenciado e busca, e construindo o que diferencia o produto. A conta de construir inclui operar, atualizar e ficar de plantão por anos. A de contratar inclui preço em escala e o custo de sair.",
+            },
+            {
+                frente: "Como você escolheria o banco de dados de um sistema novo?",
+                verso: "Pelos formatos de acesso e pelas garantias exigidas, e pelo que o time sabe operar numa madrugada. Relacional gerenciado atende a maioria dos casos por muito tempo. Escolher um banco especializado no início troca um problema hipotético de escala por um problema real de operação.",
+            },
+            {
+                frente: "Como você avaliaria adotar um banco especializado ao lado do principal?",
+                verso: "Perguntando qual consulta ou volume o principal comprovadamente não aguenta, como busca textual, grafo ou série temporal, e como os dados serão mantidos em sincronia. Todo banco a mais é mais uma fonte de divergência, backup, monitoramento e conhecimento que o time precisa ter.",
+            },
+            {
+                frente: "Como você decidiria com o negócio entre consistência forte e eventual?",
+                verso: "Operação por operação, perguntando o que acontece se o usuário vir um valor atrasado ou se duas ações concorrentes forem aceitas. Saldo e estoque costumam exigir consistência forte; curtidas e visualizações não. Aplicar uma regra só para tudo desperdiça ou arrisca.",
+            },
+            {
+                frente: "Como você lidaria com um requisito de tempo real mal definido?",
+                verso: "Perguntando qual atraso o usuário percebe e qual o negócio aceita, e escrevendo o número. Tempo real para um painel costuma ser alguns segundos; para uma cotação, milissegundos. A diferença entre os dois muda da escolha de polling a uma infraestrutura inteira de fluxo.",
+            },
+            {
+                frente: "Como você documentaria uma decisão de arquitetura?",
+                verso: "Num registro curto: contexto, opções consideradas, decisão, consequências e o que faria revisitá-la, datado e junto do código. O valor está em registrar por que o outro caminho foi descartado. Sem isso, a decisão é desfeita por quem não conhece o problema que ela evitou.",
+            },
+            {
+                frente: "O que você procura primeiro ao revisar o documento de design de outra pessoa?",
+                verso: "Se o problema e os requisitos estão claros e com números, quais outros desenhos foram descartados e por quê, e o que acontece quando cada dependência falha. Depois migração, operação e custo. Documento que só descreve a solução escolhida esconde a decisão.",
+            },
+            {
+                frente: "Como você trataria decisões reversíveis e irreversíveis de forma diferente?",
+                verso: "Decisão fácil de desfazer se toma rápido e se corrige com dado. Decisão cara de desfazer, como formato de dado público, chave de particionamento e contrato com cliente, pede mais análise, protótipo e revisão. Tratar tudo com o mesmo peso ou trava o time ou gera dívida permanente.",
+            },
+            {
+                frente: "Como você conduziria uma migração de arquitetura grande?",
+                verso: "Por etapas que entregam valor e têm volta, com os dois mundos convivendo, métrica comparando comportamento e critério de conclusão de cada etapa. E com prazo para desligar o antigo, porque migração sem fim deixa o time mantendo dois sistemas indefinidamente.",
+            },
+            {
+                frente: "Como você evitaria uma reescrita completa de um sistema?",
+                verso: "Mostrando o custo do período sem entrega e a regra de negócio que só existe no código antigo, e oferecendo substituir por partes atrás de uma fachada. Reescrita completa costuma entregar depois do prazo um sistema que ainda não faz tudo que o antigo fazia.",
+            },
+            {
+                frente: "Como você substituiria um sistema legado aos poucos?",
+                verso: "Colocando uma fachada na frente, desviando uma funcionalidade por vez para o sistema novo e mantendo o resto no antigo, até ele não receber mais nada e poder ser desligado. Cada desvio é pequeno e reversível. A parte difícil é o dado, que costuma precisar de sincronização temporária.",
+            },
+            {
+                frente: "Como você lidaria com dados compartilhados entre times?",
+                verso: "Dando um dono a cada conjunto de dados e expondo por contrato, API ou eventos, em vez de vários serviços lendo e escrevendo a mesma tabela. Tabela compartilhada transforma toda mudança de schema numa negociação entre times e cria dependência que ninguém enxerga.",
+            },
+            {
+                frente: "Como você definiria quem é dono de cada dado?",
+                verso: "Pelo time responsável pela regra que cria e altera aquele dado. Os demais consomem cópias ou consultam o dono, e não gravam. Dado com mais de um escritor acumula regras conflitantes, e ninguém consegue responder qual versão é a certa.",
+            },
+            {
+                frente: "Como você desenharia para falhas de dependências externas?",
+                verso: "Assumindo que cada uma vai ficar lenta e cair: timeout, limite de concorrência, disjuntor, resposta de reserva e fila para o que pode esperar. E listando o que acontece com o produto quando cada uma some. Dependência sem plano de falha define a sua disponibilidade no lugar de você.",
+            },
+            {
+                frente: "Como você definiria SLOs para um serviço interno?",
+                verso: "Pelo que os serviços consumidores precisam para cumprir os deles, medido do ponto de vista de quem chama. Serviço interno sem SLO vira dependência sem expectativa, e o consumidor descobre o limite no incidente. Também dá argumento para priorizar confiabilidade.",
+            },
+            {
+                frente: "Como você lidaria com uma falha em cascata?",
+                verso: "Parando a propagação primeiro: cortando tráfego não essencial, abrindo disjuntores e reduzindo repetição. Depois recuperando de dentro para fora, trazendo as dependências antes dos consumidores. No desenho, isolamento, limite de concorrência e repetição com espera evitam que se repita.",
+            },
+            {
+                frente: "Como você transformaria incidentes recorrentes em mudança de desenho?",
+                verso: "Agrupando os incidentes pela causa estrutural e não pelo sintoma, e perguntando qual mudança elimina a classe inteira, como isolar um recurso compartilhado. Corrigir cada ocorrência isoladamente mantém o time apagando o mesmo incêndio com nomes diferentes.",
+            },
+            {
+                frente: "Como você planejaria a capacidade para o próximo ano?",
+                verso: "Partindo do crescimento esperado pelo negócio e da relação medida entre tráfego e uso de cada recurso, projetando o pico com folga e identificando o que atinge o limite primeiro. O plano precisa dizer o que exige mudança de desenho, porque isso leva meses, e não só dinheiro.",
+            },
+            {
+                frente: "O que costuma quebrar primeiro quando o tráfego cresce dez vezes?",
+                verso: "O banco de dados, principalmente escrita e conexões, depois recursos compartilhados como cache e fila, e os limites dos provedores externos. Servidores de aplicação sem estado costumam escalar bem. O que tem estado e o que você não controla são onde o crescimento dói.",
+            },
+            {
+                frente: "Como você decidiria entre otimizar e escalar?",
+                verso: "Medindo onde está a saturação e quanto custa cada caminho. Escalar compra tempo rápido e custa dinheiro contínuo; otimizar custa tempo do time uma vez. Se o gargalo é um recurso compartilhado, escalar não resolve. Se o time é o recurso escasso, escalar costuma ser o certo.",
+            },
+            {
+                frente: "Como você justificaria o custo de rodar em várias regiões?",
+                verso: "Pelo prejuízo de ficar fora quando uma região inteira cai, pela latência de usuários distantes e por exigência regulatória, comparado ao custo de infraestrutura duplicada e complexidade de dados. Para muitos produtos, várias zonas numa região e backup em outra bastam.",
+            },
+            {
+                frente: "Como você lidaria com a exigência de manter dados dentro de um país?",
+                verso: "Particionando por localização do cliente, com os dados pessoais armazenados e processados na região exigida, e mapeando tudo que pode levar dado para fora: backup, log, análise e fornecedor. A regra costuma ser violada por uma cópia secundária que ninguém lembrou.",
+            },
+            {
+                frente: "Como você colocaria privacidade como requisito desde o início?",
+                verso: "Coletando o mínimo, separando dado pessoal do resto, definindo retenção e caminho de exclusão e controlando acesso por finalidade. Tudo isso é barato no desenho e muito caro de acrescentar quando o dado pessoal já está espalhado por tabelas, logs e cópias.",
+            },
+            {
+                frente: "Como você trataria segurança como requisito de design?",
+                verso: "Modelando as ameaças antes de construir: o que proteger, de quem e por onde podem entrar. Depois autenticação entre serviços, menor privilégio, criptografia e trilha de acesso já no desenho. Segurança acrescentada no final vira remendo em volta de uma arquitetura que não foi pensada para ela.",
+            },
+            {
+                frente: "Como você reduziria a superfície de ataque de uma arquitetura?",
+                verso: "Expondo o mínimo à internet, com uma entrada única, removendo serviços e portas sem uso, dando a cada componente só as permissões necessárias e isolando o que guarda dado sensível. Cada dependência e cada endpoint esquecido é uma porta a mais para vigiar.",
+            },
+            {
+                frente: "Como você lidaria com dívida arquitetural?",
+                verso: "Tornando visível com custo concreto: incidentes, lentidão de entrega e áreas que ninguém consegue mudar. Priorizando a que bloqueia o plano do negócio e pagando junto com as entregas que tocam aquela área. Dívida discutida em abstrato nunca ganha prioridade.",
+            },
+            {
+                frente: "Como você mediria se uma arquitetura está saudável?",
+                verso: "Pela facilidade de mudar e operar: tempo para entregar uma mudança comum, quantos times precisam coordenar, frequência e duração de incidentes e custo por unidade crescendo menos que o volume. Diagrama bonito não é métrica; atrito para mudar é.",
+            },
+            {
+                frente: "Como você decidiria adotar uma arquitetura orientada a eventos?",
+                verso: "Quando há vários consumidores interessados nos mesmos fatos, picos a absorver e processos que não precisam de resposta imediata. Custa rastreamento distribuído, consistência eventual e reprocessamento. Para fluxo simples de pergunta e resposta, só acrescenta peças.",
+            },
+            {
+                frente: "Como você evitaria que eventos virem acoplamento escondido?",
+                verso: "Tratando o formato do evento como contrato público, com dono, versão e registro de quem consome. Evento com dado demais transforma consumidores em dependentes do schema interno do produtor. Publicar fatos do negócio, e não o registro inteiro do banco, reduz esse vínculo.",
+            },
+            {
+                frente: "Como você versionaria eventos consumidos por vários times?",
+                verso: "Evoluindo de forma compatível, com campos novos opcionais e consumidores ignorando o desconhecido, e validação de compatibilidade antes de publicar. Mudança incompatível vira novo tipo de evento publicado em paralelo por um prazo. Mensagem antiga já na fila precisa continuar legível.",
+            },
+            {
+                frente: "Como você lidaria com um sistema legado que ninguém entende?",
+                verso: "Observando antes de mexer: instrumentar para ver o que é chamado, de onde vêm e para onde vão os dados, e escrever testes que capturam o comportamento atual. Com isso vira possível mudar com segurança. Mexer por intuição num sistema desconhecido é como se criam incidentes.",
+            },
+            {
+                frente: "Como você garantiria observabilidade já no desenho?",
+                verso: "Definindo o que precisa ser respondido em produção, como onde a requisição demorou e quantos clientes foram afetados, e desenhando identificador de correlação, métricas por dependência e SLOs junto com os componentes. Observabilidade acrescentada depois do incidente chega tarde.",
+            },
+            {
+                frente: "Como você decidiria o nível de abstração de uma plataforma interna?",
+                verso: "Pelo que os times repetem e erram, oferecendo caminhos prontos para o caso comum sem impedir sair dele. Abstração demais esconde o que o time precisa entender num incidente; de menos, cada time reinventa a mesma infraestrutura. A plataforma deve ser adotada por ser mais fácil, e não por obrigação.",
+            },
+            {
+                frente: "Como você avaliaria adotar um orquestrador de contêineres para o time?",
+                verso: "Pelo número de serviços, pela necessidade de escala e pela capacidade de operar a plataforma em si. Para poucos serviços, um serviço gerenciado de contêineres entrega o necessário sem o custo. Adotar cedo transforma o time de produto num time de infraestrutura.",
+            },
+            {
+                frente: "Como você decidiria entre funções sem servidor e contêineres em escala?",
+                verso: "Pelo padrão de tráfego e pela previsibilidade de custo. Tráfego irregular e processamento por evento ganham com funções; carga constante e alta costuma sair mais barata em contêiner. Limites de tempo de execução, partida a frio e conexões com banco pesam na decisão.",
+            },
+            {
+                frente: "Como você lidaria com a dependência de um provedor de nuvem?",
+                verso: "Aceitando a dependência onde ela traz ganho real, como bancos gerenciados, e evitando onde ela prende sem trazer nada. Isolar o acesso a serviços proprietários atrás de interfaces reduz o custo de trocar. Ser totalmente portável costuma custar mais do que a troca que nunca acontece.",
+            },
+            {
+                frente: "Como você trataria a pressão para adotar a tecnologia da moda?",
+                verso: "Pedindo o problema que ela resolve melhor que o atual, com evidência, e o custo de aprender e operar. Uma prova de conceito limitada responde melhor que discussão. Tecnologia nova tem lugar, mas cada uma gasta parte de uma capacidade limitada do time de lidar com novidade.",
+            },
+            {
+                frente: "Como você comunicaria risco técnico para a liderança?",
+                verso: "Em termos de impacto e probabilidade: o que pode acontecer com clientes e receita, com que chance, o que custa prevenir e o que acontece se não fizer nada. Com uma recomendação clara. Risco apresentado só em jargão técnico é ignorado até virar incidente.",
+            },
+            {
+                frente: "Como você desenharia pensando no time que vai operar o sistema?",
+                verso: "Escolhendo tecnologias que o time conhece, reduzindo o número de peças, automatizando a operação comum e escrevendo como diagnosticar as falhas prováveis. O melhor desenho no papel falha se ninguém consegue entender o que acontece nele às três da manhã.",
+            },
+            {
+                frente: "Como a estrutura dos times afeta a arquitetura?",
+                verso: "Os sistemas tendem a copiar a forma como os times se comunicam, então fronteiras entre times viram fronteiras entre sistemas. Por isso vale desenhar os times junto com a arquitetura desejada. Serviço dividido entre dois times sem dono claro vira gargalo de coordenação.",
+            },
+            {
+                frente: "Como você evitaria que o desenho de um sistema dependa de uma pessoa só?",
+                verso: "Registrando decisões e seus motivos, revisando designs em grupo, rodando quem opera e quem evolui cada parte e documentando como o sistema funciona e falha. O teste é simples: se essa pessoa sair de férias, o time consegue mudar e operar o sistema sem ela?",
+            },
+            {
+                frente: "O que diferencia uma resposta sênior numa entrevista de System Design?",
+                verso: "Conduzir a conversa, fazer as perguntas que mudam o desenho, justificar cada escolha com o trade-off e antecipar falha, operação e evolução. Uma resposta júnior lista componentes corretos; uma sênior explica por que aqueles, o que se perde com eles e quando mudaria de ideia.",
+            },
+            {
+                frente: "Como você lidaria com o entrevistador mudando o requisito no meio?",
+                verso: "Tratando como parte do exercício: identificando quais decisões anteriores dependiam da premissa antiga, dizendo o que muda e o que se mantém e ajustando o desenho. Recomeçar do zero ou defender o desenho antigo mostra rigidez; adaptar mostra que as escolhas tinham motivo.",
+            },
+            {
+                frente: "Como você decidiria quando parar de aprofundar um componente na entrevista?",
+                verso: "Quando o nível de detalhe já não muda decisões e outras partes do sistema ainda não foram cobertas, verificando com o entrevistador onde ele quer profundidade. Gastar metade do tempo num detalhe interessante e deixar o fluxo principal incompleto é um erro comum.",
+            },
+            {
+                frente: "Sendo o entrevistador, como você avaliaria um candidato numa entrevista de design?",
+                verso: "Pela forma de raciocinar, e não pelo desenho final: se levanta requisitos, estima, justifica escolhas, reconhece trade-offs, lida com falhas e se adapta a novas informações. Candidato que acerta o desenho decorado e não explica o porquê revela menos do que parece.",
+            },
+            {
+                frente: "Como você trataria um produto com IA cujo custo está explodindo?",
+                verso: "Medindo custo por funcionalidade, cliente e tipo de pedido para achar a concentração, e então aplicando cache, modelo menor para tarefa simples, contexto mais curto e limite por plano. Ajustar preço e cota faz parte da solução, porque o custo cresce com o uso de cada cliente.",
+            },
+            {
+                frente: "Como você decidiria entre hospedar um modelo próprio e usar a API de um provedor?",
+                verso: "Pelo volume, pela qualidade necessária, pela exigência sobre os dados e pela capacidade de operar GPUs. API de provedor começa rápido e custa por uso; modelo próprio exige escala e equipe para compensar. Uma camada que permita trocar reduz o custo de errar nessa escolha.",
+            },
+            {
+                frente: "Como você desenharia a continuidade quando o provedor do modelo cai?",
+                verso: "Com uma camada de acesso que permita desviar para outro provedor ou modelo, testada periodicamente, e degradação definida para quando nenhum estiver disponível, como fila ou funcionalidade temporariamente limitada. Trocar de modelo muda o comportamento, então a avaliação precisa cobrir os dois.",
+            },
+            {
+                frente: "Como você desenharia limites de uso por cliente num SaaS com vários clientes?",
+                verso: "Com cotas e limites de taxa por cliente aplicados na entrada e medidos continuamente, planos que definem esses valores e aviso antes de o cliente atingir o teto. O limite protege os outros clientes e o custo. Sem ele, um cliente grande define a experiência de todos.",
+            },
+            {
+                frente: "Como você isolaria clientes para um não prejudicar os outros?",
+                verso: "Separando recursos na medida do risco: limites e filas por cliente para todos, e banco, pool ou célula dedicados para os maiores. O identificador do cliente precisa estar em toda consulta e métrica. Isolamento total para todos é caro; nenhum isolamento é ruim para todos.",
+            },
+            {
+                frente: "Como você definiria o que é pronto para produção num sistema novo?",
+                verso: "SLO definido e medido, alerta ligado a sintoma do usuário, painel e logs úteis, teste de carga no volume esperado, plano de reversão, backup testado, segurança revisada e alguém de plantão sabendo operar. Funcionar no ambiente de teste é só o começo.",
+            },
+            {
+                frente: "Como você atenderia um requisito de auditoria de quem fez o quê?",
+                verso: "Gravando cada ação relevante com autor, momento, alvo e valores antes e depois, na mesma transação da mudança, num registro que não pode ser alterado nem apagado pela aplicação. Log comum não serve para auditoria, porque é incompleto, alterável e tem retenção curta.",
+            },
+            {
+                frente: "Como você planejaria desligar um sistema?",
+                verso: "Descobrindo todos os consumidores pelo tráfego real, e não por documentação, comunicando um prazo, migrando cada um e acompanhando o uso até zerar. Depois bloqueando o acesso por um período antes de apagar, e guardando os dados pelo tempo exigido. Consumidor esquecido aparece no dia do desligamento.",
+            },
+            {
+                frente: "Como você decidiria o nível de consistência de cada operação num mesmo sistema?",
+                verso: "Classificando as operações pelo custo de um erro de concorrência ou de dado atrasado, e usando garantias fortes só onde esse custo é alto, como dinheiro e estoque. O resto usa caminhos mais rápidos e baratos. Um sistema real mistura níveis, e isso precisa estar documentado.",
+            },
+            {
+                frente: "Como você equilibraria simplicidade e preparação para escala?",
+                verso: "Desenhando simples para o volume dos próximos meses, com as decisões caras de mudar já pensadas para a escala planejada, como formato de dado e chave de partição. Otimizar para uma escala que não chegou atrasa o produto; ignorar o que é irreversível cobra uma migração dolorosa.",
+            },
+            {
+                frente: "Como você lidaria com um desenho que funciona hoje e não aguenta o plano do negócio?",
+                verso: "Mostrando com números em que ponto do crescimento ele falha e quanto tempo leva a mudança necessária, e planejando essa mudança antes de chegar lá. Mudança de arquitetura feita às pressas, durante o crescimento, custa mais e arrisca justamente o momento de maior receita.",
+            },
+            {
+                frente: "Como você conduziria um ensaio de falha em produção?",
+                verso: "Com uma hipótese clara sobre o comportamento esperado, raio de impacto limitado, monitoramento atento, forma de interromper na hora e as pessoas avisadas. Começando em horário controlado e ampliando depois. O objetivo é descobrir fraquezas antes que um incidente real as mostre.",
+            },
+            {
+                frente: "Como você decidiria o que é síncrono e o que é assíncrono num fluxo crítico?",
+                verso: "Mantendo síncrono só o que o usuário precisa confirmar para seguir, como a validação e a reserva do pagamento, e tornando assíncrono o que pode acontecer depois, como email, nota fiscal e análise. Cada passo síncrono a mais soma latência e mais uma dependência que pode derrubar o fluxo.",
+            },
+            {
+                frente: "Como você lidaria com um contrato entre sistemas que não pode quebrar?",
+                verso: "Com testes de contrato automáticos entre os dois lados, mudanças apenas compatíveis, versões paralelas quando inevitável e registro de todos os consumidores. Contrato crítico precisa de dono, processo de mudança e monitoramento de uso das versões antigas.",
+            },
+            {
+                frente: "Como você revisaria um desenho para descobrir onde ele vai falhar?",
+                verso: "Seguindo o caminho de uma requisição e perguntando em cada passo: e se isso ficar lento, cair, responder errado ou receber dez vezes o tráfego? Depois olhando estado compartilhado, dependências externas e operações não repetíveis. Os pontos de falha costumam aparecer nessas perguntas.",
+            },
+        ],
+    },
+};

--- a/backend/scripts/data/entrevista/typescript.ts
+++ b/backend/scripts/data/entrevista/typescript.ts
@@ -1,0 +1,1144 @@
+import type { TopicoDeEntrevista } from "../../seed-entrevista.ts";
+
+/**
+ * Perguntas de entrevista de TypeScript.
+ *
+ * O nível segue o que a pergunta cobra, e não o assunto. O any aparece nos quatro
+ * níveis: em estágio é o que ele significa, em sênior é a política do time sobre
+ * onde ele é aceitável e como impedir que vire regra.
+ */
+export const typescript: TopicoDeEntrevista = {
+    slug: "typescript",
+    nome: "TypeScript",
+    position: 9,
+    perguntas: {
+        estagio: [
+            {
+                frente: "Que problema o TypeScript resolve?",
+                verso: "Pegar em tempo de escrita erros que só apareceriam rodando: campo que não existe, argumento na ordem errada, valor que pode ser nulo. Junto disso vem autocompletar confiável e refatoração segura, que é o ganho que mais se sente no dia a dia.",
+            },
+            {
+                frente: "O TypeScript existe em tempo de execução?",
+                verso: "Não. Os tipos são apagados na compilação, e o que roda é JavaScript comum. Por isso não dá para checar um tipo com if em tempo de execução, e por isso dado vindo da rede precisa ser validado de verdade, e não apenas declarado.",
+            },
+            {
+                frente: "O que o compilador do TypeScript faz?",
+                verso: "Checa os tipos e gera JavaScript, podendo ajustar a sintaxe para uma versão mais antiga. As duas coisas são independentes: dá para gerar código mesmo com erro de tipo, e dá para só checar sem gerar arquivo nenhum.",
+            },
+            {
+                frente: "O que é inferência de tipo?",
+                verso: "É o compilador deduzir o tipo a partir do valor, sem você escrever. Uma variável iniciada com texto é texto. Isso mantém o código enxuto, e é por isso que anotar tudo costuma ser ruído em vez de segurança.",
+            },
+            {
+                frente: "Quando vale anotar o tipo em vez de deixar inferir?",
+                verso: "Em fronteiras: parâmetros, retorno de função pública e objetos que descrevem contrato. Ali a anotação documenta e trava a intenção. Dentro da função, deixar inferir costuma ser melhor, porque acompanha a mudança sem manutenção.",
+            },
+            {
+                frente: "O que o tipo any significa?",
+                verso: "Que o compilador desiste daquele valor: qualquer operação passa e qualquer atribuição é aceita. Ele não é um tipo, é a ausência de checagem, e contamina o que toca. Um any no meio do caminho apaga a segurança de tudo que vem depois.",
+            },
+            {
+                frente: "O que é unknown, e como se usa?",
+                verso: "É o topo seguro: aceita qualquer valor, mas não deixa fazer nada com ele antes de você provar o que é, com checagem. É o que se usa para dado vindo de fora, porque obriga a validar antes de acessar campo.",
+            },
+            {
+                frente: "Qual a diferença entre any e unknown?",
+                verso: "Os dois aceitam qualquer coisa na entrada. O any também aceita qualquer uso, sem reclamar; o unknown exige que você estreite o tipo antes. Trocar any por unknown é a mudança de menor custo para tornar uma base mais segura.",
+            },
+            {
+                frente: "O que o tipo never representa?",
+                verso: "O valor que nunca acontece. Aparece no retorno de função que sempre lança ou nunca termina, e no caso restante de uma verificação exaustiva. É o que permite o compilador avisar quando alguém acrescenta uma opção e esquece de tratá-la.",
+            },
+            {
+                frente: "Qual a diferença entre void e undefined?",
+                verso: "Void diz que o retorno não deve ser usado, mesmo que na prática venha indefinido. Undefined é um valor de verdade. A distinção importa em retorno de chamada: uma função declarada como void aceita implementação que devolve algo, e esse valor é ignorado.",
+            },
+            {
+                frente: "O que a opção estrita de nulos muda?",
+                verso: "Nulo e indefinido deixam de ser aceitos em qualquer tipo e passam a precisar de declaração explícita. É a mudança que mais pega erro numa base, porque obriga a tratar o caso ausente onde ele existe de verdade.",
+            },
+            {
+                frente: "O que é uma união de tipos?",
+                verso: "Um tipo que aceita mais de uma forma, escrito com barra vertical, como texto ou número. Antes de usar, é preciso estreitar para saber com qual você está lidando. União de literais também é o jeito mais simples de descrever um conjunto fechado de opções.",
+            },
+            {
+                frente: "O que é uma interseção de tipos?",
+                verso: "A combinação de dois tipos em um, que exige ter tudo dos dois. Serve para compor, como um objeto que é uma entidade mais campos de auditoria. Interseção de tipos incompatíveis produz algo impossível de satisfazer.",
+            },
+            {
+                frente: "Qual a diferença entre interface e type?",
+                verso: "Interface descreve a forma de um objeto e pode ser estendida e reaberta. Type é um apelido para qualquer tipo, inclusive união e tupla. Para objeto, os dois servem; a escolha costuma ser convenção do time, e o que decide é precisar de união ou não.",
+            },
+            {
+                frente: "Como você tipa uma função?",
+                verso: "Anotando cada parâmetro e, quando útil, o retorno. O retorno costuma ser inferido bem, mas declará-lo em função pública trava o contrato e faz o erro aparecer dentro da função, e não em quem usa.",
+            },
+            {
+                frente: "Como você declara um parâmetro opcional?",
+                verso: "Com interrogação depois do nome, o que torna o tipo dele união com indefinido. Parâmetro opcional precisa vir depois dos obrigatórios. Se o valor tem um padrão razoável, valor padrão costuma ser melhor que opcional.",
+            },
+            {
+                frente: "O que muda entre parâmetro opcional e parâmetro com valor padrão?",
+                verso: "O opcional pode chegar indefinido e você trata. O com padrão nunca chega indefinido dentro da função, porque o valor é preenchido na chamada. O segundo elimina uma checagem, e é o que costuma deixar o corpo mais limpo.",
+            },
+            {
+                frente: "Como você tipa um array?",
+                verso: "Com o tipo seguido de colchetes ou com a forma genérica, que são equivalentes. O que importa é o array ser homogêneo: quando ele tem tipos diferentes por posição, o certo é uma tupla, e não uma união solta.",
+            },
+            {
+                frente: "O que é uma tupla?",
+                verso: "Um array de tamanho e tipos fixos por posição, como um par de texto e número. Serve para retorno de par, como o de um hook de estado. Usada demais ela piora a leitura, porque a posição não diz o que cada valor significa.",
+            },
+            {
+                frente: "O que é um tipo literal?",
+                verso: "Um tipo que aceita um valor específico, como o texto ativo. Combinado em união, ele descreve um conjunto fechado de opções com autocompletar. É a forma mais leve de representar estado, sem precisar de enum.",
+            },
+            {
+                frente: "O que o as const faz?",
+                verso: "Congela o valor no tipo mais específico possível: literais em vez de texto, e propriedades somente leitura. É o que permite derivar uma união a partir de uma lista de constantes, mantendo um lugar só como fonte da verdade.",
+            },
+            {
+                frente: "Quando um enum vale a pena, e o que usar no lugar?",
+                verso: "Enum gera código em tempo de execução e tem regras próprias que surpreendem. Na maioria dos casos, um objeto constante com as const mais uma união de literais entrega o mesmo com menos surpresa e sem nada no pacote final.",
+            },
+            {
+                frente: "O que é uma asserção de tipo?",
+                verso: "É dizer ao compilador que você sabe mais do que ele, com a palavra as. Ela não converte nada em tempo de execução: só cala a checagem. Se a afirmação estiver errada, o erro aparece adiante, num lugar sem relação aparente.",
+            },
+            {
+                frente: "Por que asserção de tipo é arriscada?",
+                verso: "Porque desliga a única proteção que você tinha naquele ponto, e o compilador confia. Ela é aceitável na borda, logo depois de uma validação de verdade. Espalhada pelo código, ela transforma o TypeScript em comentário.",
+            },
+            {
+                frente: "O que o operador de não nulo faz, e qual o risco?",
+                verso: "A exclamação diz que o valor não é nulo nem indefinido, sem checar nada. O risco é ser mentira: o erro em tempo de execução volta, agora sem aviso do compilador. Quase sempre existe uma checagem simples que resolve melhor.",
+            },
+            {
+                frente: "O que é encadeamento opcional?",
+                verso: "O ponto de interrogação antes do acesso, que devolve indefinido em vez de quebrar quando o valor é nulo. É útil, e vira problema quando é usado para calar erro: cinco encadeamentos seguidos costumam esconder que o dado deveria existir.",
+            },
+            {
+                frente: "Qual a diferença entre o operador de coalescência nula e o ou lógico?",
+                verso: "O de coalescência só cai no valor de reserva quando o lado esquerdo é nulo ou indefinido. O ou lógico cai também com zero, texto vazio e falso. É por isso que um contador zerado vira o valor padrão quando se usa o operador errado.",
+            },
+            {
+                frente: "O que readonly muda numa propriedade?",
+                verso: "Impede reatribuir aquele campo depois de criado, na checagem de tipos. Não congela nada em tempo de execução, e não impede alterar o conteúdo de um objeto interno. É intenção documentada, e não proteção real.",
+            },
+            {
+                frente: "Como você tipa um objeto?",
+                verso: "Descrevendo suas propriedades com nome e tipo, marcando as opcionais e evitando campos genéricos demais. Um tipo com nome no domínio vale mais que um objeto anônimo repetido em cinco lugares.",
+            },
+            {
+                frente: "O que é uma assinatura de índice?",
+                verso: "É declarar que o objeto aceita qualquer chave de um tipo, como texto, com valores de um tipo. Serve para dicionário. O custo é perder o autocompletar das chaves conhecidas, e por isso Record com união de chaves costuma ser melhor.",
+            },
+            {
+                frente: "O que são genéricos, na ideia?",
+                verso: "Tipos com parâmetro: você escreve uma função ou estrutura que funciona com vários tipos, sem perder a informação. Uma função que devolve o primeiro item de uma lista devolve o tipo do item, e não algo genérico demais.",
+            },
+            {
+                frente: "O que é o tsconfig?",
+                verso: "O arquivo que diz ao compilador quais arquivos entram, quão estrito ele deve ser, para qual versão gerar e como resolver módulos. Ele é a diferença entre um projeto que pega erros de verdade e outro que só tem tipos decorativos.",
+            },
+            {
+                frente: "O que a opção estrita liga?",
+                verso: "Um conjunto de checagens, entre elas nulos estritos, proibição de any implícito e checagem de inicialização de campos. É a configuração recomendada para projeto novo, porque ligar depois numa base grande custa muito mais.",
+            },
+            {
+                frente: "O que target e module controlam?",
+                verso: "O target define a versão de JavaScript gerada, o que determina o que precisa ser transformado. O module define o formato dos imports gerados. Os dois precisam combinar com onde o código vai rodar, senão o erro aparece só na execução.",
+            },
+            {
+                frente: "O que a opção lib controla?",
+                verso: "Quais definições do ambiente estão disponíveis, como as APIs do navegador ou os recursos de uma versão da linguagem. É por isso que um método existente pode aparecer como inexistente: falta declarar a biblioteca correspondente.",
+            },
+            {
+                frente: "Para que serve gerar arquivos de declaração?",
+                verso: "Para publicar uma biblioteca com tipos sem publicar o código-fonte, permitindo que quem consome tenha autocompletar e checagem. Sem eles, quem usa o pacote cai em any, e todo o ganho do TypeScript se perde na fronteira.",
+            },
+            {
+                frente: "O que o modo de só checar tipos faz?",
+                verso: "Roda a checagem sem gerar arquivo nenhum. É o que se usa quando outra ferramenta cuida da geração, como um empacotador ou o próprio Node removendo tipos. Assim a checagem vira um passo próprio da esteira.",
+            },
+            {
+                frente: "Como você usa uma biblioteca que não tem tipos?",
+                verso: "Instalando o pacote de tipos mantido pela comunidade quando existe, ou escrevendo um arquivo de declaração mínimo com o que você usa. Deixar cair em any funciona e apaga a checagem em todo lugar que toca aquela biblioteca.",
+            },
+            {
+                frente: "O que é um arquivo de declaração?",
+                verso: "Um arquivo só com tipos, sem implementação, que descreve a forma de um módulo ou de variáveis globais. É como o TypeScript conhece bibliotecas escritas em JavaScript e o ambiente em que o código roda.",
+            },
+            {
+                frente: "Como você tipa variáveis de ambiente?",
+                verso: "Lendo todas num módulo de configuração, validando e exportando um objeto tipado. Declarar que a variável existe não a faz existir: em tempo de execução ela pode vir indefinida, e é a validação que evita a surpresa.",
+            },
+            {
+                frente: "Como você tipa a resposta de uma requisição?",
+                verso: "Declarando o tipo esperado e, na borda, validando de verdade que a resposta tem esse formato. O tipo é uma promessa sua, não do servidor: se o contrato mudar, o compilador continua feliz e o erro aparece em produção.",
+            },
+            {
+                frente: "Qual a diferença entre importar tipo e importar valor?",
+                verso: "A importação de tipo é apagada na compilação e não gera dependência em tempo de execução. Marcar explicitamente evita importar um módulo inteiro só por causa de um tipo, e evita ciclo de importação que só existe no código gerado.",
+            },
+            {
+                frente: "O que acontece com os tipos no código gerado?",
+                verso: "Somem. Anotação, interface e tipo não deixam rastro. É por isso que não existe reflexão sobre tipos e que validação em tempo de execução precisa ser escrita à parte, com uma biblioteca ou na mão.",
+            },
+            {
+                frente: "Como você lê uma mensagem de erro do TypeScript?",
+                verso: "De baixo para cima: a última linha costuma dizer qual propriedade ou tipo não bate, e o topo dá o contexto. Em erro de objeto grande, vale isolar o trecho numa variável tipada para o compilador apontar o campo exato.",
+            },
+            {
+                frente: "O que significa dizer que o TypeScript tem tipagem estrutural?",
+                verso: "Que a compatibilidade é pela forma, e não pelo nome: se o objeto tem as propriedades exigidas, ele serve, mesmo sem declarar que implementa nada. É o oposto de linguagens onde o tipo precisa ser declarado explicitamente.",
+            },
+            {
+                frente: "Por que um objeto literal com campo a mais dá erro?",
+                verso: "Por causa da checagem de propriedades em excesso, que só vale para literais atribuídos diretamente. Ela existe para pegar erro de digitação em nome de campo. Passando pela variável antes, o erro some, porque a checagem estrutural aceita.",
+            },
+            {
+                frente: "Como você tipa uma função assíncrona?",
+                verso: "Declarando o retorno como promessa do tipo real. Uma função marcada como assíncrona sempre devolve promessa, então o tipo precisa refletir isso. O erro comum é esquecer o await e acabar tratando a promessa como se fosse o valor.",
+            },
+            {
+                frente: "Como você tipa as props de um componente?",
+                verso: "Com um tipo declarado para o objeto de propriedades, marcando o que é opcional e evitando any. Isso vira documentação viva, com autocompletar em quem usa o componente. Prop booleana solta em excesso é sinal de que faltou uma união.",
+            },
+            {
+                frente: "Como você tipa o estado de um componente?",
+                verso: "Deixando inferir quando o valor inicial já diz tudo, e anotando quando ele começa vazio ou nulo. Estado que começa nulo precisa do tipo declarado como união, senão o compilador acha que ele será sempre nulo.",
+            },
+            {
+                frente: "O que é um tipo utilitário?",
+                verso: "Um tipo pronto que transforma outro, como tornar tudo opcional, escolher algumas propriedades ou remover outras. Eles evitam duplicar a definição de um objeto para cada variação, mantendo uma fonte da verdade só.",
+            },
+            {
+                frente: "Para que servem Partial e Required?",
+                verso: "Partial torna todas as propriedades opcionais, útil para atualização parcial. Required faz o contrário. Usar Partial no lugar errado esconde campo obrigatório faltando, então ele combina com atualização, e não com criação.",
+            },
+            {
+                frente: "Para que servem Pick e Omit?",
+                verso: "Pick cria um tipo com algumas propriedades do original; Omit cria com todas menos as listadas. Servem para derivar o tipo de uma resposta a partir da entidade, sem repetir campos e sem esquecer de atualizar os dois.",
+            },
+            {
+                frente: "Como você tipa um objeto de chave e valor?",
+                verso: "Com Record, informando o tipo das chaves e dos valores. Quando as chaves são conhecidas, usar uma união de literais como chave faz o compilador cobrar que todas estejam presentes, o que é melhor que uma assinatura de índice solta.",
+            },
+            {
+                frente: "Como você tipa um evento de formulário?",
+                verso: "Com o tipo de evento correspondente, informando qual elemento o disparou, para o alvo ter as propriedades certas. Sem isso, ler o valor do campo exige asserção, que é exatamente o tipo de remendo que a tipagem deveria evitar.",
+            },
+            {
+                frente: "Como você tipa uma lista de opções para um seletor?",
+                verso: "Com um array de objetos tendo valor tipado como união de literais e rótulo como texto, marcado com as const quando é constante. Assim o valor selecionado já vem estreitado, e não como texto qualquer.",
+            },
+            {
+                frente: "O que muda ao declarar o retorno de uma função?",
+                verso: "O erro passa a aparecer dentro da função, apontando o ponto que devolve algo diferente, e não em quem chama. Também impede que uma mudança interna altere o contrato sem ninguém notar.",
+            },
+            {
+                frente: "Como você lida com um valor que pode ser nulo?",
+                verso: "Checando antes de usar, o que faz o compilador estreitar o tipo dali para baixo. Encerrar cedo com um retorno costuma ler melhor que aninhar. Silenciar com asserção devolve o erro para o tempo de execução.",
+            },
+            {
+                frente: "O que significa a mensagem de que um tipo não é atribuível a outro?",
+                verso: "Que a forma esperada exige algo que o valor não tem, ou tem em formato diferente. Costuma ser propriedade faltando, opcional onde se esperava obrigatório, ou união que inclui indefinido. O detalhe do erro aponta o campo.",
+            },
+            {
+                frente: "Como você evita repetir o mesmo tipo em vários arquivos?",
+                verso: "Declarando num módulo de tipos do domínio e importando. Duplicar a mesma interface em três lugares parece inofensivo até o dia em que uma delas ganha um campo e as outras não, e o erro só aparece em tempo de execução.",
+            },
+            {
+                frente: "Como você nomeia tipos num projeto?",
+                verso: "Pelo conceito do domínio, sem prefixo nem sufixo técnico, e no singular. Nome que descreve o papel envelhece melhor que nome que descreve a estrutura, e evita ter tipos chamados dados e informação espalhados pela base.",
+            },
+            {
+                frente: "Onde os tipos de um projeto devem viver?",
+                verso: "Perto de quem os usa: tipo de domínio junto do domínio, tipo de resposta junto do cliente da API. Uma pasta central com todos os tipos vira depósito, acopla módulos que não têm relação e cresce sem ninguém revisar.",
+            },
+            {
+                frente: "Como você tipa uma função que recebe outra função?",
+                verso: "Declarando a assinatura esperada do retorno de chamada, com parâmetros e retorno. Assim quem chama recebe autocompletar dentro do lambda. Aceitar uma função genérica sem assinatura é onde o any volta pela porta dos fundos.",
+            },
+            {
+                frente: "O que acontece se você desligar a checagem num arquivo?",
+                verso: "Aquele arquivo deixa de ser verificado e passa a exportar tipos frouxos para quem depende dele. O buraco não fica contido: ele se espalha por todo mundo que importa daquele módulo.",
+            },
+            {
+                frente: "Como você começa a usar TypeScript num projeto JavaScript?",
+                verso: "Permitindo os dois formatos e convertendo arquivo por arquivo, começando pelas bordas e pelo que é compartilhado, com a checagem rodando na esteira desde o começo. Converter tudo de uma vez produz tipos frouxos que não protegem nada.",
+            },
+            {
+                frente: "Qual a diferença entre ignorar um erro e esperar um erro?",
+                verso: "A marcação de ignorar cala qualquer erro naquela linha e continua calada quando o erro sumir. A de esperar erro reclama se a linha passar a compilar, então ela avisa que o remendo não é mais necessário. Sempre que der, use a segunda.",
+            },
+            {
+                frente: "Por que o TypeScript não impede erro em tempo de execução?",
+                verso: "Porque ele checa o que você escreveu, e não o que chega. Resposta de API, leitura de arquivo e entrada do usuário podem vir diferente do declarado. A garantia acaba na borda, e é lá que precisa existir validação de verdade.",
+            },
+            {
+                frente: "Como você tipa um valor que vem de JSON?",
+                verso: "Como unknown, e validando antes de usar. O resultado da desserialização é qualquer coisa: declarar o tipo esperado é uma promessa sem verificação, e o erro só aparece quando alguém acessa um campo que não veio.",
+            },
+            {
+                frente: "O que é autocompletar baseado em tipos, na prática?",
+                verso: "O editor usando as mesmas informações do compilador para sugerir propriedade, argumento e valor possível. É o retorno mais imediato do TypeScript, e some justamente quando o código cai em any, que é quando você mais precisaria.",
+            },
+            {
+                frente: "Como você tipa uma constante de configuração?",
+                verso: "Com as const para congelar os literais e um tipo derivado dela, em vez de declarar o tipo à mão. Assim a lista de valores válidos tem um lugar só, e acrescentar um valor atualiza o tipo automaticamente.",
+            },
+            {
+                frente: "O que significa dizer que os tipos são apagados?",
+                verso: "Que nada do sistema de tipos sobrevive à compilação: nem interface, nem genérico, nem anotação. É a razão de não existir checagem em tempo de execução com base neles e de o pacote final não crescer por causa de tipagem.",
+            },
+        ],
+        junior: [
+            {
+                frente: "O que é estreitamento de tipo?",
+                verso: "É o compilador reduzir uma união conforme as checagens que você faz. Depois de um if que confirma que o valor é texto, dali para baixo ele é texto. É o mecanismo que torna união utilizável sem asserção.",
+            },
+            {
+                frente: "Como o operador typeof estreita um tipo?",
+                verso: "Comparando com o nome do tipo primitivo, o compilador entende o ramo. Funciona bem para texto, número, booleano e função. Para objeto ele não ajuda muito, porque nulo também é objeto, e é aí que se usa outra forma de checagem.",
+            },
+            {
+                frente: "Quando o instanceof serve para estreitar?",
+                verso: "Quando o valor é instância de uma classe, como um erro personalizado. Não funciona para interface, que não existe em tempo de execução, nem entre contextos diferentes, como dois quadros do navegador, onde o construtor não é o mesmo.",
+            },
+            {
+                frente: "O que é um guarda de tipo definido por você?",
+                verso: "Uma função que devolve booleano e declara no retorno que o argumento é de determinado tipo. O compilador passa a confiar nela para estreitar. O risco é a implementação mentir: ali a garantia é sua, e não do compilador.",
+            },
+            {
+                frente: "O que é uma união discriminada?",
+                verso: "Uma união de objetos que compartilham um campo com valor literal diferente, como tipo sucesso e tipo erro. Checar esse campo estreita para o membro certo, com os campos daquele caso disponíveis e os outros fora de alcance.",
+            },
+            {
+                frente: "Por que união discriminada é melhor que campos opcionais?",
+                verso: "Porque ela torna estados impossíveis irrepresentáveis. Com campos opcionais, dá para ter erro e dado ao mesmo tempo, ou nenhum dos dois, e todo consumidor precisa checar tudo. Com discriminante, cada caso traz exatamente o que existe nele.",
+            },
+            {
+                frente: "Como você garante que tratou todos os casos de uma união?",
+                verso: "Atribuindo o valor restante a never no ramo final. Se alguém acrescentar um caso, o compilador acusa ali. É a checagem exaustiva, e é o que transforma acrescentar uma opção nova em erro de compilação em vez de bug silencioso.",
+            },
+            {
+                frente: "O que o operador keyof faz?",
+                verso: "Devolve a união das chaves de um tipo. Serve para escrever funções que recebem o nome de uma propriedade e devolvem o tipo certo daquele campo, em vez de aceitar texto qualquer.",
+            },
+            {
+                frente: "O que typeof faz no espaço de tipos?",
+                verso: "Pega o tipo de um valor existente, como uma constante ou um objeto de configuração. Combinado com as const, é o que permite derivar a união de opções a partir da lista real, sem manter duas declarações em sincronia.",
+            },
+            {
+                frente: "Como você acessa o tipo de uma propriedade específica?",
+                verso: "Indexando o tipo com o nome da chave entre colchetes. Isso evita repetir a declaração e mantém a ligação: se o campo mudar de tipo, quem depende dele muda junto e o erro aparece na compilação.",
+            },
+            {
+                frente: "Qual a diferença entre Record e assinatura de índice?",
+                verso: "Record com união de chaves conhecidas obriga a preencher todas e mantém autocompletar. Assinatura de índice aceita qualquer chave e devolve o tipo do valor para tudo, inclusive para chave que não existe, o que esconde erro de digitação.",
+            },
+            {
+                frente: "O que o satisfies resolve?",
+                verso: "Checa que um valor obedece a um tipo sem alargar a inferência dele. Você ganha a validação do formato e mantém os literais específicos, o que é o que se quer em objeto de configuração e mapa de rotas.",
+            },
+            {
+                frente: "Qual a diferença entre satisfies e uma asserção?",
+                verso: "A asserção afirma sem checar e pode mentir. O satisfies verifica de verdade e ainda preserva o tipo inferido. Onde antes se usava asserção para calar erro em objeto de configuração, hoje satisfies faz o certo.",
+            },
+            {
+                frente: "Por que a variável do catch é unknown?",
+                verso: "Porque em JavaScript qualquer valor pode ser lançado, não só um erro. Com a opção estrita, o compilador obriga a checar antes de acessar mensagem. Tratar como erro sem checar quebra quando alguém lança um texto.",
+            },
+            {
+                frente: "Como você trata um erro tipado no catch?",
+                verso: "Checando com instanceof contra a classe de erro esperada, e tendo um caminho para o que não bate. Erro personalizado com campo discriminante também funciona bem, porque permite tratar por código em vez de por mensagem.",
+            },
+            {
+                frente: "Como você modela o resultado de uma operação que pode falhar?",
+                verso: "Com uma união discriminada de sucesso e falha, obrigando quem chama a tratar os dois. É útil quando a falha é esperada, como validação. Para o que não deveria acontecer, exceção continua sendo o caminho.",
+            },
+            {
+                frente: "O que é uma restrição em um genérico?",
+                verso: "É limitar o parâmetro de tipo com extends, exigindo que ele tenha determinada forma. Sem restrição, dentro da função você não pode fazer nada com o valor. Com ela, você acessa o que foi exigido e mantém o tipo específico de quem chamou.",
+            },
+            {
+                frente: "Quando um genérico é desnecessário?",
+                verso: "Quando o parâmetro de tipo aparece uma vez só na assinatura. Nesse caso ele não está ligando entrada e saída, e uma união ou unknown descreveria melhor. Genérico existe para preservar a relação entre o que entra e o que sai.",
+            },
+            {
+                frente: "O que ReturnType e Parameters fazem?",
+                verso: "Extraem o tipo de retorno e a tupla de parâmetros de uma função. Servem para derivar tipos de código existente sem duplicar, principalmente ao envolver uma função de biblioteca ou tipar um dublê de teste.",
+            },
+            {
+                frente: "O que o utilitário Awaited resolve?",
+                verso: "Desembrulha o tipo de dentro de uma promessa, inclusive aninhada. É o que permite derivar o tipo de dado a partir de uma função assíncrona já existente, em vez de declarar o mesmo formato duas vezes.",
+            },
+            {
+                frente: "Qual a diferença entre um array normal e um somente leitura?",
+                verso: "O somente leitura não aceita métodos que alteram, como push e sort no lugar. É o tipo certo para parâmetro que a função não deve modificar, e comunica isso a quem lê. Um array normal é atribuível a ele, mas não o contrário.",
+            },
+            {
+                frente: "Por que Object.keys devolve um array de texto?",
+                verso: "Porque um objeto em tempo de execução pode ter mais chaves do que o tipo declara, por causa da tipagem estrutural. Devolver as chaves conhecidas seria mentira. Quando você tem certeza, o caminho é uma função utilitária com asserção controlada.",
+            },
+            {
+                frente: "Como você itera um objeto mantendo os tipos?",
+                verso: "Com entradas tipadas por uma função auxiliar, ou percorrendo uma lista de chaves conhecidas derivada por keyof. O importante é ter um lugar só onde a asserção acontece, em vez de espalhar conversões pelo laço.",
+            },
+            {
+                frente: "Como você tipa uma função que aceita várias formas de chamada?",
+                verso: "Com sobrecarga, declarando as assinaturas válidas e uma implementação compatível com todas. Serve quando o retorno depende do formato dos argumentos. Se as formas são independentes, duas funções com nomes claros costumam ser melhores.",
+            },
+            {
+                frente: "Quando união é melhor que sobrecarga?",
+                verso: "Quando o retorno não muda conforme a entrada. União mantém uma assinatura só e é mais fácil de manter. Sobrecarga existe para casos em que o tipo de saída depende do tipo de entrada, e ela precisa ser mantida à mão.",
+            },
+            {
+                frente: "Como você tipa uma classe em TypeScript?",
+                verso: "Declarando os campos com seus tipos e modificadores, e usando o construtor para exigir o que é obrigatório. Parâmetro de construtor com modificador já cria a propriedade, o que reduz repetição em classes de serviço.",
+            },
+            {
+                frente: "O que os modificadores de acesso garantem?",
+                verso: "Private e protected são checados só na compilação, então nada impede o acesso em tempo de execução. Para privacidade real existe o campo com cerquilha, que é do próprio JavaScript. A diferença aparece quando alguém consome o código compilado.",
+            },
+            {
+                frente: "O que implements faz numa classe?",
+                verso: "Declara que ela deve satisfazer um contrato, e o compilador cobra. Não muda a compatibilidade estrutural: uma classe sem implements que tenha a mesma forma continua servindo. O ganho é o erro aparecer na classe, e não em quem usa.",
+            },
+            {
+                frente: "Como você tipa uma extensão de um objeto de biblioteca?",
+                verso: "Com declaração de módulo reaberta, acrescentando a propriedade ao tipo existente. É como se acrescenta o usuário autenticado ao objeto de requisição. Requer disciplina: o tipo passa a prometer algo que só existe se o middleware rodar.",
+            },
+            {
+                frente: "O que é fusão de declarações?",
+                verso: "Duas declarações do mesmo nome se combinarem, como duas interfaces com o mesmo nome virando uma. É o mecanismo que permite estender tipos de bibliotecas. Também é uma fonte de confusão quando acontece sem querer.",
+            },
+            {
+                frente: "Como você compartilha tipos entre dois projetos?",
+                verso: "Publicando um pacote de tipos versionado, ou gerando a partir de um contrato. Importar direto do outro projeto por caminho relativo acopla os dois e quebra assim que um deles for publicado sozinho.",
+            },
+            {
+                frente: "Como você evita ciclos de importação por causa de tipos?",
+                verso: "Importando com a marcação de tipo, que é apagada e não gera dependência em tempo de execução, e movendo tipos compartilhados para um módulo sem lógica. Ciclo que só existe no código gerado é dos mais difíceis de enxergar.",
+            },
+            {
+                frente: "Como você tipa um hook próprio no React?",
+                verso: "Deixando o retorno inferido quando ele é um objeto, e usando as const quando é uma tupla, para as posições não virarem união. Sem isso, desestruturar um par devolve o tipo somado dos dois em cada posição.",
+            },
+            {
+                frente: "Como você tipa um redutor de estado?",
+                verso: "Com uma união discriminada para as ações e o tipo do estado, deixando o switch estreitar cada caso. Assim cada ação carrega só os campos que fazem sentido para ela, e acrescentar uma ação sem tratar vira erro de compilação.",
+            },
+            {
+                frente: "Como você tipa um contexto do React?",
+                verso: "Criando com valor inicial indefinido e um tipo de união, e expondo um hook que lança se for usado fora do provedor. Assim o consumidor recebe o tipo já estreitado, sem precisar checar indefinido em toda tela.",
+            },
+            {
+                frente: "Como você tipa uma referência a elemento?",
+                verso: "Informando o tipo do elemento no genérico e iniciando com nulo, porque antes da montagem ela é nula. O compilador então obriga a checar antes de usar, que é exatamente o caso que quebra quando o efeito roda cedo demais.",
+            },
+            {
+                frente: "Como você tipa children em um componente?",
+                verso: "Com o tipo de nó do React, que aceita texto, elemento, lista e nulo. Tipar como elemento único recusa texto e listas, e é uma das causas mais comuns de erro em componentes de layout.",
+            },
+            {
+                frente: "Como você tipa uma lista genérica reutilizável?",
+                verso: "Com um parâmetro de tipo para o item, e as funções de renderização e de chave recebendo esse tipo. Assim quem usa mantém o autocompletar do item dentro do render, em vez de receber algo genérico demais.",
+            },
+            {
+                frente: "Como você deriva um tipo a partir de um esquema de validação?",
+                verso: "Usando o utilitário da própria biblioteca de validação, que infere o tipo do esquema. Assim existe uma fonte da verdade: a validação em tempo de execução e o tipo em tempo de compilação não podem divergir.",
+            },
+            {
+                frente: "Por que validar se o dado já está tipado?",
+                verso: "Porque o tipo não existe em tempo de execução: ele descreve o que você espera, não o que chega. Resposta de API, arquivo e formulário podem vir diferentes. Sem validação na borda, o tipo vira documentação otimista.",
+            },
+            {
+                frente: "Como você tipa a configuração de um projeto?",
+                verso: "Lendo o ambiente num módulo, validando com esquema e exportando o objeto já tipado e imutável. O resto do código importa esse objeto e nunca lê o ambiente direto, o que também deixa claro em um lugar tudo que o serviço precisa.",
+            },
+            {
+                frente: "Como você lida com any que veio de uma biblioteca?",
+                verso: "Envolvendo o uso numa função própria que declara o tipo real e valida o mínimo. Assim o any fica contido num arquivo, em vez de se espalhar por quem chama. Deixar solto contamina silenciosamente todo o fluxo.",
+            },
+            {
+                frente: "Como você encontra any escondido numa base?",
+                verso: "Ligando as regras que proíbem any implícito e as de lint que acusam expressão insegura, e olhando onde a checagem foi desligada. O any mais perigoso não é o escrito: é o herdado de biblioteca sem tipos.",
+            },
+            {
+                frente: "O que a checagem de índice não verificado muda?",
+                verso: "Acessar posição de array ou chave de dicionário passa a incluir indefinido no tipo, porque o compilador não sabe se existe. É a opção que mais expõe bug real, e também a que mais incomoda no começo, porque exige checar.",
+            },
+            {
+                frente: "Como você tipa uma função que envolve outra preservando a assinatura?",
+                verso: "Com parâmetro de tipo capturando os parâmetros e o retorno da original, usando os utilitários de função. Assim o invólucro aceita exatamente os mesmos argumentos e devolve o mesmo tipo, sem duplicar a assinatura.",
+            },
+            {
+                frente: "O que muda com a checagem estrita de tipos de função?",
+                verso: "Parâmetros passam a ser comparados de forma mais rigorosa, o que impede passar uma função que aceita menos do que o contrato promete. Métodos continuam com a regra antiga, mais frouxa, por compatibilidade com o ecossistema.",
+            },
+            {
+                frente: "Como você tipa um dicionário de tradução?",
+                verso: "Com as const na estrutura e um tipo derivado das chaves, para o compilador aceitar só chaves existentes. Assim uma chave removida quebra na compilação em vez de virar texto faltando na tela.",
+            },
+            {
+                frente: "Como você tipa um objeto que vem parcialmente preenchido?",
+                verso: "Com Partial quando é atualização, e com uma união discriminada quando o estado incompleto significa outra coisa. Marcar tudo opcional para caber nos dois casos obriga a checar cada campo em todo lugar.",
+            },
+            {
+                frente: "Como você impede que dois identificadores de tipos diferentes sejam trocados?",
+                verso: "Marcando cada um com um campo de marca invisível, criando tipos incompatíveis mesmo sendo texto por baixo. Assim passar o identificador de pedido onde se espera o de usuário vira erro de compilação, e não bug em produção.",
+            },
+            {
+                frente: "Como você tipa valores com unidade, como milissegundos?",
+                verso: "Com tipo marcado ou com um objeto que carrega a unidade, para não somar segundo com milissegundo sem perceber. O compilador não sabe o que o número significa, e esse é um erro que aparece em produção como atraso estranho.",
+            },
+            {
+                frente: "Como você tipa o retorno de uma consulta com colunas escolhidas?",
+                verso: "Derivando da entidade com Pick, ou deixando a biblioteca inferir a partir da consulta quando ela suporta. Declarar à mão duplica a definição e some da revisão quando alguém acrescenta uma coluna.",
+            },
+            {
+                frente: "Como você tipa um emissor de eventos?",
+                verso: "Com um mapa de nome do evento para a tupla de argumentos, e métodos genéricos que usam esse mapa. Assim ouvir um evento que não existe ou tratar argumento errado vira erro de compilação, em vez de retorno de chamada nunca chamado.",
+            },
+            {
+                frente: "Como você tipa uma função que aceita um caminho de propriedade?",
+                verso: "Com keyof para um nível, e com tipo literal de template para caminhos aninhados. O segundo caso é poderoso e caro: se o objeto for grande, o tipo explode e o editor fica lento. Vale medir antes de adotar.",
+            },
+            {
+                frente: "Como você lida com a mensagem de erro enorme de um tipo genérico?",
+                verso: "Isolando o trecho numa variável com o tipo esperado, para o compilador comparar coisas menores, e simplificando o genérico até o erro ficar legível. Muitas vezes a causa é um campo opcional lá no fundo da estrutura.",
+            },
+            {
+                frente: "Como você tipa um cliente HTTP próprio?",
+                verso: "Com um genérico para o corpo de resposta e validação na borda antes de devolver. O tipo declarado é uma promessa: sem validar, ele mente quando a API mudar, e o erro só aparece páginas depois.",
+            },
+            {
+                frente: "Como você tipa erros de uma API?",
+                verso: "Com uma união discriminada por código, para o consumidor tratar cada caso, e um tipo de erro genérico para o inesperado. Erro tipado só como texto obriga todo mundo a comparar mensagem, que muda sem aviso.",
+            },
+            {
+                frente: "Como você tipa um middleware de servidor?",
+                verso: "Declarando os tipos de requisição, resposta e próximo passo do próprio framework, e estendendo a requisição quando você acrescenta contexto. O cuidado é lembrar que a extensão é uma promessa: se o middleware não rodar, o campo não existe.",
+            },
+            {
+                frente: "Como você lida com bibliotecas que ainda usam decoradores antigos?",
+                verso: "Verificando qual proposta a biblioteca segue, porque a versão do padrão e a antiga têm comportamento e configuração diferentes. Misturar as duas no mesmo projeto produz erro difícil de interpretar na inicialização.",
+            },
+            {
+                frente: "Como você tipa um valor de enumeração vindo do banco?",
+                verso: "Com união de literais espelhando os valores, e validação ao ler, porque o banco pode ter algo que o código não conhece. Confiar na conversão direta é o que faz uma linha antiga quebrar a aplicação inteira.",
+            },
+            {
+                frente: "Como você testa que um tipo se comporta como esperado?",
+                verso: "Com testes de tipo: atribuições que devem compilar e outras marcadas com a expectativa de erro. Isso vale para biblioteca e para tipos utilitários complexos, onde uma mudança pode afrouxar tudo sem quebrar nenhum teste comum.",
+            },
+            {
+                frente: "Como você lida com um erro de tipo dentro de uma dependência?",
+                verso: "Pulando a checagem dos arquivos de declaração das dependências, que é o padrão em muitos projetos, e abrindo questão no repositório dela. A opção esconde erro real de compatibilidade, então vale saber que ela está ligada.",
+            },
+            {
+                frente: "Como você organiza os tipos de uma API que o front consome?",
+                verso: "Gerando a partir do contrato quando ele existe, ou publicando um pacote de tipos versionado. E validando na borda mesmo assim. Copiar as interfaces para o front funciona por um tempo e diverge na primeira mudança.",
+            },
+            {
+                frente: "Como você tipa um formulário com muitos campos?",
+                verso: "Derivando do esquema de validação, para não manter duas listas. A tipagem do formulário e a validação precisam ser a mesma fonte, senão o campo novo aparece num lado e não no outro, e ninguém percebe até o envio falhar.",
+            },
+            {
+                frente: "Como você lida com um tipo que é quase igual a outro?",
+                verso: "Derivando com Pick, Omit ou interseção em vez de copiar. Duplicar parece mais simples, e o custo aparece quando o original muda: uma das cópias fica para trás e o compilador não avisa, porque as duas são válidas.",
+            },
+            {
+                frente: "Como você declara um módulo que não tem tipos?",
+                verso: "Com um arquivo de declaração informando o nome do módulo e o que você usa dele. Declarar como any resolve o erro e apaga a checagem; declarar as funções usadas custa poucos minutos e mantém a segurança.",
+            },
+            {
+                frente: "Como você tipa uma função que devolve tipos diferentes conforme uma opção?",
+                verso: "Com sobrecarga ou com tipo condicional sobre o parâmetro. Antes disso, vale perguntar se não são duas funções: assinatura que muda de retorno conforme uma bandeira booleana costuma ser difícil de usar e de manter.",
+            },
+            {
+                frente: "Como você evita que um objeto de configuração aceite chave errada?",
+                verso: "Tipando com um Record de chaves conhecidas ou usando satisfies contra um tipo que descreve o formato. Assim uma chave com erro de digitação vira erro de compilação, em vez de opção ignorada em silêncio.",
+            },
+            {
+                frente: "Como você lida com valores que só existem em certos ambientes?",
+                verso: "Declarando o tipo como possivelmente ausente e tratando, em vez de assumir presença. Aquilo que existe só no navegador ou só no servidor precisa de fronteira explícita, senão o código quebra do outro lado sem aviso do compilador.",
+            },
+            {
+                frente: "Como você tipa uma função de comparação para ordenação?",
+                verso: "Recebendo dois itens do mesmo tipo e devolvendo número. Quando a ordenação é por campo, um genérico com keyof garante que só campos existentes sejam aceitos, e evita ordenar por um nome que ninguém percebeu estar errado.",
+            },
+            {
+                frente: "O que muda quando você marca uma propriedade como opcional e quando você inclui indefinido no tipo?",
+                verso: "Opcional permite a chave não existir. Incluir indefinido exige a chave, aceitando o valor indefinido. Na maioria dos casos a diferença é irrelevante, e ela passa a importar quando a opção estrita de propriedades opcionais está ligada.",
+            },
+        ],
+        pleno: [
+            {
+                frente: "O que são tipos condicionais?",
+                verso: "Tipos que escolhem um resultado conforme uma relação entre outros, na forma se estende então senão. É o que permite descrever transformações genéricas, como desembrulhar uma promessa. Usado demais, produz tipo que ninguém consegue depurar.",
+            },
+            {
+                frente: "Como o infer funciona?",
+                verso: "Dentro de um tipo condicional, ele captura uma parte do tipo comparado e dá um nome a ela, como o elemento de um array. É assim que utilitários extraem retorno e parâmetros de uma função sem você declarar nada.",
+            },
+            {
+                frente: "O que são tipos mapeados?",
+                verso: "Tipos que percorrem as chaves de outro e produzem um novo, aplicando modificadores. É a base de Partial, Required e Readonly. Também permitem renomear chaves e filtrar propriedades por tipo, o que resolve muita duplicação.",
+            },
+            {
+                frente: "Como você remove a opcionalidade de propriedades num tipo mapeado?",
+                verso: "Com o modificador de menos aplicado à interrogação, que tira o opcional. O mesmo vale para readonly. É o que permite escrever o inverso de Partial e derivar o tipo completo a partir de um parcial.",
+            },
+            {
+                frente: "O que são tipos literais de template?",
+                verso: "Tipos que compõem texto a partir de outros tipos, como prefixo mais chave. Permitem descrever nomes de eventos e caminhos de propriedade com precisão. O custo é explosão combinatória: com muitas chaves, o tipo fica pesado para o compilador.",
+            },
+            {
+                frente: "Quando um tipo avançado deixa de valer a pena?",
+                verso: "Quando ninguém no time consegue mudá-lo com segurança, quando a mensagem de erro que ele produz é ilegível, ou quando ele deixa o editor lento. Tipo é código: se o custo de manutenção passa do risco que ele evita, ele não paga.",
+            },
+            {
+                frente: "Como você depura um tipo complexo?",
+                verso: "Quebrando em passos nomeados e inspecionando cada um no editor, e usando um utilitário que expande a estrutura para leitura. Trabalhar com um exemplo concreto pequeno vale mais que olhar o genérico inteiro.",
+            },
+            {
+                frente: "O que é variância, e por que ela importa?",
+                verso: "É como a compatibilidade de um tipo composto segue a dos tipos que ele contém. Retorno é covariante e parâmetro deveria ser contravariante. Onde a linguagem afrouxa isso, por compatibilidade histórica, surgem buracos que o compilador aceita.",
+            },
+            {
+                frente: "Por que atribuir um array de um subtipo pode ser inseguro?",
+                verso: "Porque arrays são tratados como covariantes: um array de gato passa onde se espera array de animal, e alguém pode inserir um cachorro nele. É um buraco conhecido, herdado por praticidade, e a defesa é usar array somente leitura em parâmetros.",
+            },
+            {
+                frente: "Por que a checagem de propriedade em excesso não pega tudo?",
+                verso: "Porque ela só vale para objeto literal atribuído diretamente. Passando por uma variável intermediária, a compatibilidade estrutural aceita o campo a mais. É por isso que o mesmo objeto dá erro num lugar e passa no outro.",
+            },
+            {
+                frente: "Como você modela estados impossíveis fora do sistema?",
+                verso: "Trocando conjuntos de booleanas e campos opcionais por uma união discriminada em que cada caso carrega só o que existe nele. Assim carregando com erro preenchido deixa de compilar, em vez de virar bug de tela.",
+            },
+            {
+                frente: "Como você tipa uma máquina de estados?",
+                verso: "Com uma união de estados, uma união de eventos e uma função de transição que só aceita combinações válidas. Tipos condicionais permitem cobrar que um evento só seja aceito em certos estados, o que elimina uma classe inteira de bug.",
+            },
+            {
+                frente: "Como você geraria tipos a partir de um contrato de API?",
+                verso: "Com um gerador a partir da especificação, rodando na esteira e falhando se o arquivo gerado estiver desatualizado. Isso mantém front e backend em sincronia sem trabalho manual, e transforma quebra de contrato em erro de compilação.",
+            },
+            {
+                frente: "Quando gerar tipos é melhor que escrever à mão?",
+                verso: "Quando existe uma fonte da verdade externa, como esquema de API ou de banco, e ela muda com frequência. Escrever à mão duplica e diverge. O custo do gerado é ter mais um passo de build e código versionado que ninguém edita.",
+            },
+            {
+                frente: "Como você mantém tipo e validação em tempo de execução em sincronia?",
+                verso: "Declarando o esquema uma vez e derivando o tipo dele, e não o contrário. Assim não existe a possibilidade de o tipo dizer uma coisa e a validação aceitar outra, que é o problema clássico de manter os dois à mão.",
+            },
+            {
+                frente: "Como você escreveria um arquivo de declaração para uma biblioteca?",
+                verso: "Declarando o módulo pelo nome e exportando só o que você usa, com tipos honestos. Começar mínimo e crescer conforme o uso é melhor que tentar descrever a biblioteca inteira e errar assinaturas que você nunca chamou.",
+            },
+            {
+                frente: "Como você publica um pacote com tipos corretos?",
+                verso: "Gerando as declarações, apontando o campo de tipos, declarando as entradas no mapa de exportações e testando o consumo em um projeto com cada configuração de módulos. Muita biblioteca quebra justamente na combinação que ninguém testou.",
+            },
+            {
+                frente: "O que o mapa de exportações do package.json controla?",
+                verso: "Quais caminhos internos podem ser importados e qual arquivo responde a cada formato de módulo, incluindo as declarações. É o que evita alguém importar caminho interno seu e ficar dependente de detalhe de implementação.",
+            },
+            {
+                frente: "Como você suporta os dois formatos de módulo numa biblioteca?",
+                verso: "Gerando dois artefatos e declarando cada um no mapa de exportações, com declarações de tipo compatíveis com os dois. É trabalhoso, e por isso muitas bibliotecas hoje publicam só o formato padrão e cobram isso de quem consome.",
+            },
+            {
+                frente: "O que a resolução de módulos do TypeScript decide?",
+                verso: "Como um caminho de importação vira arquivo: se aceita extensão, como lê o mapa de exportações e quais declarações encontra. É a fonte mais comum de erro em que o editor acha o módulo e a execução não, ou o contrário.",
+            },
+            {
+                frente: "Como você organiza referências de projeto num repositório grande?",
+                verso: "Dividindo em projetos com dependências declaradas, para a checagem ser incremental e respeitar fronteiras. O ganho é build parcial e erro quando alguém importa através de uma fronteira que não deveria existir.",
+            },
+            {
+                frente: "Como você mediria o tempo de checagem de tipos?",
+                verso: "Com o diagnóstico estendido do compilador, que mostra tempo por fase e quantidade de tipos criados. Isso separa projeto grande de tipo caro. Sem medir, a resposta padrão vira comprar máquina melhor.",
+            },
+            {
+                frente: "O que costuma deixar a checagem de tipos lenta?",
+                verso: "Tipos condicionais profundos, literais de template combinando muitas chaves, uniões enormes e bibliotecas com declarações gigantes. Também importar tudo de um pacote em vez do subcaminho. Poucos pontos costumam responder pela maior parte do tempo.",
+            },
+            {
+                frente: "Como você lida com um tipo recursivo que estoura o limite?",
+                verso: "Limitando a profundidade com um contador de tipo, simplificando o formato ou aceitando um tipo menos preciso. Quando um tipo precisa de truques para não estourar, normalmente existe uma modelagem mais simples do problema.",
+            },
+            {
+                frente: "Quando interface tem vantagem sobre type por desempenho?",
+                verso: "Em objetos grandes que são estendidos, porque interfaces são armazenadas de forma incremental, e interseções de type precisam ser recalculadas. A diferença só aparece em projeto grande, e aí é uma otimização barata de aplicar.",
+            },
+            {
+                frente: "Como você adotaria uma opção estrita nova numa base grande?",
+                verso: "Ligando em um pacote ou pasta por vez, com uma lista do que falta, e cobrando na esteira só o que já foi migrado. Ligar tudo de uma vez gera milhares de erros e o time desliga de novo na semana seguinte.",
+            },
+            {
+                frente: "O que a opção que pula a checagem de bibliotecas faz?",
+                verso: "Ignora erros dentro dos arquivos de declaração das dependências, o que acelera muito a checagem e esconde incompatibilidade real entre versões de tipos. Quase todo projeto liga, e vale saber que ela está ligada quando algo estranho aparece.",
+            },
+            {
+                frente: "Como você usa TypeScript no Node sem passo de compilação?",
+                verso: "Deixando o Node remover os tipos na execução, o que funciona para sintaxe que só some. O ponto crítico é que isso não checa nada: a checagem continua sendo um passo próprio, e sem ela o projeto só tem anotação decorativa.",
+            },
+            {
+                frente: "Qual o risco de rodar sem checagem no ciclo de desenvolvimento?",
+                verso: "O erro de tipo só aparece na esteira, ou nem aparece se ninguém rodar. O editor ajuda, mas não bloqueia. Por isso a checagem precisa estar num gancho ou na esteira obrigatória, e não na disciplina de cada pessoa.",
+            },
+            {
+                frente: "Como você configura apelidos de caminho sem quebrar em execução?",
+                verso: "Garantindo que a ferramenta que executa ou empacota resolva os mesmos apelidos do compilador. O TypeScript só entende no nível de tipos: se o gerador não reescrever o caminho, o módulo não é encontrado em tempo de execução.",
+            },
+            {
+                frente: "Como você tipa um contêiner de injeção de dependência?",
+                verso: "Com um mapa de tokens para tipos, e uma função de resolução genérica sobre esse mapa. Assim pedir uma dependência devolve o tipo certo e um token inexistente vira erro. Sem isso, o contêiner devolve any e apaga a tipagem do serviço inteiro.",
+            },
+            {
+                frente: "Como você tipa consultas dinâmicas a um banco?",
+                verso: "Com construtor de consultas que infere o resultado a partir das colunas escolhidas, quando a biblioteca oferece. Quando não, declarando o tipo do retorno perto da consulta e validando. Concatenar texto e declarar any é onde o erro escapa.",
+            },
+            {
+                frente: "Como você lida com tipos gerados versionados no repositório?",
+                verso: "Gerando na esteira e falhando se o resultado diferir do que está versionado. Assim o arquivo continua disponível para o editor e ninguém o edita à mão sem ser pego. Gerar sem checar leva a arquivo desatualizado por meses.",
+            },
+            {
+                frente: "Como você garante compatibilidade de tipos entre versões de uma biblioteca?",
+                verso: "Com testes de tipo que devem continuar compilando, e revisão do que muda em assinatura pública. Tipo faz parte do contrato: afrouxar ou estreitar um parâmetro quebra quem consome sem mudar uma linha de comportamento.",
+            },
+            {
+                frente: "Como você trataria uma mudança que quebra tipos de consumidores internos?",
+                verso: "Anunciando com prazo, oferecendo o tipo antigo marcado como obsoleto por uma versão e mostrando o caminho de migração. Quebra de tipo é quebra de contrato, mesmo que o código continue rodando igual.",
+            },
+            {
+                frente: "Como você organiza tipos num monorepo?",
+                verso: "Cada pacote publicando os seus, e um pacote comum só para o que é realmente compartilhado, como contratos. Um pacote de tipos que todo mundo importa vira ponto de acoplamento e faz qualquer mudança recompilar tudo.",
+            },
+            {
+                frente: "Como você evitaria que todo o monorepo recompile a cada mudança?",
+                verso: "Com referências de projeto, build incremental e cache por hash das entradas. Também limitando dependências entre pacotes. Sem isso, o custo cresce até o ponto em que ninguém roda a checagem completa localmente.",
+            },
+            {
+                frente: "Como você lida com o editor ficando lento num projeto TypeScript?",
+                verso: "Medindo o que o serviço de linguagem gasta, procurando tipos caros e importações amplas, e dividindo em projetos menores. Autocompletar lento faz as pessoas ignorarem os tipos, e aí a linguagem perde justamente o que ela dá de melhor.",
+            },
+            {
+                frente: "Como você tipa uma função que aceita configuração parcial com padrões?",
+                verso: "Recebendo o tipo parcial e devolvendo o completo depois de aplicar os padrões, para o resto do código não precisar checar opcionais. O erro comum é manter o tipo parcial circulando e checar indefinido em todo lugar.",
+            },
+            {
+                frente: "Como você lida com dados legados sem formato definido?",
+                verso: "Tipando como unknown na entrada e passando por uma camada de validação e conversão que produz o tipo novo. Assim a bagunça fica contida num arquivo, e o resto do sistema trabalha com um formato honesto.",
+            },
+            {
+                frente: "Como você trata a diferença entre o tipo do banco e o tipo do domínio?",
+                verso: "Mantendo os dois e convertendo na fronteira do repositório. Usar o tipo gerado pelo banco no domínio inteiro faz cada mudança de coluna atravessar a aplicação, e ainda coloca detalhes de persistência dentro da regra de negócio.",
+            },
+            {
+                frente: "Como você tipa um sistema de eventos entre módulos?",
+                verso: "Com um mapa central de evento para carga útil, e funções de publicação e assinatura genéricas sobre esse mapa. Assim publicar um evento com carga errada não compila, e o mapa vira a documentação do que trafega entre os módulos.",
+            },
+            {
+                frente: "Como você tipa mensagens de uma fila?",
+                verso: "Com uma união discriminada por tipo de mensagem, validada na leitura porque a mensagem pode ter sido publicada por outra versão. Tipo sozinho não protege de mensagem antiga na fila, que é o caso mais comum de erro em consumo.",
+            },
+            {
+                frente: "Como você lida com versões de mensagens mudando ao longo do tempo?",
+                verso: "Com campo de versão no formato e um tipo por versão, convertendo as antigas para a atual na entrada. Assim o consumidor trabalha com uma forma só. Sem isso, cada consumidor aprende a lidar com todas as versões por conta própria.",
+            },
+            {
+                frente: "Como você usa JSDoc junto com TypeScript?",
+                verso: "Para documentar intenção, exemplos e o que não é óbvio na assinatura, e não para repetir os tipos. Em projeto JavaScript, o JSDoc também consegue tipar de verdade, com a checagem ligada, o que é um caminho de adoção sem mudar extensão.",
+            },
+            {
+                frente: "Como você documenta um tipo público?",
+                verso: "Com comentário sobre o que ele representa no domínio e o que cada campo significa quando o nome não basta, e marcando o que está obsoleto. O editor mostra isso no autocompletar, que é onde quem consome de fato lê.",
+            },
+            {
+                frente: "Como você lida com uma dependência cujos tipos estão errados?",
+                verso: "Corrigindo localmente com uma declaração própria que sobrescreve, ou envolvendo o uso, e mandando correção para o repositório de tipos. Asserção espalhada resolve na hora e deixa a base cheia de remendo sem rastro do motivo.",
+            },
+            {
+                frente: "Como você lida com o mesmo tipo definido em dois pacotes?",
+                verso: "Escolhendo um dono e fazendo o outro importar. Dois tipos estruturalmente iguais são compatíveis, então o problema não aparece de imediato: ele aparece quando um deles muda e o outro não, e ninguém sabe qual é o certo.",
+            },
+            {
+                frente: "Como você tipa um invólucro de cache genérico?",
+                verso: "Com parâmetro de tipo para o valor e chave tipada, e o método de obter devolvendo o tipo do valor ou indefinido. O erro comum é devolver any para servir a todos os casos, o que anula a segurança de quem usa.",
+            },
+            {
+                frente: "Como você tipa uma resposta paginada?",
+                verso: "Com um genérico sobre o item e campos de cursor ou total, usado por todos os endpoints de listagem. Assim o formato é único e uma mudança de paginação atinge um tipo só, em vez de vinte declarações espalhadas.",
+            },
+            {
+                frente: "Como você impede que o front use um campo interno da API?",
+                verso: "Devolvendo um tipo de saída explícito, derivado da entidade com Omit, em vez do registro inteiro. Assim o campo interno nem existe no contrato, e acrescentar uma coluna no banco não vaza dado sem ninguém notar.",
+            },
+            {
+                frente: "Como você tipa código que roda no navegador e no servidor?",
+                verso: "Separando por pacote ou por arquivo, com as bibliotecas de ambiente declaradas corretamente em cada um. Misturar faz o compilador aceitar objetos do navegador no servidor, e o erro aparece só na execução.",
+            },
+            {
+                frente: "Como você trataria uma função com dez parâmetros opcionais?",
+                verso: "Trocando por um objeto de opções tipado, o que dá nome a cada valor e evita passar na ordem errada. Com união discriminada dá para tornar impossíveis as combinações que não fazem sentido, o que a lista de parâmetros nunca consegue.",
+            },
+            {
+                frente: "Como você garante que um valor lido do ambiente é de um conjunto fechado?",
+                verso: "Validando contra uma lista com uma função que estreita o tipo, e falhando na subida quando não bate. Declarar o tipo como união sem validar é a forma mais comum de acreditar que uma variável está certa quando ela está vazia.",
+            },
+            {
+                frente: "Como você tipa uma função que altera o objeto recebido?",
+                verso: "Deixando explícito no nome e no tipo, evitando readonly no parâmetro, ou preferindo devolver um objeto novo. Função que altera o argumento e também devolve algo é a que mais confunde quem lê, porque parece pura e não é.",
+            },
+            {
+                frente: "Como você lida com bibliotecas que exigem configuração experimental do compilador?",
+                verso: "Isolando o uso e verificando o custo: opção experimental pode mudar entre versões e travar a atualização do compilador. Quando o recurso é central para a biblioteca, isso vira uma dependência de longo prazo que precisa ser decidida em time.",
+            },
+            {
+                frente: "Como você trataria um utilitário de tipos caseiro que virou peça central?",
+                verso: "Documentando, cobrindo com testes de tipo e reduzindo ao mínimo necessário, ou trocando por um da biblioteca padrão de utilitários que o time já usa. Tipo complexo sem teste é a parte da base que ninguém ousa mudar.",
+            },
+            {
+                frente: "Como você lida com o compilador aceitando algo que quebra em execução?",
+                verso: "Assumindo que houve asserção, any ou dado externo não validado. O caminho é achar a fronteira em que a garantia se perdeu e colocar validação ali, em vez de espalhar checagem defensiva por todo o fluxo.",
+            },
+            {
+                frente: "Como você reduziria o uso de asserções numa base?",
+                verso: "Trocando por satisfies em configuração, por guardas em estreitamento e por validação na borda. Depois medindo quantas restaram e onde. A maior parte das asserções existe porque falta uma validação, e não porque o tipo é impossível.",
+            },
+            {
+                frente: "Como você tipa uma tabela de rotas com parâmetros?",
+                verso: "Com literais de template extraindo os parâmetros do caminho, para a função de navegação exigir exatamente os que a rota tem. É um caso em que o tipo avançado paga, porque link quebrado passa a não compilar.",
+            },
+            {
+                frente: "Como você lida com a checagem de tipos demorando na esteira?",
+                verso: "Rodando em paralelo com o resto, usando build incremental com cache entre execuções e dividindo por pacote. Se ainda assim demora, o problema costuma ser um tipo caro específico, e vale medir antes de aceitar como custo fixo.",
+            },
+            {
+                frente: "Como você impediria que um pacote importe de outro que não deveria?",
+                verso: "Com referências de projeto declarando as dependências permitidas, mais uma regra de lint de fronteira. A checagem por si já reclama quando não há referência, e é a forma mais barata de manter arquitetura em repositório grande.",
+            },
+            {
+                frente: "Como você tipa retorno de uma função que pode devolver nada?",
+                verso: "Com união incluindo indefinido ou nulo, escolhendo um só e sendo consistente na base inteira. Misturar os dois obriga quem chama a checar as duas coisas, e é uma das inconsistências mais comuns em projeto grande.",
+            },
+            {
+                frente: "Como você lida com um tipo que precisa aceitar extensão pelo consumidor?",
+                verso: "Com genérico que permite acrescentar campos, ou com interface que pode ser estendida. O cuidado é não abrir mais do que o necessário: tipo aberto demais vira contrato impossível de evoluir sem quebrar alguém.",
+            },
+            {
+                frente: "Como você trataria a checagem de tipos em arquivos de teste?",
+                verso: "Com a mesma rigidez do código de produção, e não com uma configuração frouxa. Teste com any esconde mudança de contrato, e o dublê deixa de refletir a assinatura real, que é justamente o que ele deveria garantir.",
+            },
+            {
+                frente: "Como você tipa dublês de teste sem duplicar a interface?",
+                verso: "Derivando do tipo real com utilitários, para o dublê quebrar quando a assinatura mudar. Escrever o dublê à mão com forma própria faz o teste continuar passando depois de uma mudança que quebra a produção.",
+            },
+            {
+                frente: "Como você lidaria com um arquivo enorme sem tipos numa migração?",
+                verso: "Deixando por último, com a checagem menos rígida só nele e uma anotação registrando o motivo, enquanto o resto avança. Tentar converter o pior arquivo primeiro é como migrações param na primeira semana.",
+            },
+            {
+                frente: "Como você definiria o que é um arquivo migrado de verdade?",
+                verso: "Sem any explícito, sem asserção sem justificativa, sem marcação de erro ignorado e com as bordas validadas. Renomear a extensão e calar os erros conta como migrado no relatório e não entrega nenhuma segurança.",
+            },
+            {
+                frente: "Como você avaliaria trocar o compilador por uma ferramenta mais rápida?",
+                verso: "Separando os dois papéis: gerar código e checar tipos. Ferramentas rápidas costumam só remover tipos, então a checagem continua precisando do compilador em algum passo. Trocar sem manter esse passo entrega build rápido e nenhuma garantia.",
+            },
+            {
+                frente: "Como você mediria o progresso de segurança de tipos numa base?",
+                verso: "Contando any explícitos e implícitos, asserções, marcações de erro ignorado e arquivos fora da checagem estrita, e acompanhando a tendência. Número absoluto importa menos que a direção e que impedir a entrada de casos novos.",
+            },
+        ],
+        senior: [
+            {
+                frente: "Como você conduziria a adoção de TypeScript num time que só escreveu JavaScript?",
+                verso: "Ligando a checagem na esteira desde o primeiro arquivo, convertendo por borda e por módulo compartilhado, com regras estritas chegando aos poucos. E mostrando ganho cedo, em contrato de API e refatoração, que é onde a diferença é sentida.",
+            },
+            {
+                frente: "Como você mediria se a adoção de TypeScript valeu a pena?",
+                verso: "Por defeito que deixou de chegar em produção naquela classe de erro, tempo de refatoração e quantidade de correção emergencial por campo inexistente. Contar arquivos convertidos mede esforço, não resultado.",
+            },
+            {
+                frente: "Como você definiria a política de any de um time?",
+                verso: "Proibido por padrão na esteira, permitido com comentário justificando e prazo, e sempre contido numa fronteira. O que mata uma base é o any implícito vindo de biblioteca, então a regra precisa cobrir isso e não só o escrito à mão.",
+            },
+            {
+                frente: "Como você trataria marcações de erro ignorado espalhadas pela base?",
+                verso: "Trocando pela variante que reclama quando o erro some, contando quantas existem e impedindo novas na esteira. Depois atacando por área. Cada uma delas é um lugar onde alguém sabia que estava errado e não teve tempo, e isso precisa de rastro.",
+            },
+            {
+                frente: "Como você decidiria o nível de rigor da configuração?",
+                verso: "Projeto novo nasce no modo estrito, com as opções extras que doem menos primeiro. Base existente sobe por etapa, com meta e prazo. Rigor que o time desliga na primeira semana é pior que rigor menor sustentado.",
+            },
+            {
+                frente: "Como você revisaria um PR cheio de tipos elaborados?",
+                verso: "Perguntando qual erro real cada tipo evita e se alguém do time consegue mudá-lo daqui a seis meses. Depois olhando a mensagem de erro que ele produz. Tipo que exige o autor para ser alterado é gargalo, não segurança.",
+            },
+            {
+                frente: "Como você ensinaria TypeScript a quem vem de JavaScript?",
+                verso: "Pelo que resolve problema do dia, na ordem: união e estreitamento, tipar bordas, e depois genéricos. Deixando tipos avançados para quando aparecer necessidade. Começar por tipos condicionais é a forma mais rápida de o time achar que TypeScript atrapalha.",
+            },
+            {
+                frente: "Como você lidaria com alguém do time que considera TypeScript um estorvo?",
+                verso: "Escutando onde ele estorva de verdade, porque costuma ser configuração ruim, tipos elaborados demais ou biblioteca mal tipada. Corrigindo isso, a resistência some. Impor regra sem resolver o incômodo produz any com comentário irônico.",
+            },
+            {
+                frente: "Onde o sistema de tipos não protege, e o que fazer?",
+                verso: "Em tudo que atravessa a fronteira do processo: rede, arquivo, banco, entrada do usuário, variável de ambiente. Ali é preciso validação em tempo de execução. O tipo é acordo interno; a borda é o único lugar onde ele pode ser verificado.",
+            },
+            {
+                frente: "Como você garantiria que toda borda do sistema é validada?",
+                verso: "Concentrando as entradas em poucas funções, com esquema declarado e tipo derivado, e regra de lint impedindo desserialização crua fora delas. Validação espalhada é validação esquecida em algum ponto novo.",
+            },
+            {
+                frente: "Como você escolheria entre tipos gerados e escritos à mão?",
+                verso: "Gerados quando existe fonte da verdade externa e ela muda; escritos quando o tipo expressa uma decisão de domínio. Gerar tudo produz nomes ruins e acopla o domínio ao banco. Escrever tudo diverge do contrato na primeira mudança.",
+            },
+            {
+                frente: "Como você trataria o contrato de tipos entre dois times?",
+                verso: "Como produto: pacote versionado ou geração a partir da especificação, com prazo de descontinuação e teste de contrato. Combinar formato por conversa e cada lado declarar o seu é o que gera integração que só quebra em produção.",
+            },
+            {
+                frente: "Como você lidaria com uma API de terceiro sem contrato publicado?",
+                verso: "Escrevendo o tipo do que você usa, validando na borda e cobrindo com um teste contra o ambiente real fora do caminho crítico. Assim mudança silenciosa do fornecedor aparece como falha de teste, e não como erro do usuário.",
+            },
+            {
+                frente: "Como você conduziria a atualização da versão do compilador?",
+                verso: "Lendo as mudanças de comportamento, subindo numa branch e medindo quantos erros novos aparecem, porque versão nova costuma ser mais rigorosa. Isso é ganho, e precisa de tempo alocado, senão o time trava numa versão antiga por anos.",
+            },
+            {
+                frente: "Como você avaliaria adotar a versão nativa do compilador?",
+                verso: "Pelo ganho medido de tempo de checagem e resposta do editor no seu projeto, e pelo custo de acompanhar recurso ainda não portado e ferramentas que dependem da interface antiga. Vale medir antes, e manter caminho de volta.",
+            },
+            {
+                frente: "Como você padronizaria a configuração de TypeScript entre projetos?",
+                verso: "Com uma configuração base publicada como pacote, e cada projeto estendendo com o mínimo. Assim endurecer uma regra é uma mudança de versão, e não vinte PRs. E fica visível quem se desviou do padrão e por quê.",
+            },
+            {
+                frente: "Como você organizaria um monorepo com muitos pacotes TypeScript?",
+                verso: "Com referências de projeto, fronteiras declaradas, build incremental com cache e um pacote comum pequeno. O sinal de que deu errado é a checagem completa demorar tanto que ninguém roda antes de abrir o PR.",
+            },
+            {
+                frente: "Como você evitaria acoplamento excessivo por tipos compartilhados?",
+                verso: "Compartilhando só contrato de fronteira, e deixando cada módulo com seu tipo interno. Tipo compartilhado é dependência: quando todo mundo importa do mesmo pacote, qualquer mudança nele obriga a recompilar e revisar o repositório inteiro.",
+            },
+            {
+                frente: "Como você lidaria com o mesmo conceito tipado de três formas por times diferentes?",
+                verso: "Escolhendo um dono e um tipo canônico, com os outros importando, e prazo para a migração. Antes disso vale entender se são mesmo o mesmo conceito, porque às vezes o que parece duplicação são visões legítimas e diferentes.",
+            },
+            {
+                frente: "Como você trataria o custo de checagem crescendo na esteira?",
+                verso: "Medindo por fase, dividindo em projetos e atacando os tipos caros, em vez de aceitar como custo fixo ou desligar a checagem. Esteira lenta acaba levando alguém a propor pular a checagem em PR, que é onde ela mais serve.",
+            },
+            {
+                frente: "Como você lidaria com dívida de tipos frouxos numa base grande?",
+                verso: "Congelando o que existe com uma linha de base e impedindo casos novos, depois reduzindo por área com meta. Assim o número só cai. Mutirão de tipagem sem trava de entrada devolve o mesmo problema em alguns meses.",
+            },
+            {
+                frente: "Como você priorizaria onde endurecer os tipos primeiro?",
+                verso: "Onde o defeito dói: fluxo de dinheiro, autenticação e integração com terceiros. Depois no código mais alterado. Endurecer tipo em módulo estável que ninguém toca dá número bonito e nenhum ganho de segurança.",
+            },
+            {
+                frente: "Como você lidaria com um time que confia demais nos tipos?",
+                verso: "Mostrando com um caso real: dado de API mudando e o compilador feliz. Isso muda a conversa mais rápido que argumento. Tipo substitui uma classe de teste, e não os testes de comportamento nem a validação de borda.",
+            },
+            {
+                frente: "O que os tipos substituem em teste, e o que não?",
+                verso: "Substituem os testes que só checariam formato e presença de campo. Não substituem teste de regra, de integração e de caso de borda. Time que corta testes porque adotou tipagem troca uma proteção por outra e acha que somou.",
+            },
+            {
+                frente: "Como você usaria lint junto com o compilador?",
+                verso: "O compilador cuida de tipo, o lint cuida de padrão e de uso perigoso que compila, como promessa sem await, any escapando e comparação suspeita. As regras que usam informação de tipo são as mais valiosas, e também as mais lentas.",
+            },
+            {
+                frente: "O que o lint pega que o compilador não pega?",
+                verso: "Promessa criada e não aguardada, retorno ignorado, encadeamento opcional inútil, uso de any vindo de biblioteca e convenções do time. São coisas válidas para a linguagem e erradas para o projeto, que é justamente o espaço do lint.",
+            },
+            {
+                frente: "Como você trataria uma regra de lint que o time ignora sistematicamente?",
+                verso: "Ou removendo, ou corrigindo a base e tornando obrigatória. Regra que só gera aviso ignorado ensina o time a ignorar todos os avisos. A pergunta honesta é se ela evita um erro real ou se é gosto de quem configurou.",
+            },
+            {
+                frente: "Como você lidaria com partes do projeto que continuam em JavaScript?",
+                verso: "Ligando a checagem sobre elas com JSDoc, que já entrega boa parte do ganho, ou isolando com fronteira tipada. O pior cenário é JavaScript sem checagem exportando any para módulos tipados, o que apaga a segurança de quem importa.",
+            },
+            {
+                frente: "Como você garantiria tipos em scripts e código de infraestrutura?",
+                verso: "Tratando como código de produção: mesma configuração, mesma checagem na esteira. Script de migração e de infraestrutura roda em produção com poder alto, e é justamente onde costuma se aceitar any e improviso.",
+            },
+            {
+                frente: "Como você usaria tipos para impedir erro de negócio?",
+                verso: "Tornando impossível representar o estado inválido: identificadores marcados, união discriminada em vez de campos opcionais, e tipo que exige o passo anterior. É a diferença entre o compilador dizer não e uma revisão esperar que alguém perceba.",
+            },
+            {
+                frente: "Quando você aceitaria abrir mão de tipagem forte?",
+                verso: "Em protótipo com data para morrer, em script isolado e em fronteira com biblioteca mal tipada, sempre contido e com comentário. O que não pode é a exceção virar padrão sem ninguém registrar por que ela existiu.",
+            },
+            {
+                frente: "Como você trataria uma contribuição externa que afrouxa tipos?",
+                verso: "Explicando o padrão na revisão com o motivo, e oferecendo o caminho certo em vez de só recusar. Se o afrouxamento é sintoma de tipo difícil de usar, o problema é o tipo, e a contribuição está apontando isso.",
+            },
+            {
+                frente: "Como você decidiria criar um pacote de tipos compartilhado?",
+                verso: "Quando o mesmo contrato é usado por três ou mais projetos e muda com frequência. Antes disso, duplicar custa menos que manter versão e publicação. Pacote de tipos criado cedo demais vira dependência que todo mundo precisa esperar.",
+            },
+            {
+                frente: "Como você lidaria com a expectativa de que tipos deixam o código mais lento?",
+                verso: "Mostrando que eles somem na compilação e não afetam o que roda. O custo é tempo de checagem e de build, e ele é real. A conversa fica honesta quando se separa custo de desenvolvimento de custo de execução.",
+            },
+            {
+                frente: "Como você trataria a documentação de uma biblioteca interna tipada?",
+                verso: "Deixando os tipos serem a documentação principal, com comentários no que não é óbvio e exemplos executáveis. Documento separado envelhece; o autocompletar é o que a pessoa vai ler de fato às onze da noite.",
+            },
+            {
+                frente: "Como você impediria uso indevido de uma API interna?",
+                verso: "Restringindo o que é exportado no mapa de exportações, marcando o que é interno e usando tipos que só permitem a sequência correta de chamadas. Depender de disciplina e de comentário dizendo para não usar nunca funcionou.",
+            },
+            {
+                frente: "Como você lidaria com um contrato que precisa mudar e tem muitos consumidores?",
+                verso: "Acrescentando o novo, mantendo o antigo marcado como obsoleto por uma versão, medindo o uso e removendo com prazo. Quebrar de uma vez porque o compilador aponta os erros ignora quem não faz parte do seu repositório.",
+            },
+            {
+                frente: "Como você usaria tipos para reduzir o custo de revisão de código?",
+                verso: "Deixando o compilador cuidar de forma, presença de campo e assinatura, para a revisão gastar tempo com desenho, risco e caso de borda. Revisão que passa a maior parte apontando campo errado é revisão que a ferramenta deveria ter feito.",
+            },
+            {
+                frente: "Como você avaliaria adotar validação de esquema em todo o projeto?",
+                verso: "Pelo ganho na borda contra o custo de manter esquema e a sobrecarga em caminho quente. Uso na entrada de API e em configuração paga quase sempre; validar entre módulos internos costuma ser duplicação do que o tipo já garante.",
+            },
+            {
+                frente: "Como você lidaria com performance do editor para o time inteiro?",
+                verso: "Medindo com as ferramentas de diagnóstico do serviço de linguagem, cortando tipos caros e dividindo projetos. Editor lento faz as pessoas ignorarem sublinhado vermelho e desligarem verificações, e aí a tipagem deixa de valer.",
+            },
+            {
+                frente: "Como você definiria o que é pronto num PR de migração para TypeScript?",
+                verso: "Sem any, sem asserção sem justificativa, bordas validadas e comportamento inalterado, com o teste provando. Migração que corrige bug junto fica impossível de revisar, e é onde se introduz regressão sem ninguém ver.",
+            },
+            {
+                frente: "Como você trataria geração de código que ninguém entende?",
+                verso: "Documentando o que gera o quê e quando roda, versionando o resultado e falhando na esteira se estiver desatualizado. Código gerado sem dono é o que ninguém ousa mexer e todo mundo contorna com asserção.",
+            },
+            {
+                frente: "Como você lidaria com o compilador travando a atualização de uma dependência?",
+                verso: "Verificando se o problema é declaração incompatível ou versão mínima exigida, e isolando com declaração própria enquanto resolve. Fixar a dependência sem prazo transforma uma incompatibilidade de tipos em dívida de segurança.",
+            },
+            {
+                frente: "Como você trataria tipos em código de teste que diverge da produção?",
+                verso: "Derivando o dublê do tipo real, para a mudança de assinatura quebrar o teste. Teste com tipo próprio continua verde depois de uma mudança que quebra a produção, o que é pior que não ter teste, porque dá confiança falsa.",
+            },
+            {
+                frente: "Como você lidaria com um time que escreve tipos duplicando o esquema de validação?",
+                verso: "Mostrando a derivação a partir do esquema e removendo a declaração manual, deixando uma fonte só. Duas declarações do mesmo formato divergem sempre, e a divergência aparece como campo aceito na validação e ausente no tipo.",
+            },
+            {
+                frente: "Como você conduziria a decisão de tipar ou não uma parte legada?",
+                verso: "Pelo quanto ela muda e pelo risco do que ela faz. Código estável que ninguém toca não ganha nada com migração. Isso é diferente de deixar sem checagem: dá para isolar atrás de uma fronteira tipada sem reescrever nada.",
+            },
+            {
+                frente: "Como você usaria tipos para tornar uma API interna difícil de usar errado?",
+                verso: "Exigindo o objeto de contexto correto, recusando combinações inválidas por união e devolvendo tipos que forçam o tratamento do erro. O objetivo é que o caminho errado não compile, e não que exista um documento pedindo cuidado.",
+            },
+            {
+                frente: "Como você trataria a queixa de que os tipos deixam o desenvolvimento mais lento?",
+                verso: "Separando o que é atrito legítimo, como configuração ruim e tipos elaborados, do que é o custo de descobrir um problema antes. O primeiro se resolve; o segundo é o objetivo. E vale medir o tempo gasto com bug que deixou de existir.",
+            },
+            {
+                frente: "Como você garantiria que tipos públicos de uma biblioteca não quebrem sem aviso?",
+                verso: "Com testes de tipo na suíte e revisão obrigatória do que muda em assinatura exportada. Mudança de tipo não aparece em teste de comportamento, então sem isso a quebra chega para quem consome antes de qualquer aviso.",
+            },
+            {
+                frente: "Como você definiria fronteiras de tipos numa arquitetura em camadas?",
+                verso: "Cada camada com seus tipos e conversão explícita na passagem. O tipo do banco não atravessa até a borda HTTP, e o de requisição não entra no domínio. É trabalho extra que paga toda vez que uma das pontas muda.",
+            },
+            {
+                frente: "Como você avaliaria se o time está usando tipos para o que interessa?",
+                verso: "Vendo se os erros que chegam em produção seriam pegáveis por tipo. Se são de regra, de integração e de dado, endurecer tipagem não vai mudar nada, e o esforço deveria ir para validação de borda e teste.",
+            },
+            {
+                frente: "Como você lidaria com um tipo público que ficou impossível de evoluir?",
+                verso: "Criando o tipo novo ao lado, migrando consumidores com prazo e removendo o antigo. Tentar mudar no lugar quebra todo mundo de uma vez. E vale entender por que ele engessou: normalmente ele expunha detalhe interno demais.",
+            },
+            {
+                frente: "Como você trataria a escolha entre validação estrita e tolerância na entrada?",
+                verso: "Estrita no que você grava, tolerante no que você lê de terceiros, ignorando campo desconhecido em vez de falhar. Rejeitar campo a mais em mensagem quebra o consumidor sempre que o produtor evolui, e isso vira acoplamento de deploy.",
+            },
+            {
+                frente: "Como você garantiria que o time saiba quando validar em tempo de execução?",
+                verso: "Com uma regra simples e escrita: tudo que atravessa a fronteira do processo é validado, o resto confia no tipo. Regra clara é melhor que julgamento caso a caso, porque a decisão acontece em pressa e em revisão rápida.",
+            },
+            {
+                frente: "Como você lidaria com tipos que não acompanham a evolução do produto?",
+                verso: "Tratando tipo como parte da mudança, e não como ajuste posterior. Se o modelo do domínio mudou, o tipo muda junto no mesmo PR. Tipos que descrevem o produto de dois anos atrás confundem mais do que ajudam.",
+            },
+            {
+                frente: "Como você lidaria com uma proposta de abandonar TypeScript?",
+                verso: "Perguntando qual dor específica motiva, porque costuma ser build lento, configuração ou tipos elaborados, e isso tem solução. Se a decisão for tomada mesmo assim, JSDoc com checagem mantém boa parte do ganho sem passo de compilação.",
+            },
+            {
+                frente: "Como você trataria tipos numa base com várias equipes e ritmos diferentes?",
+                verso: "Com configuração base compartilhada, fronteiras claras por pacote e regra de entrada na esteira, deixando cada time avançar no ritmo dentro do seu escopo. O que precisa ser igual é o contrato entre eles, não o estilo interno.",
+            },
+            {
+                frente: "Como você definiria a responsabilidade sobre os tipos compartilhados?",
+                verso: "Com dono declarado, revisão obrigatória e processo de proposta. Tipos de fronteira sem dono acumulam campos opcionais até não descreverem nada, porque cada time acrescenta o seu e ninguém remove.",
+            },
+            {
+                frente: "Como você usaria a tipagem para reduzir incidentes de integração?",
+                verso: "Gerando os tipos do contrato, validando na borda e mantendo teste de contrato rodando contra o ambiente real. Isso transforma mudança do outro lado em falha visível cedo, em vez de erro do usuário no dia seguinte.",
+            },
+            {
+                frente: "Como você conduziria a revisão de uma configuração de compilador herdada?",
+                verso: "Listando cada opção, o que ela liga e por que está ali, removendo o que foi copiado sem motivo. Configuração herdada costuma ter opções frouxas que ninguém escolheu, e são elas que explicam por que a base aceita coisas estranhas.",
+            },
+            {
+                frente: "Como você garantiria que uma decisão de tipagem sobreviva à saída de quem a tomou?",
+                verso: "Registrando como decisão datada, com contexto e consequências, junto do código. Tipo complexo sem registro é desfeito no primeiro PR de quem não entendeu, e o problema que ele evitava volta sem ninguém reconhecer.",
+            },
+            {
+                frente: "Como você trataria a diferença entre tipar para o compilador e tipar para quem lê?",
+                verso: "Preferindo nomes de domínio e tipos simples, mesmo quando um tipo mais preciso seria possível. Quem mantém lê muito mais vezes do que escreve. Precisão que ninguém entende cobra em toda mudança futura.",
+            },
+            {
+                frente: "Como você avaliaria o custo total de uma abordagem de tipagem avançada?",
+                verso: "Somando tempo de checagem, resposta do editor, dificuldade de revisão e de onboarding, contra os defeitos que ela evita. Poucos casos justificam. Onde justifica, vale isolar num pacote com testes de tipo e dono definido.",
+            },
+            {
+                frente: "Como você lidaria com quem propõe adotar um recurso experimental do compilador?",
+                verso: "Perguntando quem sustenta se ele mudar, e se ele trava a atualização de versão. Recurso experimental em código central vira dependência de longo prazo. Em código isolado e substituível, o risco é aceitável.",
+            },
+            {
+                frente: "Como você trataria o uso de tipos em código de configuração de infraestrutura?",
+                verso: "Com a mesma seriedade do resto: erro ali afeta produção diretamente e costuma passar despercebido em revisão. Tipar recursos e validar valores evita o erro clássico de nome de ambiente digitado errado passando batido.",
+            },
+            {
+                frente: "Como você conduziria a padronização de nomes e formatos de tipos?",
+                verso: "Com poucas regras escritas e exemplos, aplicadas por lint onde der. Discussão recorrente sobre prefixo e sufixo consome revisão e não muda resultado, então uma decisão registrada vale mais que a melhor convenção sem acordo.",
+            },
+            {
+                frente: "Como você lidaria com a pressão para entregar sem tipar a borda?",
+                verso: "Oferecendo o mínimo: validar a entrada crítica e marcar o resto com prazo. Borda sem validação é o ponto em que o sistema aceita qualquer coisa, então esse é o último lugar onde vale cortar caminho.",
+            },
+            {
+                frente: "Como você decidiria entre tipo mais permissivo e mais restrito numa API pública?",
+                verso: "Restrito no que você recebe, para poder evoluir; generoso no que você devolve, porque estreitar depois quebra consumidores. Prometer menos e entregar o que precisa é o que permite mudar sem coordenar com todo mundo.",
+            },
+            {
+                frente: "Como você lidaria com um incidente causado por um dado que o tipo dizia existir?",
+                verso: "Corrigindo a borda que aceitou o dado, e não espalhando checagem defensiva pelo fluxo. Depois procurando outras entradas com o mesmo padrão, porque quase nunca é caso único. E registrando: é o tipo de incidente que se repete até a regra de validação virar padrão.",
+            },
+            {
+                frente: "Como você avaliaria a saúde da tipagem de um projeto que você acabou de assumir?",
+                verso: "Olhando a configuração, contando any e asserções, vendo se as bordas validam e rodando a checagem para ver quanto tempo leva. Isso dá em uma tarde um retrato melhor que semanas lendo código.",
+            },
+        ],
+    },
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
-        "globals": "^17.10.0",
+        "globals": "^17.11.0",
         "prettier": "^3.9.6",
         "ts7": "npm:typescript@7.0.2",
         "typescript": "~6.0.2",
@@ -2706,9 +2706,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.10.0.tgz",
-      "integrity": "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "prettier": "^3.9.6",
         "ts7": "npm:typescript@7.0.2",
         "typescript": "~6.0.2",
-        "typescript-eslint": "^8.66.0",
+        "typescript-eslint": "^8.69.0",
         "vite": "^8.2.2"
       }
     },
@@ -1090,17 +1090,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+      "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/type-utils": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/type-utils": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1113,15 +1113,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.66.0",
+        "@typescript-eslint/parser": "^8.69.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1129,16 +1129,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1154,14 +1154,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.66.0",
-        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1176,14 +1176,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0"
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1194,9 +1194,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1211,15 +1211,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+      "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1236,9 +1236,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1250,16 +1250,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.66.0",
-        "@typescript-eslint/tsconfig-utils": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1291,16 +1291,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0"
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1315,13 +1315,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/types": "8.69.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5160,16 +5160,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
-      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+      "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.66.0",
-        "@typescript-eslint/parser": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0"
+        "@typescript-eslint/eslint-plugin": "8.69.0",
+        "@typescript-eslint/parser": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^19.2.4",
+        "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "^6.0.5",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,7 @@
         "ts7": "npm:typescript@7.0.2",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.66.0",
-        "vite": "^8.2.1"
+        "vite": "^8.2.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5389,16 +5389,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -5415,7 +5415,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
-        "eslint": "^10.8.0",
+        "eslint": "^10.9.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
@@ -2279,9 +2279,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",
-    "globals": "^17.10.0",
+    "globals": "^17.11.0",
     "prettier": "^3.9.6",
     "ts7": "npm:typescript@7.0.2",
     "typescript": "~6.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "prettier": "^3.9.6",
     "ts7": "npm:typescript@7.0.2",
     "typescript": "~6.0.2",
-    "typescript-eslint": "^8.66.0",
+    "typescript-eslint": "^8.69.0",
     "vite": "^8.2.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,6 @@
     "ts7": "npm:typescript@7.0.2",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.66.0",
-    "vite": "^8.2.1"
+    "vite": "^8.2.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
-    "eslint": "^10.8.0",
+    "eslint": "^10.9.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.4",
+    "@types/react-dom": "^19.2.5",
     "@vitejs/plugin-react": "^6.0.5",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## O que vai para produção

- Perguntas de entrevista de Java, React, Node.js, TypeScript e System Design, com 70 por nível em cada tópico (#661).
- Atualizações de dependências abertas pelo dependabot.

### Backend

- `@anthropic-ai/sdk` de 0.116.0 para 0.117.1 (#651)
- `nodemailer` de 9.0.4 para 9.0.5 (#653)
- `unpdf` de 1.8.0 para 1.8.1 (#650)
- `typescript-eslint` de 8.66.0 para 8.67.0 (#656)
- `globals` de 17.10.0 para 17.11.0 (#649)

### Frontend

- `vite` de 8.2.1 para 8.2.2 (#658)
- `eslint` de 10.8.0 para 10.9.1 (#659)
- `typescript-eslint` de 8.66.0 para 8.68.0 (#660)
- `@types/react-dom` de 19.2.4 para 19.2.5 (#657)
- `globals` de 17.10.0 para 17.11.0 (#655)

Todas são versões de correção ou menores, sem mudança de código na aplicação.

## Depois do deploy

As perguntas novas só aparecem depois de rodar o seed de entrevista em produção. Ele é idempotente: os tópicos que já existem são pulados.
