### PR TITLE
chore: leva para produção as questões novas dos simulados CLF-C02 e AIF-C01

### DIFF
--- a/backend/scripts/data/LICENSE-cloudcertprep.txt
+++ b/backend/scripts/data/LICENSE-cloudcertprep.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alex Santonastaso
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep-d1.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep-d1.ts
@@ -1,0 +1,1759 @@
+// Questões do simulado AWS Certified AI Practitioner (AIF-C01), domínio 1 da prova
+// (Fundamentals of AI and ML), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aif-c01-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D1: Questao[] = [
+    {
+        statement:
+            "Uma empresa roda em produção um pipeline de ML no Amazon SageMaker AI. As requisições trazem payloads de até 1 GB, podem levar até uma hora para serem processadas, e a empresa quer latência próxima do tempo real. Qual opção de inferência do SageMaker AI atende a esses requisitos?",
+        explanation:
+            "A inferência assíncrona foi feita para payloads de até 1 GB e processamento de até uma hora com latência próxima do tempo real: enfileira as requisições e grava o resultado no Amazon S3. Tempo real e serverless têm limites bem menores de payload e de tempo, e o batch transform roda jobs offline, sem latência baixa.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Inferência assíncrona, que enfileira as requisições e as processa em segundo plano",
+                true,
+            ],
+            [
+                "Inferência em tempo real, com endpoint sempre ativo que responde a cada chamada na hora",
+                false,
+            ],
+            [
+                "Batch transform, que processa o conjunto de dados inteiro em um job offline agendado",
+                false,
+            ],
+            [
+                "Inferência serverless, que provisiona capacidade sob demanda e reduz a escala a zero",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa construir modelos para várias tarefas novas, mas relacionadas entre si. Em vez de treinar cada modelo do zero, quer adaptar modelos que já foram pré-treinados. Qual estratégia de ML atende a esse requisito?",
+        explanation:
+            "O aprendizado por transferência (transfer learning) parte de um modelo já treinado em uma tarefa e o adapta a tarefas relacionadas, poupando dados e tempo de treino. Mudar o número de épocas só altera quantas passagens o treino faz nos dados, e o aprendizado não supervisionado busca padrões sem rótulos, sem reaproveitar modelos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aprendizado por transferência, reaproveitando modelos já treinados", true],
+            ["Aumentar o número de épocas, treinando cada modelo por mais tempo", false],
+            ["Aprendizado não supervisionado, agrupando os dados das novas tarefas", false],
+            ["Reduzir o número de épocas, encurtando o treino de cada modelo novo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup cria um app de quiz educativo com perguntas como: 'Um saco tem seis bolinhas vermelhas, quatro verdes e três amarelas. Qual é a probabilidade de tirar uma verde?' O app precisa calcular a resposta de cada pergunta. Qual abordagem faz isso com o MENOR esforço operacional?",
+        explanation:
+            "A probabilidade é um cálculo determinístico (casos favoráveis divididos pelo total, aqui 4 de 13), então poucas linhas de código dão a resposta exata, sem coletar dados, treinar nem hospedar modelo. Regressão, modelo não supervisionado e aprendizado por reforço criariam um pipeline de ML desnecessário para aproximar um valor que dá para calcular.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Escrever um código simples que calcula a probabilidade com regras básicas de aritmética",
+                true,
+            ],
+            [
+                "Treinar um modelo de regressão supervisionada para prever a probabilidade de cada pergunta",
+                false,
+            ],
+            [
+                "Criar um modelo não supervisionado que estima a densidade de probabilidade das respostas",
+                false,
+            ],
+            [
+                "Aplicar aprendizado por reforço para treinar um modelo que devolve a probabilidade certa",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa colocou um modelo em produção e quer uma métrica que mostre a eficiência do modelo durante a execução, ao atender as requisições. Qual métrica ela deve usar?",
+        explanation:
+            "A latência média de inferência mede quanto o modelo leva para devolver uma previsão quando já está rodando, então reflete diretamente a eficiência em produção. O CSAT é um resultado de negócio, e o número de exemplos e o tempo por época dizem respeito à fase de treinamento, não à execução.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Latência média de inferência, o tempo para devolver cada previsão", true],
+            ["Pontuação de satisfação do cliente (CSAT) com o produto que usa o modelo", false],
+            ["Número de exemplos de treinamento usados para construir o modelo", false],
+            ["Tempo de treinamento por época, medido durante o ajuste do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer usar IA para proteger sua aplicação contra ameaças, verificando se cada endereço IP que chega vem de uma origem suspeita. Qual solução atende a esse requisito?",
+        explanation:
+            "A detecção de anomalias aprende como é o tráfego normal e sinaliza o que foge desse padrão, como um IP com comportamento suspeito. O reconhecimento de fala transcreve áudio, o reconhecimento de entidades nomeadas extrai nomes de textos e a previsão de fraudes estima tendências futuras, sem avaliar cada acesso que chega.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Um sistema de detecção de anomalias que sinaliza acessos fora do padrão normal",
+                true,
+            ],
+            [
+                "Um sistema de reconhecimento de fala que converte o áudio das chamadas em texto",
+                false,
+            ],
+            [
+                "Um sistema de previsão de fraudes que estima o volume de golpes nos próximos meses",
+                false,
+            ],
+            [
+                "Um sistema de reconhecimento de entidades nomeadas que extrai nomes de textos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa criou um modelo de classificação de imagens e quer que um aplicativo web o chame para obter previsões em tempo real. Ela precisa de uma forma totalmente gerenciada de hospedar o modelo e servir as previsões, com escala automática conforme a demanda. Qual solução atende a esses requisitos?",
+        explanation:
+            "O Amazon SageMaker Serverless Inference hospeda o modelo e provisiona e escala a computação automaticamente conforme o tráfego, sem gerenciar servidores. O CloudFront é uma rede de entrega de conteúdo, o API Gateway só expõe APIs e precisaria de computação por trás, e o AWS Batch roda jobs em lote, não previsões sob demanda.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Implantar o modelo com o Amazon SageMaker Serverless Inference", true],
+            ["Implantar o modelo com o Amazon CloudFront, perto dos usuários", false],
+            ["Hospedar o modelo e servir as previsões pelo Amazon API Gateway", false],
+            ["Hospedar o modelo e servir as previsões com jobs do AWS Batch", false],
+        ],
+    },
+    {
+        statement:
+            "Um pesquisador de vida selvagem tem um grande acervo de fotos de animais e quer localizar e categorizar automaticamente os animais presentes em cada imagem, sem trabalho manual. Qual técnica atende a esse requisito?",
+        explanation:
+            "A detecção de objetos é uma técnica de visão computacional que encontra e classifica os objetos de uma imagem, então localiza cada animal e atribui uma categoria. O reconhecimento de entidades nomeadas trabalha com texto, o inpainting gera conteúdo para preencher partes da imagem e a detecção de anomalias só aponta desvios de padrão.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Detecção de objetos, que localiza e classifica os elementos de uma imagem", true],
+            ["Reconhecimento de entidades nomeadas, que extrai nomes e lugares de textos", false],
+            ["Inpainting, técnica generativa que preenche regiões ausentes de uma imagem", false],
+            ["Detecção de anomalias, que sinaliza dados que fogem do padrão esperado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de hotéis quer identificar o sentimento das avaliações escritas pelos hóspedes. Quais serviços da AWS atendem a esse requisito? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Comprehend tem análise de sentimento pronta (positivo, negativo, neutro ou misto), e os foundation models do Amazon Bedrock também classificam sentimento a partir de um prompt. O Polly transforma texto em fala, o Lex cria interfaces de conversa e o Rekognition analisa imagens e vídeos, sem avaliar textos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Comprehend, que já traz análise de sentimento pronta para textos", true],
+            ["Amazon Polly, que converte os textos das avaliações em fala natural", false],
+            ["Amazon Bedrock, com foundation models que classificam o sentimento via prompt", true],
+            [
+                "Amazon Lex, que cria chatbots de voz e de texto para conversar com os hóspedes",
+                false,
+            ],
+            ["Amazon Rekognition, que analisa imagens e vídeos enviados pelos hóspedes", false],
+        ],
+    },
+    {
+        statement:
+            "Uma fabricante de eletrônicos quer prever a demanda dos clientes por seus produtos de memória. A equipe não sabe programar nem conhece algoritmos de ML, mas precisa criar um modelo preditivo que use dados internos e externos. Qual solução atende a esses requisitos?",
+        explanation:
+            "O Amazon SageMaker Canvas importa dados de várias fontes, internas e externas, e cria modelos de previsão de séries temporais por interface visual, sem código. Usar algoritmos integrados do SageMaker AI exige escolher e configurar o algoritmo, em geral com código, e escrever código de treinamento próprio também foge da capacidade da equipe.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Importar os dados no Amazon SageMaker Canvas e criar os modelos de previsão no próprio Canvas",
+                true,
+            ],
+            [
+                "Preparar os dados no Amazon SageMaker Data Wrangler e treinar os modelos com algoritmos integrados do SageMaker AI",
+                false,
+            ],
+            [
+                "Armazenar os dados no Amazon S3 e treinar os modelos com algoritmos integrados do SageMaker AI",
+                false,
+            ],
+            [
+                "Preparar os dados no Amazon SageMaker Data Wrangler e treinar os modelos com código de treinamento próprio",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando um chatbot de atendimento que deve melhorar continuamente suas respostas aprendendo com as conversas anteriores. Qual estratégia de aprendizado oferece essa capacidade de se aperfeiçoar sozinho?",
+        explanation:
+            "O aprendizado por reforço melhora o comportamento com base em recompensas, como a avaliação positiva do cliente, então o chatbot se aperfeiçoa com as próprias interações. As opções supervisionadas dependem de pessoas rotulando exemplos ou mantendo a base, e o agrupamento não supervisionado organiza perguntas sem melhorar as respostas.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Aprendizado por reforço, recompensando as respostas com avaliação positiva dos clientes",
+                true,
+            ],
+            [
+                "Aprendizado supervisionado, com um conjunto de respostas boas e ruins rotuladas manualmente",
+                false,
+            ],
+            [
+                "Aprendizado não supervisionado, agrupando as perguntas parecidas dos clientes em clusters",
+                false,
+            ],
+            [
+                "Aprendizado supervisionado, treinado com uma base de FAQ atualizada com frequência",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA treinou um modelo de deep learning que classifica imagens de cães por raça e agora quer avaliar o desempenho desse modelo. Qual recurso ajuda nessa avaliação?",
+        explanation:
+            "A matriz de confusão mostra, para cada classe, quantas previsões acertaram e em quais classes o modelo confundiu as raças, por isso serve para avaliar classificadores. A matriz de correlação é uma ferramenta de análise exploratória dos dados, e R² e erro quadrático médio são métricas de regressão, feitas para valores contínuos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Matriz de confusão, que cruza as raças previstas com as raças reais", true],
+            ["Matriz de correlação, que mede a relação entre as variáveis dos dados", false],
+            ["Coeficiente de determinação (R²), que mede a variância explicada", false],
+            ["Erro quadrático médio (MSE), que mede o desvio entre valores numéricos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma seguradora precisa rodar seu modelo de ML sobre vários anos de registros de sinistros arquivados para gerar previsões, com conjuntos de dados de vários gigabytes. Os resultados não são necessários de imediato. Qual opção de inferência do Amazon SageMaker AI é a mais adequada?",
+        explanation:
+            "O batch transform, a inferência em lote do SageMaker AI, processa o conjunto de dados inteiro em um job, sem manter endpoint ativo, o que serve para grandes volumes quando as previsões não são urgentes. Tempo real e serverless atendem chamadas individuais com baixa latência, e a inferência assíncrona trata requisições grandes uma a uma, não um arquivo histórico inteiro.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Batch transform, que roda a inferência como job offline sobre todo o conjunto de dados",
+                true,
+            ],
+            [
+                "Inferência serverless, que escala sob demanda e atende chamadas intermitentes na hora",
+                false,
+            ],
+            [
+                "Inferência em tempo real, com endpoint persistente que responde com baixa latência",
+                false,
+            ],
+            [
+                "Inferência assíncrona, que enfileira requisições grandes e responde quase em tempo real",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma agência de recrutamento recebe cada vez mais currículos em PDF e não consegue mais analisá-los manualmente. Ela precisa de uma forma automatizada de converter esses currículos em texto simples para processamento posterior. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Textract extrai automaticamente texto e dados de documentos digitalizados e arquivos PDF, então transforma os currículos em texto para as etapas seguintes. O Lex cria interfaces de conversa, o Transcribe converte fala em texto e o Personalize gera recomendações, e nenhum deles lê o conteúdo de PDFs.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Textract, que extrai texto e dados de documentos e arquivos PDF", true],
+            [
+                "Amazon Lex, que cria chatbots e interfaces de voz para conversar com usuários",
+                false,
+            ],
+            ["Amazon Transcribe, que converte a fala de arquivos de áudio em texto escrito", false],
+            ["Amazon Personalize, que gera recomendações personalizadas em tempo real", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de ciência de dados acabou de reunir um novo conjunto de dados e agora o examina calculando estatísticas descritivas, montando gráficos e construindo uma matriz de correlação. Qual etapa do pipeline de ML essa atividade descreve?",
+        explanation:
+            "Estatísticas descritivas, gráficos e matriz de correlação são as ferramentas da análise exploratória de dados, feita para entender distribuição e relações antes de modelar. A coleta vem antes e só reúne os dados, a engenharia de atributos cria variáveis depois dessa análise, e o treinamento é a etapa em que o algoritmo aprende.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Análise exploratória de dados, para entender a estrutura do conjunto", true],
+            ["Treinamento do modelo, para ajustar os parâmetros a partir dos dados", false],
+            ["Coleta de dados, para reunir os registros brutos das fontes de origem", false],
+            ["Engenharia de atributos, para criar variáveis que melhoram o modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa recuperou um conjunto de documentos de texto depois de uma falha no banco de dados, mas algumas palavras se perderam. Ela quer um modelo de ML que preveja a palavra mais provável para cada lacuna. Que tipo de modelo é adequado?",
+        explanation:
+            "Modelos baseados em BERT são transformers treinados com modelagem de linguagem mascarada: aprendem a prever um token oculto usando o contexto dos dois lados, exatamente o que preencher lacunas exige. A modelagem de tópicos encontra temas, o clustering agrupa documentos e a análise prescritiva recomenda ações, sem prever palavras.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Modelos baseados em BERT, que preveem palavras mascaradas pelo contexto", true],
+            [
+                "Modelagem de tópicos, que descobre os temas presentes em uma coleção de textos",
+                false,
+            ],
+            ["Modelos de clustering, que agrupam documentos parecidos sem usar rótulos", false],
+            ["Modelos de análise prescritiva, que recomendam a melhor ação a tomar", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de software quer usar IA para aumentar a produtividade dos seus desenvolvedores na escrita de código. Qual solução atende a esse requisito?",
+        explanation:
+            "Ferramentas de processamento de linguagem natural, base dos assistentes de código com IA generativa, transformam descrições em código e completam trechos, acelerando o trabalho. A classificação binária só separa entradas em duas classes, o clustering agrupa itens sem criar código e a previsão estima valores futuros, sem ajudar a escrever.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Usar uma ferramenta de processamento de linguagem natural (PLN) que gera código",
+                true,
+            ],
+            [
+                "Usar um modelo de classificação binária para gerar revisões do código escrito",
+                false,
+            ],
+            ["Usar um algoritmo de clustering para agrupar trechos de código semelhantes", false],
+            [
+                "Usar um modelo de previsão para estimar quantos defeitos o código terá no futuro",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma loja de varejo planeja prever a demanda de um produto nas próximas semanas usando o algoritmo DeepAR do Amazon SageMaker AI. Que tipo de dado é necessário para atender a esse requisito?",
+        explanation:
+            "O DeepAR é um algoritmo supervisionado de previsão que usa redes neurais recorrentes para projetar séries temporais, então precisa do histórico de demanda registrado em sequência, com data. Texto serve a tarefas de linguagem, imagem à visão computacional e áudio ao processamento de fala, e nenhum traz a ordem temporal de que a previsão depende.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Dados de séries temporais, com valores registrados em ordem ao longo do tempo", true],
+            [
+                "Dados de texto, como descrições de produtos e avaliações escritas por clientes",
+                false,
+            ],
+            ["Dados de áudio, como gravações de ligações feitas para a central de vendas", false],
+            ["Dados de imagem, como fotos das prateleiras e das vitrines de cada loja", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA tem um conjunto de flores já identificadas por espécie, com o comprimento e a largura das pétalas e das sépalas. Ele precisa prever a espécie de novas flores a partir dessas quatro medidas. Qual algoritmo atende a esse requisito?",
+        explanation:
+            "O k-NN é um algoritmo supervisionado de classificação: atribui a uma flor nova a espécie mais comum entre os vizinhos mais próximos no espaço das medidas. O K-means agrupa dados sem rótulos, sem prever espécies conhecidas, a regressão linear prevê valores numéricos e o ARIMA faz previsão de séries temporais.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "K-nearest neighbors (k-NN), que classifica pelo rótulo dos vizinhos mais próximos",
+                true,
+            ],
+            [
+                "Regressão linear, que prevê um valor numérico contínuo a partir das quatro medidas",
+                false,
+            ],
+            ["K-means, que agrupa as flores em clusters sem usar as espécies já conhecidas", false],
+            ["ARIMA, que projeta valores futuros de uma série de dados ordenada no tempo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de pesquisa de fauna quer treinar um modelo que identifique a espécie mostrada nas fotos de armadilhas fotográficas. Ela já tem um grande conjunto de imagens marcadas com a espécie correta e não vai rotular mais nenhuma. Que tipo de aprendizado deve usar?",
+        explanation:
+            "Como cada imagem já vem com a espécie correta, o modelo aprende a mapear entrada e rótulo, o que define o aprendizado supervisionado. O aprendizado ativo pede novos rótulos a pessoas, e a equipe não vai rotular mais; o não supervisionado serve quando não há rótulos, e o por reforço aprende com recompensas em um ambiente.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aprendizado supervisionado, treinando com as imagens já rotuladas", true],
+            ["Aprendizado por reforço, com recompensas a cada espécie reconhecida", false],
+            ["Aprendizado ativo, pedindo rótulos humanos para os casos mais incertos", false],
+            ["Aprendizado não supervisionado, agrupando as fotos por semelhança visual", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de restaurantes quer criar um modelo de ML para reduzir o desperdício diário de alimentos e aumentar a receita, e precisa que a acurácia do modelo continue melhorando com o tempo. Qual solução atende a esses requisitos?",
+        explanation:
+            "O Amazon SageMaker AI cobre o ciclo de vida do modelo, e retreiná-lo com dados recentes faz ele acompanhar as mudanças de demanda e melhorar a acurácia. O Personalize gera recomendações e, só com dados históricos, não se adaptaria; o CloudWatch monitora recursos e o Rekognition analisa imagens, e nenhum dos dois treina esse tipo de modelo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Usar o Amazon SageMaker AI e retreinar o modelo periodicamente com dados mais recentes",
+                true,
+            ],
+            [
+                "Usar o Amazon Personalize e refinar o modelo apenas com os dados históricos de pedidos",
+                false,
+            ],
+            [
+                "Usar o Amazon Rekognition para analisar fotos dos pratos e aprimorar o modelo",
+                false,
+            ],
+            [
+                "Usar o Amazon CloudWatch para examinar os pedidos dos clientes e ajustar o modelo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa do setor imobiliário criou um modelo de ML que prevê preços de venda de imóveis e quer hospedá-lo para gerar previsões sem precisar gerenciar servidores ou infraestrutura. Qual solução atende a esse requisito?",
+        explanation:
+            "Um endpoint do Amazon SageMaker AI é uma opção gerenciada: a AWS cuida dos servidores, da escala e da manutenção, e a empresa só chama o modelo para obter previsões. No EC2 ou no EKS a própria empresa provisiona, escala e atualiza servidores ou contêineres, e CloudFront com S3 distribui conteúdo, sem executar inferência.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Implantar o modelo em um endpoint de inferência do Amazon SageMaker AI", true],
+            ["Implantar o modelo em uma instância do Amazon EC2 com o framework de ML", false],
+            [
+                "Implantar o modelo com o Amazon CloudFront integrado a um bucket do Amazon S3",
+                false,
+            ],
+            ["Implantar o modelo em contêineres em um cluster do Amazon EKS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma fábrica usa IA para inspecionar seus produtos e encontrar danos ou defeitos. Que tipo de aplicação de IA a empresa está usando?",
+        explanation:
+            "A visão computacional é a área da IA que interpreta imagens e vídeos, base dos sistemas que detectam danos e defeitos em linhas de produção. Sistemas de recomendação sugerem itens a partir do comportamento dos usuários, o processamento de linguagem natural lida com texto e fala, e a previsão de séries temporais projeta valores futuros.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Visão computacional, que interpreta o conteúdo de imagens e vídeos capturados", true],
+            [
+                "Sistema de recomendação, que sugere itens com base no comportamento dos usuários",
+                false,
+            ],
+            [
+                "Processamento de linguagem natural, que interpreta e gera textos e fala humana",
+                false,
+            ],
+            [
+                "Previsão de séries temporais, que projeta valores futuros a partir do histórico",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer construir um modelo de ML que preveja a satisfação dos clientes a partir de dados como tempo de entrega, valor do pedido e contatos com o suporte, e precisa que o ajuste do modelo seja totalmente automatizado. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon SageMaker AI treina modelos personalizados e, com o ajuste automático de modelos, roda vários treinos testando hiperparâmetros até achar a melhor combinação, sem ajuste manual. O Athena consulta dados com SQL, o Personalize gera recomendações e o Comprehend analisa textos, e nenhum deles ajusta um modelo próprio de previsão.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Amazon SageMaker AI, com o ajuste automático de modelos (automatic model tuning)",
+                true,
+            ],
+            [
+                "Amazon Athena, com consultas SQL interativas sobre os dados armazenados no Amazon S3",
+                false,
+            ],
+            [
+                "Amazon Personalize, com recomendações personalizadas geradas a partir do comportamento",
+                false,
+            ],
+            [
+                "Amazon Comprehend, com extração de entidades, frases-chave e sentimento de textos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma organização sem fins lucrativos está criando um app de celular para pessoas com baixa visão. O primeiro requisito é o app entender as perguntas que os usuários fazem falando. Qual solução atende a esse requisito?",
+        explanation:
+            "Uma rede neural de deep learning para reconhecimento de fala converte a pergunta falada em texto que o app consegue processar. Padrões em dados numéricos servem a dados tabulares, a sumarização só condensa texto e a classificação de imagens analisa fotos, não fala.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Usar uma rede neural de deep learning para fazer reconhecimento de fala", true],
+            ["Criar modelos de ML para encontrar padrões em dados numéricos tabulares", false],
+            ["Usar sumarização com IA generativa para produzir textos com tom humano", false],
+            ["Criar modelos personalizados de classificação e reconhecimento de imagens", false],
+        ],
+    },
+    {
+        statement:
+            "Uma revendedora de carros usados quer estimar o preço de venda de cada veículo a partir de atributos como quilometragem, ano de fabricação e marca. Qual algoritmo ela deve usar para atender a esse requisito?",
+        explanation:
+            "A regressão linear modela a relação entre os atributos de entrada e um alvo numérico contínuo, como o preço de um veículo. A regressão logística, apesar do nome, prevê a probabilidade de uma categoria, o K-means agrupa registros sem prever valores e o PCA só reduz a quantidade de atributos, sem gerar previsões.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Regressão linear, que relaciona os atributos a um valor numérico contínuo", true],
+            ["Regressão logística, que estima a probabilidade de uma classe categórica", false],
+            ["K-means, que agrupa veículos parecidos em clusters sem prever valores", false],
+            [
+                "Análise de componentes principais (PCA), que reduz o número de atributos usados",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Ao comparar classificadores de fraude, uma equipe descarta um modelo com precisão de 0,95 e recall de 0,20, porque a pontuação F1 dele ficou baixa. Como a pontuação F1 é calculada para chegar a esse resultado?",
+        explanation:
+            "A F1 é a média harmônica entre precisão e recall, que fica perto do menor dos dois: com 0,95 e 0,20 ela dá cerca de 0,33, enquanto a média aritmética passaria de 0,57. Pegar o maior valor esconderia o recall ruim, e a proporção de acertos sobre todas as previsões é a acurácia.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Pela média harmônica entre precisão e recall, que fica perto do menor dos dois",
+                true,
+            ],
+            [
+                "Pela média aritmética entre precisão e recall, somando os dois e dividindo por dois",
+                false,
+            ],
+            [
+                "Pelo maior valor entre precisão e recall, que representa o melhor cenário do modelo",
+                false,
+            ],
+            ["Pela proporção de acertos sobre todas as previsões, positivas e negativas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma loja online criou um sistema que marca pedidos como possíveis fraudes, e uma equipe revisa manualmente cada pedido marcado. A empresa quer reduzir o tempo que a equipe perde revisando pedidos marcados que se revelam legítimos. Qual métrica de avaliação ela deve otimizar?",
+        explanation:
+            "Pedidos legítimos marcados como fraude são falsos positivos, e a precisão (fraudes confirmadas entre todos os pedidos marcados) cai quando eles aumentam; otimizá-la reduz as revisões desperdiçadas. O recall mede quanto da fraude real é pego e pode elevar os falsos positivos, a F1 equilibra as duas e a acurácia engana com poucas fraudes.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Precisão, a fração dos pedidos marcados que eram fraude de verdade", true],
+            ["Recall, a fração das fraudes reais que o sistema consegue marcar", false],
+            ["Pontuação F1, a média harmônica entre a precisão e o recall do sistema", false],
+            ["Acurácia, a fração de todas as previsões que o sistema acertou", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de MLOps está avaliando adotar infraestrutura como código (IaC) para os ambientes de ML da empresa. Qual é um benefício do uso de IaC em MLOps?",
+        explanation:
+            "Com IaC a infraestrutura é definida, versionada e automatizada em código, o que torna repetível e consistente o provisionamento dos ambientes de ML entre desenvolvimento, teste e produção. O ajuste de hiperparâmetros continua necessário, e o tipo e o custo das instâncias dependem do que o código de IaC define, não da IaC em si.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Agiliza a implantação de cargas de ML escaláveis e consistentes em ambientes na nuvem",
+                true,
+            ],
+            [
+                "Elimina a necessidade de ajuste de hiperparâmetros durante o treinamento dos modelos",
+                false,
+            ],
+            [
+                "Provisiona instâncias mais potentes, o que leva ao treino de modelos mais precisos",
+                false,
+            ],
+            [
+                "Reduz os gastos totais ao escolher automaticamente instâncias de baixo custo para o treino",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma seguradora quer marcar cada pedido de indenização como fraudulento ou legítimo com base nos dados do sinistro. Que tipo de modelo de ML atende a esse requisito?",
+        explanation:
+            "Marcar cada pedido como fraudulento ou legítimo é escolher entre exatamente duas categorias, o que define a classificação binária. A classificação multiclasse serve para três ou mais categorias, a regressão prevê valores numéricos contínuos e os modelos de difusão geram conteúdo, como imagens, sem classificar registros.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Classificação binária, que atribui cada entrada a uma entre duas categorias", true],
+            [
+                "Classificação multiclasse, que atribui cada entrada a uma entre três ou mais categorias",
+                false,
+            ],
+            ["Regressão, que prevê um valor numérico contínuo para cada entrada analisada", false],
+            ["Modelo de difusão, que gera conteúdo novo, como imagens, a partir de ruído", false],
+        ],
+    },
+    {
+        statement:
+            "Um serviço de streaming por assinatura está criando um modelo de ML para prever quais clientes tendem a cancelar o plano. Qual métrica é adequada para avaliar esse modelo de classificação binária?",
+        explanation:
+            "A pontuação F1 junta precisão e recall em um único valor, o que serve a uma classificação binária como a de cancelamento, em que importa acertar quem vai sair sem gerar alarmes demais. R² e erro quadrático médio são métricas de regressão para valores contínuos, e o tempo de treinamento é um dado operacional, não de qualidade.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Pontuação F1, que combina a precisão e o recall das previsões de cancelamento", true],
+            [
+                "Coeficiente de determinação (R²), a parcela da variância explicada pelo modelo",
+                false,
+            ],
+            [
+                "Erro quadrático médio (MSE), a média dos erros ao quadrado em valores numéricos",
+                false,
+            ],
+            [
+                "Tempo de treinamento do modelo, medido do início ao fim de cada job de treino",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Ao avaliar um modelo que classifica fotos de peças como defeituosas ou não, uma equipe precisa de uma métrica que mostre a razão entre os itens classificados corretamente e o total de itens classificados, certos ou errados. Qual métrica atende a esse requisito?",
+        explanation:
+            "A acurácia divide as previsões corretas (verdadeiros positivos e verdadeiros negativos) pelo total de previsões, exatamente a razão pedida. A precisão olha só as previsões positivas, o recall olha só os casos realmente positivos, e a F1 combina essas duas métricas em vez de medir o acerto geral.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Acurácia, a proporção de previsões corretas sobre o total de previsões", true],
+            ["Precisão, a proporção de acertos entre as peças apontadas como defeituosas", false],
+            ["Recall, a proporção das peças realmente defeituosas que o modelo identificou", false],
+            ["Pontuação F1, a média harmônica entre a precisão e o recall do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Um estúdio de animação quer gerar automaticamente legendas para os diálogos dos seus filmes. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Transcribe usa reconhecimento automático de fala para transformar o áudio em texto com marcação de tempo e gera legendas nos formatos WebVTT e SRT. O Translate só traduz texto que já existe, o Polly faz o caminho inverso, de texto para fala, e o Comprehend analisa textos prontos, sem transcrever áudio.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Transcribe, que converte a fala em texto com marcação de tempo", true],
+            ["Amazon Translate, que traduz textos de um idioma para outro com qualidade", false],
+            ["Amazon Polly, que sintetiza fala natural a partir de textos escritos", false],
+            ["Amazon Comprehend, que extrai sentimentos e entidades de textos existentes", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer ler automaticamente as mensagens que os clientes escrevem no chat de suporte e encaminhar cada uma para um tema, como cobrança, problemas técnicos ou alterações de conta. Qual conceito de IA esse cenário representa?",
+        explanation:
+            "Ler mensagens escritas e encaminhar cada uma para um tema é uma tarefa de processamento de linguagem natural, mais especificamente classificação de texto, pois exige interpretar a linguagem humana. O reconhecimento de fala trata áudio, a visão computacional trata imagens e vídeos, e a previsão estima valores futuros a partir de histórico.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Processamento de linguagem natural, que interpreta e categoriza textos", true],
+            ["Reconhecimento de fala, que transforma o áudio de conversas faladas em texto", false],
+            ["Visão computacional, que interpreta o conteúdo visual de imagens e vídeos", false],
+            ["Previsão, que estima valores numéricos futuros a partir de dados históricos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando uma aplicação que deve organizar automaticamente clientes e produtos em grupos de itens semelhantes, com base nos atributos de cada um, sem categorias definidas previamente. Qual estratégia de ML a empresa deve usar?",
+        explanation:
+            "O aprendizado não supervisionado encontra padrões e grupos naturais em dados sem rótulos, então serve para agrupar clientes e produtos parecidos quando não há categorias prévias. O supervisionado exige rótulos conhecidos, o semissupervisionado precisa de ao menos alguns dados rotulados e o por reforço aprende com recompensas em um ambiente.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Aprendizado não supervisionado, que descobre agrupamentos naturais nos dados sem rótulos",
+                true,
+            ],
+            [
+                "Aprendizado supervisionado, que aprende a partir de exemplos com rótulos conhecidos",
+                false,
+            ],
+            [
+                "Aprendizado por reforço, que ajusta as ações de um agente com base em recompensas",
+                false,
+            ],
+            [
+                "Aprendizado semissupervisionado, que combina poucos dados rotulados com muitos sem rótulo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma plataforma de ensino online publica seus materiais de curso em inglês e quer oferecer o mesmo conteúdo a alunos que falam vários outros idiomas. Qual solução atende a esses requisitos?",
+        explanation:
+            "O Amazon Translate faz tradução automática de texto com alta qualidade, sob demanda ou em lote, então converte os materiais do inglês para vários idiomas. O Transcribe transforma fala em texto sem traduzir, o Personalize gera recomendações a partir do comportamento dos usuários e o Textract extrai texto e dados de documentos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Usar a tradução em tempo real do Amazon Translate nos materiais dos cursos", true],
+            ["Adicionar o Amazon Transcribe para converter as aulas faladas em texto", false],
+            ["Adicionar o Amazon Personalize para recomendar cursos a cada aluno", false],
+            [
+                "Usar o processamento de documentos em tempo real do Amazon Textract nos materiais",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um documentarista quer alcançar um público maior adicionando automaticamente legendas e dublagens em vários idiomas aos seus filmes. Quais DUAS etapas, juntas, atendem a esse requisito? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Transcribe converte os diálogos em texto e o Amazon Translate traduz esse texto, gerando legendas em vários idiomas; o Amazon Polly transforma o texto traduzido em fala, criando as dublagens. Translate e Transcribe entregam texto, não áudio, e o Textract extrai texto de documentos e imagens, não da fala dos vídeos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Usar o Amazon Polly para gerar as dublagens em vários idiomas a partir de texto",
+                true,
+            ],
+            [
+                "Usar o Amazon Transcribe e o Amazon Translate para gerar legendas em vários idiomas",
+                true,
+            ],
+            [
+                "Usar o Amazon Translate para gerar as dublagens em vários idiomas a partir de texto",
+                false,
+            ],
+            [
+                "Usar o Amazon Textract e o Amazon Translate para gerar legendas em vários idiomas",
+                false,
+            ],
+            [
+                "Usar o Amazon Transcribe para gerar as dublagens em vários idiomas a partir do áudio",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um hospital treinou um modelo com o histórico de pacientes (histórico médico, dados demográficos e tratamentos) para prever, em tempo real, se um paciente será readmitido em até 30 dias após a alta. Qual tarefa desse cenário representa a inferência do modelo?",
+        explanation:
+            "Inferência é usar um modelo já treinado para gerar previsões sobre dados novos, como prever a readmissão de um paciente que acabou de receber alta. Coletar registros é a etapa de coleta de dados, medir métricas é avaliação e buscar padrões é análise exploratória, todas anteriores às previsões.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Aplicar o modelo treinado para prever se um paciente recém-liberado será readmitido",
+                true,
+            ],
+            [
+                "Coletar os registros históricos de readmissão de pacientes dos últimos anos para o treino",
+                false,
+            ],
+            ["Medir o desempenho do modelo com métricas de avaliação adequadas ao problema", false],
+            [
+                "Analisar os dados para descobrir padrões e correlações entre as características dos pacientes",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma rede varejista quer criar e implantar modelos de ML a partir das próprias planilhas de vendas e de cadastro de clientes, sem que seus analistas precisem escrever código. Qual serviço ou recurso da AWS atende a esse requisito?",
+        explanation:
+            "O SageMaker Canvas oferece uma interface visual no-code para preparar dados tabulares, treinar, avaliar e implantar modelos próprios. Rekognition e Comprehend são serviços de IA voltados a imagens e a textos, e o Textract extrai dados de documentos, sem criar modelos de previsão sobre tabelas.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Amazon SageMaker Canvas, que cria, treina e implanta modelos em uma interface visual",
+                true,
+            ],
+            [
+                "Amazon Rekognition, que analisa imagens e vídeos com modelos já treinados pela AWS",
+                false,
+            ],
+            [
+                "Amazon Comprehend, que extrai sentimento e entidades de textos com modelos prontos",
+                false,
+            ],
+            [
+                "Amazon Textract, que extrai texto e dados de formulários de documentos digitalizados",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa reunir um grande conjunto de dados para treinar um assistente de IA especializado em uma área de conteúdo específica. Qual conjunto de dados atende a esse objetivo?",
+        explanation:
+            "Um assistente conversacional aprende a entender e responder bem numa área quando treina com diálogos variados que usam o vocabulário dela. Séries de vendas servem a previsões, rótulos de sentimento de notícias não ensinam a conversar e pares de IDs de produto e usuário alimentam recomendações.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Conversas variadas que usam a terminologia própria da área de atuação do assistente",
+                true,
+            ],
+            [
+                "Séries temporais do histórico de vendas gerais da empresa nos últimos cinco anos",
+                false,
+            ],
+            [
+                "Resultados de análise de sentimento de notícias publicadas sobre o setor da empresa",
+                false,
+            ],
+            [
+                "Identificadores únicos de produtos associados aos identificadores de cada usuário",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma loja on-line quer dividir seus clientes em grupos com base em dados demográficos e no comportamento de compra. Qual algoritmo ela deve usar para atender a esse requisito?",
+        explanation:
+            "K-means é um algoritmo não supervisionado de agrupamento que separa os registros em k grupos por similaridade, o que serve para segmentar clientes sem rótulos. k-NN, árvore de decisão e SVM são algoritmos supervisionados, que precisam de exemplos rotulados para classificar ou prever um alvo conhecido.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Árvore de decisão", false],
+            ["Máquina de vetores de suporte (SVM)", false],
+            ["K-vizinhos mais próximos (k-NN)", false],
+            ["K-means (k-médias)", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados está catalogando os projetos de ML da empresa pelo tipo de aprendizado usado. Qual destes cenários é um exemplo de aprendizado não supervisionado?",
+        explanation:
+            "Organizar notícias em temas sem categorias predefinidas é agrupamento, típico do aprendizado não supervisionado, que encontra padrões em dados sem rótulos. Classificar o risco de um empréstimo e prever a demanda de energia são supervisionados (classificação e regressão), e o robô recompensado é aprendizado por reforço.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Um modelo que organiza milhares de notícias em temas relacionados sem categorias predefinidas",
+                true,
+            ],
+            [
+                "Um modelo que marca cada pedido de empréstimo como de alto ou de baixo risco de inadimplência",
+                false,
+            ],
+            [
+                "Um modelo que prevê a demanda de energia elétrica de uma cidade para o dia seguinte",
+                false,
+            ],
+            [
+                "Um modelo que ensina um robô a andar recompensando os movimentos que dão certo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de suporte usa análise de sentimento para identificar o humor expresso nos comentários dos clientes. A análise de sentimento faz parte de qual área mais ampla da IA?",
+        explanation:
+            "Análise de sentimento é uma tarefa de processamento de linguagem natural (PLN), a área da IA que permite às máquinas entender e extrair significado da linguagem humana. Visão computacional interpreta imagens, reconhecimento de fala converte áudio em texto e séries temporais preveem valores numéricos ao longo do tempo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Processamento de linguagem natural (PLN)", true],
+            ["Visão computacional (computer vision)", false],
+            ["Previsão de séries temporais (forecasting)", false],
+            ["Reconhecimento automático de fala (ASR)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de SaaS coleta um grande volume de comentários de clientes em texto livre e quer analisar o sentimento expresso neles. Qual solução atende a esse requisito?",
+        explanation:
+            "Um LLM aplica processamento de linguagem natural para ler texto não estruturado e dizer se o sentimento é positivo, negativo ou neutro, o que se encaixa em grandes volumes de comentários livres. Regressão prevê valores numéricos, recomendação sugere itens e séries temporais projetam valores no tempo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Usar um large language model (LLM) para fazer a análise de sentimento dos textos",
+                true,
+            ],
+            [
+                "Usar um algoritmo de regressão para separar os comentários em categorias predefinidas",
+                false,
+            ],
+            ["Usar um mecanismo de recomendação para detectar o sentimento de cada usuário", false],
+            [
+                "Usar um algoritmo de séries temporais para prever o sentimento a partir do histórico",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um banco revisa os registros de transações financeiras e atribui a cada um a categoria 'pessoal' ou 'empresarial', gravando essa categoria no próprio registro. Qual etapa de preparação de dados isso descreve?",
+        explanation:
+            "Rotulagem é anexar a cada registro a categoria correta, que depois serve de alvo no aprendizado supervisionado, exatamente o que o banco faz. Codificação converte categorias já existentes em números, normalização coloca atributos numéricos na mesma escala e balanceamento ajusta a proporção entre as classes.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Normalização de dados (normalization)", false],
+            ["Codificação de dados (encoding)", false],
+            ["Balanceamento de classes (balancing)", false],
+            ["Rotulagem de dados (data labeling)", true],
+        ],
+    },
+    {
+        statement:
+            "Uma distribuidora de energia quer monitorar os níveis de tensão da rede elétrica em regiões rurais. Ela vai registrar leituras de tensão continuamente no Amazon RDS e analisar como elas variam ao longo de cada dia para criar um modelo que preveja possíveis quedas de energia. Que tipo de dado a distribuidora deve coletar?",
+        explanation:
+            "Séries temporais são valores registrados em sequência ao longo do tempo, como leituras de tensão em intervalos regulares, e permitem modelar a variação diária para prever quedas. Atributos fixos das subestações não mostram essa evolução, e textos de manutenção ou áudio dos transformadores não medem a tensão.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Dados tabulares estáticos, com atributos fixos de cada subestação", false],
+            ["Dados de texto, com relatórios escritos pelas equipes de manutenção", false],
+            ["Dados de séries temporais, com leituras ordenadas por data e hora", true],
+            ["Dados de áudio, com gravações do ruído emitido pelos transformadores", false],
+        ],
+    },
+    {
+        statement:
+            "Uma fabricante quer treinar um modelo de ML que sinalize leituras incomuns nos dados dos sensores de seus equipamentos, mas não tem nenhum exemplo rotulado para o treinamento. Qual método de ML atende a esse requisito?",
+        explanation:
+            "Autoencoders são um método não supervisionado que aprende a reconstruir o padrão normal dos dados; leituras com erro de reconstrução alto aparecem como anomalias, sem precisar de rótulos. Árvore de decisão, regressão linear e regressão logística são supervisionadas e exigem exemplos rotulados para o treino.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Árvore de decisão (decision tree)", false],
+            ["Autoencoders (autocodificadores)", true],
+            ["Regressão linear (linear regression)", false],
+            ["Regressão logística (logistic regression)", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de streaming de música quer sugerir músicas a cada ouvinte com base no histórico do que ele já escutou. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Personalize é um serviço gerenciado que gera recomendações personalizadas em tempo real com base no histórico e nas interações de cada usuário. Rekognition analisa imagens e vídeos, Transcribe converte fala em texto e Comprehend extrai insights de textos, e nenhum deles gera recomendações.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Personalize", true],
+            ["Amazon Rekognition", false],
+            ["Amazon Transcribe", false],
+            ["Amazon Comprehend", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está adotando MLOps para gerenciar seus fluxos de machine learning com mais confiabilidade. Quais práticas a equipe deve priorizar? (Selecione DUAS opções.)",
+        explanation:
+            "Versionar modelos permite rastrear mudanças, reproduzir resultados e voltar a uma versão anterior, e testes e validação automatizados garantem a qualidade antes da implantação. Implantação manual contraria a automação do MLOps, documentação mínima prejudica a auditoria e, sem monitoramento, o drift passa despercebido.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Versionar os modelos para garantir a reprodutibilidade dos resultados", true],
+            ["Automatizar os testes e a validação dos modelos antes da implantação", true],
+            [
+                "Implantar os modelos manualmente, conferindo cada etapa em produção a cada nova versão",
+                false,
+            ],
+            ["Manter a documentação mínima para acelerar as entregas da equipe", false],
+            ["Dispensar o monitoramento em produção depois que o modelo é validado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma agência de saúde pública reuniu um ano de registros de pacientes e quer gerar um relatório mensal de tendências para os gestores. Todo mês, ela precisa rodar um modelo sobre um grande conjunto de registros históricos em um horário agendado, sem necessidade de resultado imediato. Qual método de inferência atende a isso com o menor custo?",
+        explanation:
+            "Batch transform roda a inferência sobre um grande conjunto de dados em um job agendado, sem endpoint ligado o tempo todo, o que barateia o relatório mensal. Tempo real mantém um endpoint permanente para respostas imediatas, serverless atende tráfego intermitente com resposta por requisição e a assíncrona enfileira requisições individuais grandes.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Inferência em tempo real (real-time)", false],
+            ["Inferência assíncrona (asynchronous)", false],
+            ["Batch transform (inferência em lote)", true],
+            ["Inferência serverless (sem servidor)", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco está criando um modelo de ML para prever a probabilidade de um solicitante de empréstimo ficar inadimplente, usando renda, score de crédito, tempo de emprego e dívidas atuais. O histórico traz, para cada solicitante anterior, um rótulo indicando se ele ficou inadimplente. Qual técnica de ML atende a esses requisitos?",
+        explanation:
+            "Com atributos de entrada e um rótulo conhecido para cada registro histórico, o modelo aprende a prever esse alvo: é aprendizado supervisionado. O não supervisionado busca padrões sem rótulos, o por reforço aprende com recompensas ao interagir com um ambiente e o semissupervisionado serve quando só parte dos dados tem rótulo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aprendizado não supervisionado", false],
+            ["Aprendizado supervisionado", true],
+            ["Aprendizado por reforço", false],
+            ["Aprendizado semissupervisionado", false],
+        ],
+    },
+    {
+        statement:
+            "Um serviço de compartilhamento de fotos precisa espelhar e girar grandes lotes de imagens usando transformações numéricas simples e determinísticas. Qual solução é a MAIS eficiente operacionalmente?",
+        explanation:
+            "Girar e espelhar imagens são operações determinísticas que uma função AWS Lambda executa em escala, sem treinar nem hospedar modelo, então ML não é necessário. Uma rede neural profunda seria esforço desnecessário, um LLM do Bedrock gera conteúdo em vez de aplicar essas transformações exatas e o Glue Data Quality valida a qualidade de dados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Construir uma rede neural profunda que receba as imagens como entrada", false],
+            ["Usar um LLM do Amazon Bedrock com temperatura alta para processar as imagens", false],
+            ["Criar uma função AWS Lambda que aplique as transformações às imagens", true],
+            ["Usar o AWS Glue Data Quality para corrigir cada uma das imagens do lote", false],
+        ],
+    },
+    {
+        statement:
+            "Em um treinamento interno, um instrutor apresenta os principais tipos de machine learning. Qual das opções NÃO é um tipo de machine learning?",
+        explanation:
+            "Aprendizado diagnóstico não é um tipo reconhecido de machine learning. Os três tipos principais são o supervisionado, que treina com dados rotulados, o não supervisionado, que descobre padrões em dados sem rótulos, e o aprendizado por reforço, em que um agente aprende com recompensas e penalidades.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aprendizado supervisionado", false],
+            ["Aprendizado não supervisionado", false],
+            ["Aprendizado por reforço", false],
+            ["Aprendizado diagnóstico", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está desenvolvendo um modelo de visão computacional para inspecionar peças em uma linha de produção. Que tipo de dado é o mais adequado para treinar esse modelo?",
+        explanation:
+            "Modelos de visão computacional aprendem com os padrões visuais e de pixels de imagens e quadros de vídeo, por isso dados de imagem são os adequados. Dados tabulares servem a problemas clássicos como regressão, séries temporais registram valores ao longo do tempo e texto é a entrada de tarefas de PLN.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Dados de texto", false],
+            ["Dados de imagem", true],
+            ["Dados tabulares", false],
+            ["Dados de séries temporais", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer analisar automaticamente os comentários escritos por seus clientes, sem precisar treinar um modelo próprio. Qual serviço da AWS é o mais indicado para essa tarefa de processamento de linguagem natural (PLN)?",
+        explanation:
+            "O Amazon Comprehend é um serviço gerenciado de PLN que extrai sentimento, frases-chave, entidades e idioma de textos sem exigir treinamento, ideal para comentários de clientes. O SageMaker AI permitiria criar um modelo próprio com muito mais esforço, o Polly converte texto em fala e o Transcribe converte fala em texto.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon SageMaker AI", false],
+            ["Amazon Comprehend", true],
+            ["Amazon Polly", false],
+            ["Amazon Transcribe", false],
+        ],
+    },
+    {
+        statement:
+            "Durante o ciclo de vida de ML, um cientista de dados faz uma análise exploratória de dados (EDA) antes de construir o modelo. Qual é o objetivo dessa etapa?",
+        explanation:
+            "A análise exploratória acontece cedo no ciclo de vida para entender a estrutura, a distribuição, a qualidade e as relações dos dados, orientando a limpeza, a engenharia de atributos e a escolha do algoritmo. Treinar, implantar e monitorar são etapas posteriores, que dependem desse entendimento dos dados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Treinar o modelo ajustando seus parâmetros com os dados já preparados", false],
+            ["Entender a estrutura, a qualidade e as relações presentes nos dados", true],
+            ["Implantar o modelo em um endpoint para atender às requisições de previsão", false],
+            ["Monitorar o desempenho do modelo em produção e detectar drift nos dados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe desenha o pipeline de ML de um modelo que prevê o cancelamento de clientes. Qual destas atividades normalmente NÃO é uma etapa desse pipeline?",
+        explanation:
+            "Campanha publicitária da marca é uma atividade de marketing, não uma etapa técnica do pipeline de ML. Coleta e preparação reúnem os dados brutos, engenharia de atributos transforma esses dados em variáveis úteis para o modelo, e treinamento e avaliação ajustam o modelo e medem seu desempenho.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Treinamento e avaliação do modelo", false],
+            ["Campanha publicitária da marca", true],
+            ["Coleta e preparação dos dados", false],
+            ["Engenharia de atributos (features)", false],
+        ],
+    },
+    {
+        statement:
+            "Ao revisar o relatório de avaliação de um classificador, um analista encontra a métrica AUC-ROC. O que significa a sigla AUC nessa métrica?",
+        explanation:
+            "AUC significa Area Under the Curve, a área sob a curva ROC. Ela mede o quanto o classificador separa as classes e vai de 0 a 1: 1 indica separação perfeita e 0,5 equivale a um palpite aleatório. As outras expansões são inventadas e não correspondem a nenhuma métrica reconhecida.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Area Under the Curve (área sob a curva ROC)", true],
+            ["Adjusted Unit Cost (custo unitário ajustado)", false],
+            ["Average Usage Count (contagem média de uso)", false],
+            ["Accuracy Under Constraints (acurácia com restrições)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup avalia usar um modelo pré-treinado em vez de treinar um modelo do zero. Qual é uma vantagem importante dessa escolha?",
+        explanation:
+            "Um modelo pré-treinado já aprendeu com um grande volume de dados, então pode ser usado para inferência sem que a empresa forneça dados de treino, poupando tempo e esforço. Ele não supera necessariamente modelos feitos para a tarefa, costuma precisar de ajuste fino em domínios específicos e ainda deve ser avaliado.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Ele supera em acurácia os modelos customizados nas tarefas específicas do domínio da empresa",
+                false,
+            ],
+            [
+                "Ele pode ser usado para inferência logo de início, sem dados próprios de treinamento",
+                true,
+            ],
+            ["Ele dispensa o ajuste fino mesmo em tarefas muito especializadas do negócio", false],
+            ["Ele elimina a necessidade de avaliar o modelo antes de colocá-lo em produção", false],
+        ],
+    },
+    {
+        statement:
+            "Um cientista de dados quer que a AWS teste automaticamente algoritmos e combinações de hiperparâmetros sobre um conjunto de dados tabular, em vez de ajustá-los manualmente, e indique o melhor modelo candidato. Qual recurso da AWS é o mais indicado?",
+        explanation:
+            "O SageMaker Autopilot automatiza o AutoML: analisa os dados, testa algoritmos e hiperparâmetros e ranqueia os candidatos, e hoje sua interface fica dentro do SageMaker Canvas. Data Wrangler prepara e transforma dados, Feature Store armazena e serve atributos e Model Cards documentam os modelos, sem essa busca automática.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon SageMaker Autopilot", true],
+            ["Amazon SageMaker Data Wrangler", false],
+            ["Amazon SageMaker Model Cards", false],
+            ["Amazon SageMaker Feature Store", false],
+        ],
+    },
+    {
+        statement:
+            "Em uma reunião de planejamento, a equipe de dados propõe adotar MLOps para os projetos de machine learning. Do que o termo MLOps é uma abreviação?",
+        explanation:
+            "MLOps significa Machine Learning Operations, o conjunto de práticas que une machine learning e princípios de DevOps para automatizar e gerenciar a implantação, o monitoramento e a manutenção de modelos em produção. As outras expansões combinam termos plausíveis, mas não são o significado da sigla.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Machine Learning Optimization", false],
+            ["Managed Learning Outputs", false],
+            ["Machine Learning Operations", true],
+            ["Model Lifecycle Operations", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe prepara um relatório para a diretoria sobre o impacto de um modelo de ML no negócio. Qual destes indicadores NÃO é uma métrica de negócio?",
+        explanation:
+            "A pontuação F1 é uma métrica técnica de desempenho, a média harmônica entre precisão e recall, e mede a qualidade das previsões, não o valor gerado. ROI, satisfação do cliente e tempo de lançamento no mercado são métricas de negócio, que capturam o impacto real e os resultados da solução.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Retorno sobre o investimento (ROI)", false],
+            ["Pontuação F1 do modelo", true],
+            ["Satisfação do cliente", false],
+            ["Tempo de lançamento no mercado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer avaliar uma solução de IA pelo valor que ela entrega ao negócio. Quais indicadores são métricas de negócio? (Selecione DUAS opções.)",
+        explanation:
+            "Satisfação do cliente mostra se a solução atende quem a usa, e time-to-value mede em quanto tempo ela começa a gerar resultado para o negócio. Precisão, mAP e RMSE são métricas técnicas de desempenho do modelo, que medem acerto de classificação, qualidade de ranking e erro de regressão.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Precisão (precision) do modelo", false],
+            ["Índice de satisfação do cliente (CSAT)", true],
+            ["Mean Average Precision (mAP)", false],
+            ["Tempo até gerar valor (time-to-value)", true],
+            ["Raiz do erro quadrático médio (RMSE) das previsões", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa colocou uma solução de IA em produção e a diretoria quer saber se o investimento trouxe resultado para o negócio. Que medidas devem entrar nessa avaliação? (Selecione DUAS opções.)",
+        explanation:
+            "Para saber se a solução gerou resultado, a empresa mede o valor para o negócio: ganhos de eficiência operacional e retorno sobre o investimento. Número de parâmetros, taxa de aprendizado e épocas de treinamento são detalhes técnicos de configuração do modelo e não mostram se ele cumpriu os objetivos do negócio.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Ganhos de eficiência nas operações do negócio", true],
+            ["Número de parâmetros do modelo implantado", false],
+            ["Retorno sobre o investimento (ROI) da solução", true],
+            ["Taxa de aprendizado usada no treinamento", false],
+            ["Quantidade de épocas de treinamento executadas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de logística quer treinar um agente que aprenda a tomar decisões de roteamento interagindo com um ambiente simulado de armazém. Qual tipo de machine learning é o mais adequado para isso?",
+        explanation:
+            "No aprendizado por reforço, um agente aprende uma estratégia interagindo com o ambiente e recebendo recompensas ou penalidades pelas ações. O supervisionado treina com exemplos rotulados, o não supervisionado encontra padrões sem rótulos e o aprendizado por transferência reaproveita o conhecimento de um modelo em outra tarefa.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aprendizado supervisionado", false],
+            ["Aprendizado não supervisionado", false],
+            ["Aprendizado por reforço", true],
+            ["Aprendizado por transferência", false],
+        ],
+    },
+    {
+        statement:
+            "Um portal de notícias quer gerar narrações em áudio a partir dos artigos escritos que publica. Qual serviço da AWS é o mais adequado para isso?",
+        explanation:
+            "O Amazon Polly converte texto em fala natural, o que atende à geração de narração a partir dos artigos. O Transcribe faz o caminho inverso, convertendo áudio em texto, o Translate traduz textos entre idiomas e o Lex cria interfaces conversacionais de voz e texto, sem gerar a narração de um artigo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Transcribe", false],
+            ["Amazon Polly", true],
+            ["Amazon Translate", false],
+            ["Amazon Lex", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe reservou uma etapa do projeto para engenharia de atributos (feature engineering). Qual é o principal objetivo dessa etapa no ciclo de vida de ML?",
+        explanation:
+            "Engenharia de atributos transforma dados brutos em entradas úteis, criando novas variáveis ou transformando as existentes para melhorar o desempenho do modelo. Reunir mais dados é a coleta, medir métricas é a avaliação e publicar em produção é a implantação, etapas distintas do ciclo de vida.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Criar ou transformar variáveis de entrada para melhorar o desempenho do modelo",
+                true,
+            ],
+            [
+                "Reunir mais dados brutos de novas fontes para ampliar a base de treinamento do projeto",
+                false,
+            ],
+            ["Medir o desempenho do modelo treinado com métricas de avaliação adequadas", false],
+            ["Publicar o modelo em um ambiente de produção para uso pelas aplicações", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa escolher entre inferência em lote e inferência em tempo real para dois sistemas diferentes. Qual é a principal diferença entre esses dois tipos de inferência?",
+        explanation:
+            "A inferência em lote reúne muitas entradas e as processa juntas em um job, priorizando a vazão em cargas sem urgência, enquanto a em tempo real responde a cada entrada assim que ela chega. A precisão depende do modelo e não do modo de inferência, o tempo real não se limita a poucos dados e o lote costuma ter maior vazão em grandes volumes.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "O lote processa várias entradas juntas, e o tempo real responde a cada entrada ao chegar",
+                true,
+            ],
+            [
+                "O lote gera previsões mais precisas, porque o modelo analisa todas as entradas em conjunto",
+                false,
+            ],
+            [
+                "O tempo real só funciona com poucos dados, porque cada requisição precisa caber na memória",
+                false,
+            ],
+            [
+                "O tempo real conclui grandes volumes mais rápido, porque dispensa agendar jobs de lote",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer usar um único serviço da AWS para construir, treinar e implantar modelos de machine learning de ponta a ponta. Qual serviço é o mais adequado?",
+        explanation:
+            "O Amazon SageMaker AI é uma plataforma gerenciada que cobre o ciclo de vida de ML: preparação de dados, treinamento, ajuste e implantação de modelos. Comprehend Medical extrai informações de textos clínicos, Polly converte texto em fala e Translate traduz idiomas, cada um resolvendo uma tarefa específica.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Comprehend Medical", false],
+            ["Amazon SageMaker AI", true],
+            ["Amazon Polly", false],
+            ["Amazon Translate", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consultoria lista possíveis aplicações de IA e ML para um cliente. Qual destas atividades NÃO é um caso de uso típico de IA ou ML?",
+        explanation:
+            "Registrar fichas manualmente em papel é uma tarefa administrativa rotineira e determinística, que não envolve aprender com dados nem fazer previsões. Detecção de fraudes, reconhecimento de fala e sistemas de recomendação são aplicações consolidadas de IA e ML, que identificam padrões e fazem previsões a partir de dados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Detecção de fraudes em transações", false],
+            ["Registro manual de fichas em papel", true],
+            ["Reconhecimento de fala em chamadas", false],
+            ["Sistemas de recomendação de produtos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma seguradora recebe milhares de formulários digitalizados e quer extrair o texto e as tabelas desses documentos e, em seguida, identificar entidades e frases-chave no conteúdo. Quais serviços da AWS atendem a essas necessidades? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Textract extrai texto, formulários e tabelas de documentos digitalizados, e o Amazon Comprehend aplica PLN ao texto extraído para identificar entidades, frases-chave e sentimento. Polly converte texto em fala, Translate traduz entre idiomas e Transcribe converte áudio em texto, sem analisar documentos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Textract", true],
+            ["Amazon Comprehend", true],
+            ["Amazon Polly", false],
+            ["Amazon Translate", false],
+            ["Amazon Transcribe", false],
+        ],
+    },
+    {
+        statement:
+            "A equipe de suporte de uma operadora de telecomunicações quer estudar o que os clientes falam nas ligações gravadas e extrair os pontos importantes. As gravações existem apenas como arquivos de áudio. Qual solução atende a esses requisitos?",
+        explanation:
+            "O Amazon Transcribe converte a fala das gravações em texto, que a equipe pode então analisar para extrair os pontos principais. O Comprehend analisa texto, mas não aceita áudio como entrada, o Lex cria chatbots em vez de transcrever gravações e o Polly sintetiza fala a partir de texto, o caminho inverso.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Converter as gravações em texto com o Amazon Transcribe para então analisar o conteúdo",
+                true,
+            ],
+            [
+                "Aplicar o Amazon Comprehend diretamente aos arquivos de áudio para classificar os assuntos",
+                false,
+            ],
+            [
+                "Criar um chatbot conversacional com o Amazon Lex para atender às próximas ligações",
+                false,
+            ],
+            [
+                "Usar o Amazon Polly para gerar áudio sintetizado com os pontos principais das ligações",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma fintech vai iniciar um projeto de ML que usará dados financeiros de clientes. Em qual etapa do ciclo de vida de ML a equipe deve identificar as obrigações regulatórias e de conformidade que o projeto precisa cumprir?",
+        explanation:
+            "As obrigações regulatórias são identificadas na definição do objetivo de negócio, pois o que se pretende construir determina quais leis se aplicam antes de qualquer dado ser coletado. Na coleta essas obrigações são aplicadas na prática, e treinamento e engenharia de atributos são etapas técnicas posteriores.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Treinamento e ajuste do modelo", false],
+            ["Coleta e preparação dos dados", false],
+            ["Definição do objetivo de negócio", true],
+            ["Engenharia de atributos (features)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de ciência de dados já treinou dezenas de modelos e não sabe mais qual versão de cada um está em produção. Ela precisa de um lugar central para registrar os próprios modelos, controlar as versões e saber qual delas foi implantada. Qual solução atende a essa necessidade?",
+        explanation:
+            "O SageMaker Model Registry é o catálogo dos modelos da própria equipe: agrupa as versões, guarda os metadados e registra o status de aprovação e de implantação. Feature Store centraliza atributos, não modelos; Pipelines orquestra as etapas do fluxo; CloudWatch acompanha métricas e alarmes operacionais.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Registrar os modelos e as versões no SageMaker Model Registry", true],
+            ["Armazenar os modelos e as versões no SageMaker Feature Store", false],
+            ["Orquestrar os modelos e as versões com o SageMaker Pipelines", false],
+            ["Acompanhar os modelos e as versões com alarmes do Amazon CloudWatch", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe monitora um modelo preditivo em produção e percebe que o desvio nos dados de entrada (data drift) ultrapassou o limite que ela mesma definiu. A equipe quer limitar o impacto negativo desse desvio nas previsões. Qual ação atende a esse objetivo?",
+        explanation:
+            "Drift acima do limite indica que os dados de produção já não se parecem com os do treino, então retreinar com dados recentes recupera a qualidade das previsões. Mudar a sensibilidade só altera quando o alerta dispara, reiniciar o endpoint mantém o mesmo modelo e rastrear experimentos registra execuções sem corrigir o desvio.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Retreinar o modelo com dados recentes que reflitam o novo padrão de entrada", true],
+            [
+                "Ajustar a sensibilidade do monitoramento para que o alerta dispare menos vezes",
+                false,
+            ],
+            [
+                "Reiniciar o endpoint de inferência para recarregar o modelo que está implantado",
+                false,
+            ],
+            [
+                "Ativar o rastreamento de experimentos para registrar os próximos treinamentos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa implantou um modelo de previsão de demanda que teve ótimo desempenho na validação. A liderança pergunta por que ainda seria preciso monitorar esse modelo depois que ele já está em produção. Qual é o principal motivo?",
+        explanation:
+            "Mesmo um modelo bem validado perde qualidade quando os dados ou a relação entre entradas e resultado mudam, e o monitoramento existe para detectar esse drift a tempo de agir. Coletar dados, fazer engenharia de atributos e treinar modelos são outras etapas do ciclo de vida, não a finalidade do monitoramento.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Detectar desvios nos dados e no modelo (drift), que degradam as previsões com o tempo",
+                true,
+            ],
+            [
+                "Coletar mais dados brutos de produção para ampliar o próximo conjunto de treinamento",
+                false,
+            ],
+            [
+                "Executar a engenharia de atributos, criando novas variáveis a partir das entradas recebidas",
+                false,
+            ],
+            [
+                "Treinar novos modelos do zero sempre que chegarem dados novos ao ambiente de produção",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma loja virtual quer exibir recomendações de produtos adaptadas ao histórico de navegação e de compras de cada cliente, sem desenvolver os próprios algoritmos de recomendação. Qual serviço da AWS atende a essa necessidade?",
+        explanation:
+            "O Amazon Personalize cria recomendações individuais a partir das interações de cada usuário, com modelos gerenciados que dispensam desenvolver algoritmos próprios. Comprehend analisa textos, Rekognition analisa imagens e vídeos e Lex constrói interfaces de conversa; nenhum deles personaliza recomendações.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Personalize", true],
+            ["Amazon Comprehend", false],
+            ["Amazon Rekognition", false],
+            ["Amazon Lex", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de comércio eletrônico vai começar a vender em outros países e precisa gerar automaticamente as descrições dos seus produtos em vários idiomas a partir do texto original. Qual serviço da AWS atende a essa necessidade?",
+        explanation:
+            "O Amazon Translate usa tradução automática neural para converter textos entre idiomas, o que permite publicar as descrições dos produtos em vários mercados. Polly converte texto em fala, Comprehend extrai informações de textos e Transcribe converte fala em texto; nenhum deles traduz.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Polly", false],
+            ["Amazon Translate", true],
+            ["Amazon Comprehend", false],
+            ["Amazon Transcribe", false],
+        ],
+    },
+    {
+        statement:
+            "Um hospital nos Estados Unidos quer uma aplicação que leia as anotações clínicas em texto livre dos prontuários, extraia os detalhes clínicos relevantes e produza resumos curtos para a equipe médica. Qual solução atende a esses requisitos?",
+        explanation:
+            "O Amazon Comprehend Medical extrai de textos clínicos entidades como condições, medicamentos e dosagens, com as relações entre elas, e um LLM no Amazon Bedrock transforma essa saída em resumos curtos. Personalize gera recomendações, Textract extrai texto de documentos sem interpretar o conteúdo clínico e a análise de sentimento não identifica entidades médicas.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Usar o Amazon Comprehend Medical para extrair entidades médicas e um LLM no Amazon Bedrock para resumir",
+                true,
+            ],
+            [
+                "Usar o Amazon Personalize para modelar o engajamento dos pacientes e repassar o resultado a um modelo genérico",
+                false,
+            ],
+            [
+                "Usar o Amazon Textract para digitalizar os documentos e aplicar uma extração simples de palavras-chave",
+                false,
+            ],
+            [
+                "Usar a análise de sentimento do Amazon Comprehend para classificar as anotações e preencher um modelo fixo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um banco implantou um modelo que prevê se cada cliente vai encerrar a conta (churn). A equipe quer medir o quanto as previsões do modelo batem com o comportamento real dos clientes. Qual métrica é adequada para essa avaliação?",
+        explanation:
+            "Prever se o cliente sai ou fica é classificação binária, e a pontuação F1 combina precisão e recall para medir o acerto contra o comportamento real, mesmo com classes desbalanceadas. RMSE avalia regressão, ROI é métrica de negócio e perplexidade avalia modelos de linguagem.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Pontuação F1", true],
+            ["Raiz do erro quadrático médio (RMSE)", false],
+            ["Retorno sobre o investimento (ROI)", false],
+            ["Perplexidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa desenvolve modelos de ML no Amazon SageMaker AI com várias equipes, e cada uma recria por conta própria as mesmas variáveis de entrada, como média de gastos e tempo de relacionamento do cliente. A empresa quer compartilhar e gerenciar essas variáveis entre as equipes. Qual recurso do SageMaker atende a esse requisito?",
+        explanation:
+            "O SageMaker Feature Store é o repositório central de atributos (features): as equipes guardam, descobrem e reutilizam as mesmas variáveis no treino e na inferência. Data Wrangler prepara e transforma dados, Model Registry versiona modelos e Model Cards documenta os modelos; nenhum deles compartilha atributos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["SageMaker Feature Store", true],
+            ["SageMaker Data Wrangler", false],
+            ["SageMaker Model Registry", false],
+            ["SageMaker Model Cards", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede social quer identificar linguagem ofensiva nos comentários, escritos em inglês, que os usuários publicam nas postagens. A empresa não pretende rotular dados nem treinar um modelo próprio. Qual abordagem ela deve adotar?",
+        explanation:
+            "A detecção de toxicidade do Amazon Comprehend é pré-treinada e classifica textos em categorias como insulto, discurso de ódio e ameaça, sem rotular dados nem treinar modelo. Rekognition modera imagens e vídeos, algoritmos do SageMaker exigem dados rotulados e o filtro do Transcribe atua sobre transcrições de áudio.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Usar a detecção de toxicidade do Amazon Comprehend", true],
+            ["Usar a moderação de conteúdo do Amazon Rekognition", false],
+            ["Treinar um classificador com algoritmos integrados do Amazon SageMaker AI", false],
+            ["Aplicar o filtro de vocabulário do Amazon Transcribe", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco precisa apresentar aos órgãos reguladores uma explicação clara de todos os fatores que influenciaram cada decisão de crédito. A equipe está escolhendo entre um modelo de gradient boosting e um large language model (LLM). Qual fator pesa mais a favor do modelo de ML tradicional?",
+        explanation:
+            "Modelos tradicionais como gradient boosting permitem relacionar cada previsão aos atributos de entrada que mais pesaram, o que atende reguladores que exigem justificar cada decisão. Vários idiomas, geração de conteúdo e interface de conversa são pontos fortes de foundation models, não motivos para escolher ML tradicional.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["A exigência de explicabilidade de cada decisão", true],
+            ["A necessidade de atender clientes em vários idiomas", false],
+            ["A capacidade de gerar textos e conteúdos novos", false],
+            ["A demanda por uma interface de conversa com o cliente", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup de saúde vai implantar uma ferramenta de apoio ao diagnóstico que precisa rodar em dispositivos com pouca memória e sem conexão com a internet. Qual fator pesa mais a favor de um modelo de ML tradicional em vez de um foundation model?",
+        explanation:
+            "Modelos de ML tradicionais costumam ser bem menores e rodam em dispositivos de borda com pouca memória, sem depender da nuvem, o que atende ao uso offline. Geração de imagens, chat multilíngue e resumo de textos livres são capacidades que favorecem foundation models, não restrições que levem ao ML tradicional.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["As limitações de memória e de conexão dos dispositivos", true],
+            ["A necessidade de gerar imagens novas em tempo real", false],
+            ["A exigência de um chat com suporte a vários idiomas", false],
+            ["A vontade de resumir textos livres de qualquer tamanho", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de logística processa milhares de pedidos de rota de entrega por dia e hoje usa um sistema baseado em regras escritas à mão. Qual benefício uma solução de IA/ML oferece que esse sistema de regras não alcança com facilidade?",
+        explanation:
+            "Sistemas de IA/ML aprendem padrões com os dados e podem ser retreinados quando esses padrões mudam, atendendo grandes volumes sem codificar uma regra para cada caso. Saída determinística é justamente característica dos sistemas de regras, nenhum sistema dispensa validação e ML não elimina custos de computação.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Escalar e se adaptar quando os padrões nos dados mudam", true],
+            ["Gerar a mesma saída determinística para cada entrada", false],
+            ["Garantir respostas sempre corretas sem nenhuma validação", false],
+            ["Eliminar todos os custos computacionais da operação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista quer personalizar as recomendações de produtos para milhões de clientes e hoje depende de uma equipe que monta as sugestões manualmente. Por que IA/ML é mais adequada que a abordagem manual para essa tarefa?",
+        explanation:
+            "IA/ML processa o histórico de milhões de clientes e identifica preferências sutis em uma escala impraticável para uma equipe manual. Ela precisa de dados para aprender, não garante 100% de acerto e exige infraestrutura de computação para treino e inferência.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Analisa muitos dados e acha padrões que pessoas dificilmente veem", true],
+            ["Dispensa qualquer dado histórico para começar a gerar as recomendações", false],
+            ["Garante 100% de acerto em todas as recomendações feitas aos clientes", false],
+            ["Elimina a necessidade de infraestrutura de computação para operar", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup quer usar um foundation model na sua aplicação, mas não tem dados nem recursos computacionais para treinar um do zero. Qual abordagem permite obter um foundation model sem fazer o pré-treinamento?",
+        explanation:
+            "Hubs de modelos oferecem foundation models de código aberto já pré-treinados, que podem ser usados direto ou ajustados, sem o volume de dados e de computação do pré-treino. Sistema de regras, árvore de decisão e rede neural pequena treinada do zero não entregam um foundation model.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Usar um modelo pré-treinado de código aberto de um hub de modelos", true],
+            ["Construir um sistema especialista baseado em regras escritas pela equipe", false],
+            ["Coletar mais dados rotulados e treinar uma árvore de decisão com eles", false],
+            ["Treinar uma rede neural pequena do zero com os dados da empresa", false],
+        ],
+    },
+    {
+        statement:
+            "Uma grande empresa está modernizando aplicações legadas, como sistemas de mainframe e aplicações .NET antigas, e quer um serviço da AWS que use agentes de IA para acelerar a transformação e a migração dessas cargas de trabalho. Qual serviço atende a esse requisito?",
+        explanation:
+            "O AWS Transform usa agentes de IA especializados para descobrir, planejar e executar a modernização e a migração de cargas como mainframe, VMware e .NET. O Database Migration Service migra bancos de dados, o Application Migration Service replica servidores sem modernizar o código e o Textract extrai texto de documentos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["AWS Transform", true],
+            ["AWS Database Migration Service", false],
+            ["AWS Application Migration Service", false],
+            ["Amazon Textract", false],
+        ],
+    },
+    {
+        statement:
+            "Em um workshop interno, uma equipe de produto precisa explicar o que diferencia a IA agêntica (agentic AI) de outras aplicações de IA. Qual descrição define melhor a IA agêntica?",
+        explanation:
+            "IA agêntica descreve sistemas que recebem um objetivo e, com autonomia, planejam as etapas, usam ferramentas e memória e executam ações até concluí-lo. Gerar imagens a partir de texto é típico de modelos de difusão, converter fala em texto é reconhecimento de fala e agrupar dados sem rótulo é clustering.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["IA que planeja, decide e executa ações sozinha para atingir um objetivo", true],
+            ["IA que gera imagens novas a partir de descrições escritas em texto", false],
+            ["IA que converte a fala gravada em texto escrito de forma automática", false],
+            ["IA que agrupa pontos de dados semelhantes em clusters sem usar nenhum rótulo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consultoria compara um sistema de IA agêntica com o sistema de IA tradicional que a empresa já usa para classificar chamados de suporte. Qual afirmação descreve corretamente a diferença entre os dois?",
+        explanation:
+            "Um sistema agêntico divide o objetivo em etapas, usa ferramentas e executa um fluxo de várias etapas com autonomia, enquanto a IA tradicional costuma processar cada solicitação e devolver uma resposta. Ser agêntico não implica precisar de mais dados, não limita o sistema a texto e não garante mais precisão.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "O agêntico executa sozinho tarefas de várias etapas, e o tradicional responde a um pedido por vez",
+                true,
+            ],
+            [
+                "O agêntico exige muito mais dados de treinamento, e o tradicional funciona bem com poucos exemplos",
+                false,
+            ],
+            [
+                "O agêntico processa apenas texto, e o tradicional consegue lidar com qualquer tipo de dado de entrada",
+                false,
+            ],
+            [
+                "O agêntico é sempre mais preciso, e o tradicional erra mais em qualquer tarefa que os dois executem",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de software quer usar IA para transformar uma ideia em requisitos, gerar o documento de design e implementar as funcionalidades a partir dessas especificações, em um fluxo de desenvolvimento orientado a especificações (spec-driven development). Qual ferramenta da AWS oferece esse fluxo?",
+        explanation:
+            "O Kiro é o ambiente de desenvolvimento agêntico da AWS criado para o desenvolvimento orientado a especificações: a partir da ideia, gera requisitos, design e lista de tarefas e implementa o código. Strands Agents é um SDK para construir agentes, AgentCore opera agentes em produção e CodePipeline automatiza a entrega contínua.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Kiro, ambiente de desenvolvimento agêntico com IDE e CLI", true],
+            ["Strands Agents, SDK de código aberto para construir agentes", false],
+            ["Amazon Bedrock AgentCore, serviço para implantar e operar agentes", false],
+            ["AWS CodePipeline, serviço de integração e entrega contínua", false],
+        ],
+    },
+    {
+        statement:
+            "Uma analista de negócios quer criar painéis interativos com insights gerados por IA e fazer perguntas sobre os dados em linguagem natural. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Quick, que evoluiu do QuickSight, reúne painéis de BI (o recurso Quick Sight) e IA generativa: a pessoa pergunta em linguagem natural e recebe visualizações e insights. Athena consulta dados no S3 com SQL, Redshift é o data warehouse e Glue integra e transforma dados (ETL).",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Quick", true],
+            ["Amazon Athena", false],
+            ["Amazon Redshift", false],
+            ["AWS Glue", false],
+        ],
+    },
+    {
+        statement:
+            "Uma central de atendimento quer criar um agente virtual por voz que entenda o que o cliente pede e encaminhe a ligação para o departamento certo. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Lex constrói interfaces de conversa por voz e texto, reconhece a intenção do cliente e permite encaminhar a ligação conforme o pedido. Polly converte texto em fala, mas não interpreta o que o cliente diz; Translate traduz textos e Comprehend extrai informações de textos sem conduzir diálogos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Polly", false],
+            ["Amazon Lex", true],
+            ["Amazon Translate", false],
+            ["Amazon Comprehend", false],
+        ],
+    },
+    {
+        statement:
+            "Um escritório de advocacia tem milhares de documentos jurídicos e quer que os funcionários encontrem jurisprudência e cláusulas contratuais relevantes fazendo perguntas em linguagem natural. Que tipo de aplicação de IA atende melhor a essa necessidade?",
+        explanation:
+            "Uma aplicação de base de conhecimento indexa grandes coleções de documentos e recupera o conteúdo relevante para perguntas feitas em linguagem natural, o que atende à busca jurídica. Detecção de fraude aponta transações suspeitas, previsão de séries temporais estima valores futuros e detecção de anomalias sinaliza padrões fora do comum.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Base de conhecimento", true],
+            ["Detecção de fraude", false],
+            ["Previsão de séries temporais", false],
+            ["Detecção de anomalias", false],
+        ],
+    },
+    {
+        statement:
+            "Em um treinamento para gestores, o instrutor pede a definição de large language model (LLM). Qual resposta está correta?",
+        explanation:
+            "Um LLM é um modelo de deep learning, geralmente baseado em transformers, treinado com enormes volumes de texto para entender contexto, gerar texto, responder perguntas e executar outras tarefas de linguagem. Banco de dados só armazena, tradutor de código converte sintaxe e transcrição de fala converte áudio em texto.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Um modelo de deep learning treinado com enormes volumes de texto para entender e gerar linguagem",
+                true,
+            ],
+            [
+                "Um banco de dados que guarda grandes volumes de texto e devolve os trechos buscados por palavra-chave",
+                false,
+            ],
+            [
+                "Uma ferramenta que traduz automaticamente o código entre diferentes linguagens de programação",
+                false,
+            ],
+            [
+                "Um sistema que converte a fala gravada em texto escrito para gerar legendas e transcrições",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma diretora pede que a equipe explique, em uma frase, o que é IA generativa antes de aprovar um projeto piloto. Qual afirmação descreve melhor a IA generativa?",
+        explanation:
+            "IA generativa aprende padrões dos dados de treino e cria conteúdo novo e parecido com eles, como texto, imagens, áudio, vídeo e código. Classificar em categorias predefinidas é tarefa de modelos de classificação, detectar anomalias é outra técnica de ML e recuperar informações existentes é busca, sem criar nada novo.",
+        topic: "IA generativa",
+        options: [
+            [
+                "IA que cria conteúdo novo, como texto e imagens, a partir de padrões aprendidos",
+                true,
+            ],
+            ["IA que classifica os dados em categorias definidas previamente pela equipe", false],
+            ["IA que detecta anomalias e desvios em grandes conjuntos de dados históricos", false],
+            [
+                "IA que recupera informações já existentes nos bancos de dados internos da empresa",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer um sistema de IA que pesquise concorrentes por conta própria, compile as descobertas em um relatório e envie o resumo por e-mail às partes interessadas, sem intervenção humana a cada etapa. Que tipo de aplicação de IA atende melhor a esse requisito?",
+        explanation:
+            "IA agêntica planeja e executa fluxos de várias etapas com autonomia, como pesquisar, compilar um relatório e enviar e-mails, usando ferramentas e sistemas diferentes. Reconhecimento de fala transcreve áudio, classificação de imagens rotula imagens e análise de sentimento avalia o tom de textos; nenhuma orquestra tarefas sozinha.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Reconhecimento de fala", false],
+            ["Classificação de imagens", false],
+            ["IA agêntica (agentic AI)", true],
+            ["Análise de sentimento", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe acostumada a criar manualmente os atributos de entrada de modelos de ML tradicionais vai testar deep learning em um projeto de visão computacional. Qual afirmação descreve melhor como o deep learning se diferencia do ML tradicional?",
+        explanation:
+            "Deep learning usa redes neurais profundas que descobrem sozinhas, a partir de dados brutos como pixels, as representações úteis que no ML tradicional costumam vir da engenharia de atributos manual. Ele se aplica a imagens, áudio e texto e, por ter muitos parâmetros, em geral precisa de mais dados, não de menos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Aprende as representações dos dados brutos sozinho, sem depender de engenharia de atributos manual",
+                true,
+            ],
+            [
+                "Exige atributos criados manualmente, enquanto o ML tradicional aprende sem essa etapa de preparação",
+                false,
+            ],
+            [
+                "É indicado principalmente para texto, enquanto o ML tradicional é o preferido para imagens e áudio",
+                false,
+            ],
+            [
+                "Costuma precisar de menos dados de treinamento que o ML tradicional para atingir o mesmo desempenho",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de varejo quer detectar automaticamente os rostos dos clientes nas gravações das câmeras de segurança para desfocá-los antes de arquivar os vídeos. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Rekognition é o serviço de visão computacional que detecta rostos em imagens e vídeos e retorna a posição de cada um, o que permite desfocá-los antes de arquivar. Textract extrai texto de documentos, Comprehend analisa textos e o Elemental MediaConvert converte formatos de vídeo sem identificar rostos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Textract", false],
+            ["Amazon Rekognition", true],
+            ["Amazon Comprehend", false],
+            ["AWS Elemental MediaConvert", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados está levantando as fontes que poderão alimentar um projeto de ML. Qual das fontes a seguir é um exemplo de dado não estruturado?",
+        explanation:
+            "E-mails escritos livremente não seguem um esquema fixo: variam em tamanho, estilo e formato e não cabem direto em linhas e colunas, por isso são dados não estruturados. Tabela de pedidos, planilha com campos nomeados e CSV com colunas fixas são dados estruturados, em que cada campo tem tipo e posição conhecidos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Uma coleção de e-mails de suporte escritos livremente pelos clientes", true],
+            ["Uma tabela de pedidos com colunas de data, quantidade e preço unitário", false],
+            ["Uma planilha com matrícula, nome, cargo e salário dos funcionários", false],
+            ["Um arquivo CSV com leituras de sensores indexadas por horário", false],
+        ],
+    },
+    {
+        statement:
+            "Em uma revisão de MLOps, a liderança pede que a equipe passe a gerenciar a dívida técnica dos seus sistemas de ML. A que essa prática se refere?",
+        explanation:
+            "Dívida técnica em MLOps é o custo acumulado de atalhos, pipelines sem documentação, dependências obsoletas e componentes acoplados, que tornam o sistema de ML difícil de manter; gerenciá-la é refatorar, documentar e modernizar. Cortar gastos de nuvem é otimização de custos, mais parâmetros é decisão de modelagem e excluir dados antigos é governança.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Tratar atalhos, dependências obsoletas e processos sem documentação que dificultam a manutenção",
+                true,
+            ],
+            [
+                "Reduzir o valor gasto com instâncias de computação na nuvem usadas no treinamento dos modelos de ML",
+                false,
+            ],
+            [
+                "Aumentar a quantidade de parâmetros dos modelos para melhorar a acurácia das previsões em produção",
+                false,
+            ],
+            [
+                "Excluir os conjuntos de dados antigos que não são mais usados por nenhum dos modelos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de ciência de dados executa dezenas de jobs de treinamento com configurações diferentes toda semana. Ela precisa comparar os resultados e reproduzir qualquer execução anterior. Qual prática de MLOps atende a essa necessidade?",
+        explanation:
+            "O rastreamento de experimentos registra parâmetros, métricas, versão do código e artefatos de cada execução, o que permite comparar resultados e reproduzir qualquer treino anterior. Implantação publica o modelo para inferência, rotulagem atribui respostas corretas aos exemplos e a entrega de atributos serve features ao modelo em produção.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Implantação de modelos", false],
+            ["Rastreamento de experimentos", true],
+            ["Rotulagem de dados", false],
+            ["Entrega de atributos para inferência", false],
+        ],
+    },
+    {
+        statement:
+            "Durante o desenvolvimento de um modelo, a equipe reserva tempo para o ajuste de hiperparâmetros antes de fechar a versão final. Qual é o objetivo dessa etapa no ciclo de vida de ML?",
+        explanation:
+            "O ajuste de hiperparâmetros busca a melhor combinação de configurações definidas antes do treino, como taxa de aprendizado, tamanho do lote e número de camadas, para maximizar a métrica-alvo. Coletar e limpar dados é preparação, publicar em endpoint é implantação e acompanhar drift é monitoramento, etapas separadas do ciclo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Encontrar as configurações do modelo que produzem o melhor desempenho", true],
+            ["Coletar e limpar os dados brutos usados no treinamento do modelo", false],
+            ["Implantar o modelo treinado em um endpoint de produção para inferência", false],
+            ["Monitorar o modelo em busca de desvios nos dados após a implantação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe treinou um modelo para prever o cancelamento de clientes. O modelo acerta muito nos dados de treinamento, mas erra bastante com clientes novos, que ele nunca viu. Qual mudança resolve esse problema?",
+        explanation:
+            "Acertar no treino e errar com clientes novos é overfitting: o modelo decorou os dados em vez de generalizar. Aumentar a regularização penaliza pesos grandes e simplifica o modelo. Reduzir a regularização e acrescentar atributos elevam a complexidade, e treinar por mais épocas ajusta o modelo ainda mais ao treino.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aumentar a força da regularização para que o modelo fique menos complexo", true],
+            [
+                "Reduzir a força da regularização para que o modelo capture padrões mais complexos",
+                false,
+            ],
+            [
+                "Acrescentar novos atributos ao conjunto de dados usado como entrada do modelo",
+                false,
+            ],
+            ["Continuar o treinamento do modelo por mais épocas com os mesmos dados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista criou um modelo para prever o preço de produtos. Ele teve resultados excelentes no conjunto de treinamento, mas foi mal no conjunto de teste e continua mal em produção desde o primeiro dia. O que a empresa deve fazer para resolver esse problema?",
+        explanation:
+            "Ir muito bem no treino e mal no teste e em produção desde o início é o sinal clássico de overfitting: o modelo decorou os exemplos. Treinar com mais dados e mais variados ajuda a generalizar. Menos dados piora o problema, treinar por mais tempo ajusta ainda mais o modelo ao treino e mais hiperparâmetros só aumentam a complexidade.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Treinar o modelo com um volume maior e mais variado de dados", true],
+            ["Treinar o modelo com um volume menor e mais filtrado de dados", false],
+            ["Treinar o modelo por mais tempo com o mesmo conjunto de dados", false],
+            ["Acrescentar mais hiperparâmetros à configuração atual do modelo", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep-d2.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep-d2.ts
@@ -1,0 +1,1118 @@
+// Questões do simulado AWS Certified AI Practitioner (AIF-C01), domínio 2 da prova
+// (Fundamentals of Generative AI), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aif-c01-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D2: Questao[] = [
+    {
+        statement:
+            "Uma fabricante de eletrodomésticos inteligentes quer que os aparelhos executem a inferência do modelo de linguagem no próprio dispositivo, com a menor latência possível. Qual solução atende a esse requisito?",
+        explanation:
+            "Rodar um SLM otimizado no próprio aparelho elimina a ida e volta pela rede, e o modelo pequeno cabe no hardware limitado da borda, o que garante a menor latência. Um LLM excede a memória e o processamento típicos desses dispositivos, e chamar uma API central, seja de SLM ou de LLM, acrescenta a latência da rede.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Implantar small language models (SLMs) otimizados nos próprios dispositivos de borda",
+                true,
+            ],
+            [
+                "Implantar large language models (LLMs) otimizados nos próprios dispositivos de borda",
+                false,
+            ],
+            [
+                "Chamar de forma assíncrona uma API central de SLM a partir dos dispositivos de borda",
+                false,
+            ],
+            [
+                "Chamar de forma assíncrona uma API central de LLM a partir dos dispositivos de borda",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "A equipe de engenharia de uma fintech planeja adotar o Kiro para entregar funcionalidades mais rápido. O que o Kiro pode fazer para ajudar a equipe?",
+        explanation:
+            "O Kiro é um ambiente de desenvolvimento com IA que gera código a partir de conversas e especificações e, com o rastreador de referências ativado, registra quando a sugestão se parece com código público. Rodar sem gerenciar servidores é o AWS Lambda, áudio para texto é o Amazon Transcribe e analisar imagens é o Amazon Rekognition.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Gerar código a partir de prompts e especificações e rastrear referências a código público",
+                true,
+            ],
+            [
+                "Executar a aplicação sem provisionar nem gerenciar servidores, cobrando apenas por execução",
+                false,
+            ],
+            [
+                "Converter arquivos de áudio em documentos de texto com modelos de reconhecimento de fala",
+                false,
+            ],
+            [
+                "Identificar objetos e rostos em imagens e vídeos com modelos de visão computacional",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma loja virtual está criando uma busca visual em que o cliente pode consultar tanto com uma frase digitada quanto com a foto de um produto. Que tipo de foundation model (FM) deve sustentar essa busca?",
+        explanation:
+            "Um modelo de embeddings multimodal coloca texto e imagem no mesmo espaço vetorial, então uma frase ou uma foto podem ser comparadas com o catálogo por similaridade. O de texto não lê imagens, e os modelos de geração criam conteúdo novo em vez de produzir os vetores de que a busca precisa.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Um modelo de embeddings multimodal, que representa texto e imagem no mesmo espaço vetorial",
+                true,
+            ],
+            [
+                "Um modelo de embeddings de texto, que representa frases e descrições de produtos como vetores",
+                false,
+            ],
+            [
+                "Um modelo de geração de imagens, que cria imagens novas de produtos a partir de uma descrição",
+                false,
+            ],
+            [
+                "Um modelo de geração multimodal, que recebe texto e imagem e produz conteúdo novo nos dois formatos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "A equipe de marketing de uma rede de artigos esportivos está mapeando onde aplicar IA generativa. Qual destas tarefas é um caso de uso de IA generativa?",
+        explanation:
+            "IA generativa cria conteúdo novo, e gerar imagens fotorrealistas a partir de texto é um caso clássico. Detectar intrusões é classificação de segurança, prever vendas é análise preditiva e criar índices é ajuste de desempenho do banco; nenhuma dessas tarefas gera conteúdo.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Gerar imagens fotorrealistas de produtos a partir de descrições em texto para uma campanha",
+                true,
+            ],
+            [
+                "Detectar intrusões na rede corporativa com um sistema que classifica o tráfego suspeito",
+                false,
+            ],
+            [
+                "Prever a tendência de vendas do próximo trimestre a partir do histórico de pedidos da rede",
+                false,
+            ],
+            [
+                "Acelerar as consultas ao banco de dados de clientes com a criação de índices otimizados",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Ao escolher um foundation model (FM) no Amazon Bedrock, uma equipe de pesquisa precisa saber quanto texto consegue enviar em um único prompt. Qual propriedade do modelo informa isso?",
+        explanation:
+            "A janela de contexto define quantos tokens o modelo consegue considerar de uma vez e, por isso, limita quanto texto cabe em uma chamada. Temperatura regula a aleatoriedade da saída, o tamanho do modelo se refere à quantidade de parâmetros e o tamanho do lote trata de quantas entradas são processadas juntas.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Janela de contexto, o limite de tokens que o modelo processa em uma única chamada",
+                true,
+            ],
+            [
+                "Temperatura, o parâmetro que controla a aleatoriedade do texto que o modelo gera",
+                false,
+            ],
+            [
+                "Tamanho do modelo, a quantidade de parâmetros que o modelo aprendeu no treinamento",
+                false,
+            ],
+            [
+                "Tamanho do lote (batch size), o número de entradas processadas juntas em cada etapa",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de ciência de dados quer escolher um foundation model (FM) pré-treinado em um catálogo e colocá-lo em uso rapidamente dentro da própria VPC. Qual serviço ou recurso da AWS permite isso?",
+        explanation:
+            "O SageMaker JumpStart oferece um catálogo de FMs pré-treinados que a equipe implanta em poucos cliques, em endpoints dentro da própria VPC. O Personalize treina modelos de recomendação, o PartyRock é um playground público sem implantação em VPC e o Model Registry versiona modelos que a equipe já treinou, sem oferecer FMs prontos.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Amazon SageMaker JumpStart, com FMs pré-treinados já prontos para implantar em poucos cliques",
+                true,
+            ],
+            [
+                "Amazon Personalize, com modelos de recomendação treinados a partir das interações dos usuários",
+                false,
+            ],
+            [
+                "PartyRock, um playground público do Amazon Bedrock para criar apps de IA generativa sem código",
+                false,
+            ],
+            [
+                "Amazon SageMaker Model Registry, com o catálogo das versões de modelos que a equipe já treinou",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista guarda grandes volumes de dados de vendas em um banco de dados e quer um aplicativo em que funcionários sem conhecimento técnico digitem uma pergunta em linguagem natural e recebam a consulta SQL gerada automaticamente. Que tipo de modelo é o mais indicado para esse aplicativo?",
+        explanation:
+            "Um GPT é um LLM treinado para gerar texto, o que inclui traduzir um pedido em linguagem natural para uma consulta SQL estruturada. A ResNet é voltada à visão computacional, a SVM classifica ou faz regressão sem gerar texto e a WaveNet gera áudio, uma modalidade diferente da necessária.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Generative pre-trained transformer (GPT), um modelo de linguagem que gera textos e código",
+                true,
+            ],
+            [
+                "Rede neural residual (ResNet), uma arquitetura profunda voltada ao reconhecimento de imagens",
+                false,
+            ],
+            [
+                "Máquina de vetores de suporte (SVM), um algoritmo supervisionado de classificação e regressão",
+                false,
+            ],
+            [
+                "WaveNet, um modelo generativo que sintetiza áudio e fala com som natural a partir de exemplos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa resume contratos com um modelo base do Amazon Bedrock e, para melhorar a qualidade, criou um modelo customizado a partir dele. Qual ação permite usar o modelo customizado para inferência no próprio Amazon Bedrock?",
+        explanation:
+            "No Bedrock, um modelo customizado é servido com Provisioned Throughput, que reserva capacidade dedicada, ou, em modelos compatíveis, com uma implantação sob demanda. Endpoint e Model Registry são fluxos do SageMaker AI, e o acesso a modelos, hoje habilitado por padrão, vale para os modelos base.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Comprar Provisioned Throughput para o modelo customizado, com capacidade dedicada no Bedrock",
+                true,
+            ],
+            [
+                "Implantar o modelo customizado em um endpoint do Amazon SageMaker AI para inferência em tempo real",
+                false,
+            ],
+            [
+                "Registrar o modelo customizado no Amazon SageMaker Model Registry com o status de aprovado",
+                false,
+            ],
+            [
+                "Solicitar acesso ao modelo customizado na página de acesso a modelos do console do Bedrock",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando uma aplicação que precisa gerar dados sintéticos parecidos com os dados que ela já possui. Que tipo de modelo a empresa pode usar para atender a esse requisito?",
+        explanation:
+            "Uma GAN treina duas redes em competição: o gerador cria amostras e o discriminador tenta separá-las das reais, até o gerador produzir dados sintéticos convincentes. O XGBoost prevê rótulos e valores, a ResNet classifica imagens e a WaveNet, embora generativa, é especializada em áudio.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Rede adversária generativa (GAN), que aprende a gerar amostras parecidas com os dados reais",
+                true,
+            ],
+            [
+                "XGBoost, um algoritmo de gradient boosting para classificação e regressão supervisionadas",
+                false,
+            ],
+            [
+                "WaveNet, um modelo generativo especializado em sintetizar áudio e fala a partir de exemplos",
+                false,
+            ],
+            [
+                "Rede neural residual (ResNet), uma arquitetura convolucional voltada a classificar imagens",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Durante um treinamento interno sobre IA generativa, a equipe pergunta como se chamam as representações numéricas de palavras, objetos e conceitos que ajudam os modelos a entender o significado do texto. Qual é o termo correto?",
+        explanation:
+            "Embeddings são vetores numéricos que representam palavras, objetos e conceitos, colocando itens de significado parecido perto uns dos outros no espaço vetorial. Tokens são os pedaços em que o texto é dividido, parâmetros são os pesos aprendidos no treino e o modelo é o sistema que faz as previsões.",
+        topic: "IA generativa",
+        options: [
+            ["Embeddings, vetores que aproximam os conceitos de significado parecido", true],
+            [
+                "Tokens, as unidades de texto em que a entrada é dividida antes do processamento",
+                false,
+            ],
+            ["Parâmetros, os pesos internos que o modelo ajusta durante o treinamento", false],
+            [
+                "Modelos, os sistemas treinados que recebem as entradas e produzem as previsões",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um analista de uma varejista quer gerar automaticamente gráficos com as vendas dos produtos líderes de cada loja no último ano, descrevendo o que precisa em linguagem natural. Qual solução da AWS atende a essa necessidade?",
+        explanation:
+            "O Amazon Quick Sight, recurso do Amazon Quick que sucedeu o Amazon Q in QuickSight, gera visuais a partir de perguntas em linguagem natural, como as vendas dos produtos líderes por loja. O Athena executa SQL e devolve tabelas, o Personalize recomenda produtos e o Comprehend analisa textos; nenhum deles monta gráficos.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Amazon Quick Sight, que cria visuais e dashboards a partir de pedidos em linguagem natural",
+                true,
+            ],
+            [
+                "Amazon Athena, que executa consultas SQL interativas sobre os dados de vendas no Amazon S3",
+                false,
+            ],
+            [
+                "Amazon Personalize, que gera recomendações de produtos a partir do histórico de interações",
+                false,
+            ],
+            [
+                "Amazon Comprehend, que extrai entidades, frases-chave e sentimento de textos dos clientes",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma agência de viagens recebe um grande volume de pedidos de reserva todos os dias e planeja usar agentes de IA criados com o Amazon Bedrock AgentCore para dar conta da demanda. Qual é um benefício central desses agentes?",
+        explanation:
+            "Agentes criados no AgentCore interpretam o pedido, dividem o trabalho em etapas e chamam APIs e sistemas para concluí-lo, automatizando tarefas repetitivas em grande volume. Agentes não treinam FMs, escolher modelo por métricas é tarefa de avaliação de modelos e reservar capacidade é papel do Provisioned Throughput.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Automatizar tarefas repetitivas e orquestrar fluxos de várias etapas com APIs e sistemas",
+                true,
+            ],
+            [
+                "Treinar foundation models customizados que preveem as necessidades futuras de cada cliente",
+                false,
+            ],
+            [
+                "Escolher o foundation model mais adequado com base em critérios e métricas predefinidos",
+                false,
+            ],
+            [
+                "Reservar capacidade dedicada de inferência para reduzir o custo por token das chamadas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa customizou um foundation model (FM) no Amazon Bedrock e agora precisa enviar um conjunto de dados de validação para que o Bedrock avalie as respostas do modelo. Em qual serviço da AWS esse conjunto de dados deve ficar?",
+        explanation:
+            "O Amazon Bedrock lê os conjuntos de treino e de validação da customização a partir de buckets do Amazon S3, então é lá que o arquivo deve ficar. O EBS oferece volumes de bloco para instâncias do EC2, e o EFS e o FSx for Lustre são sistemas de arquivos montados em servidores, que o Bedrock não usa como origem.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Amazon S3, um armazenamento de objetos escalável para arquivos e conjuntos de dados",
+                true,
+            ],
+            [
+                "Amazon Elastic Block Store (Amazon EBS), com volumes de bloco anexados a instâncias",
+                false,
+            ],
+            [
+                "Amazon Elastic File System (Amazon EFS), um sistema de arquivos compartilhado",
+                false,
+            ],
+            [
+                "Amazon FSx for Lustre, um sistema de arquivos de alto desempenho para cargas de ML",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de farmácias quer um resumo curto de cada novo medicamento com base nas avaliações escritas pelos clientes. Qual solução atende a esse requisito?",
+        explanation:
+            "LLMs do Amazon Bedrock são adequados para sumarização e condensam várias avaliações em um texto curto sobre cada medicamento. Previsão de séries temporais estima valores futuros, a classificação do Comprehend só separa itens em categorias e o Rekognition analisa imagens e vídeos, não textos.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Gerar resumos das avaliações de cada medicamento com LLMs do Amazon Bedrock", true],
+            [
+                "Criar um modelo de previsão de séries temporais no Amazon Personalize para analisar as avaliações",
+                false,
+            ],
+            [
+                "Criar um modelo de classificação no Amazon Comprehend que separa os medicamentos em grupos",
+                false,
+            ],
+            ["Gerar resumos das avaliações de cada medicamento com o Amazon Rekognition", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de assinaturas de produtos usa um chatbot de atendimento com IA generativa e quer acompanhar uma métrica que expresse em dinheiro o efeito do chatbot na operação diária. Qual métrica a empresa deve acompanhar?",
+        explanation:
+            "O custo por conversa traduz em dinheiro quanto a operação gasta com cada atendimento do chatbot e permite comparar com alternativas, como atendentes humanos. O volume de solicitações mede quantidade, o AHT mede agilidade e o custo de treinamento é um gasto de construção, não da operação diária.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Custo por conversa com cliente, somando o que cada atendimento do chatbot consome",
+                true,
+            ],
+            [
+                "Número de solicitações atendidas, contando quantas conversas o chatbot concluiu no mês",
+                false,
+            ],
+            [
+                "Tempo médio de atendimento (AHT), medindo quanto dura cada conversa até a resolução",
+                false,
+            ],
+            [
+                "Custo de treinamento dos modelos de IA usados pelo chatbot antes do lançamento",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "O chatbot de atendimento de uma seguradora, construído no Amazon Bedrock, precisa de várias trocas de mensagens para resolver um sinistro. Como o LLM pode usar o conteúdo das mensagens anteriores do cliente?",
+        explanation:
+            "LLMs não guardam memória entre chamadas, então a aplicação envia o histórico da conversa no prompt e o modelo mantém o contexto entre as trocas. O registro de invocações só grava as requisições para auditoria, o Personalize é um serviço de recomendação e o Provisioned Throughput define capacidade, não contexto.",
+        topic: "Prompt engineering",
+        options: [
+            ["Incluir as mensagens anteriores da conversa no prompt de cada nova chamada", true],
+            ["Ativar o registro de invocações do modelo para coletar as mensagens trocadas", false],
+            [
+                "Guardar o histórico da conversa no Amazon Personalize para o modelo consultar",
+                false,
+            ],
+            [
+                "Comprar Provisioned Throughput para o LLM manter o contexto entre as chamadas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "A central de atendimento de uma varejista passa manualmente aos clientes dicas de produtos de acordo com a localização de cada um e quer automatizar isso com foundation models (FMs). Qual serviço da AWS atende a essa necessidade?",
+        explanation:
+            "O Amazon Bedrock oferece foundation models gerenciados que geram dicas e descrições de produtos adaptadas à localização do cliente, sem infraestrutura para administrar. O Macie protege dados sensíveis, o Textract extrai texto de documentos e o Transcribe converte fala em texto; nenhum deles oferece FMs.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Amazon Bedrock, que dá acesso a FMs para gerar descrições e recomendações de produtos",
+                true,
+            ],
+            [
+                "Amazon Macie, que descobre e protege dados sensíveis armazenados no Amazon S3",
+                false,
+            ],
+            [
+                "Amazon Textract, que extrai texto, formulários e tabelas de documentos digitalizados",
+                false,
+            ],
+            [
+                "Amazon Transcribe, que converte em texto o áudio das ligações da central de atendimento",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma gestora de investimentos já usa machine learning em várias áreas e quer identificar qual iniciativa é de IA generativa. Qual destas tarefas é um caso de uso de IA generativa?",
+        explanation:
+            "Resumir reclamações gera um texto novo e condensado a partir de entradas longas, tarefa típica de IA generativa feita por LLMs. Classificar clientes e prever receita são tarefas preditivas, e segmentar por tipo de investimento é clustering; todas são de ML tradicional e não criam conteúdo.",
+        topic: "IA generativa",
+        options: [
+            ["Resumir as reclamações dos clientes em textos curtos com os pontos principais", true],
+            ["Classificar os clientes de acordo com os produtos que eles mais utilizam", false],
+            [
+                "Prever a receita dos próximos meses para determinados produtos de investimento",
+                false,
+            ],
+            ["Segmentar os clientes em grupos conforme o tipo de investimento que preferem", false],
+        ],
+    },
+    {
+        statement:
+            "Em uma aula sobre a arquitetura dos LLMs atuais, a instrutora pede à turma a característica que define os modelos de linguagem baseados em transformer. Qual afirmação descreve essa característica?",
+        explanation:
+            "O transformer usa autoatenção, que pondera a relevância de cada token em relação aos demais e captura o contexto da sequência inteira em paralelo. Filtros convolucionais caracterizam as CNNs, o processamento em ciclos com estado oculto é típico das RNNs e transformers também trabalham com imagem e áudio.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Usam mecanismos de autoatenção para capturar as relações de contexto entre todos os tokens",
+                true,
+            ],
+            [
+                "Usam camadas convolucionais que aplicam filtros sobre a entrada para captar padrões locais",
+                false,
+            ],
+            [
+                "Processam a sequência um elemento por vez, em ciclos repetidos que carregam um estado oculto",
+                false,
+            ],
+            [
+                "Processam apenas dados de texto, sem conseguir lidar com imagens, áudio ou outras modalidades",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma redação está testando um assistente de escrita com IA generativa. O tráfego do piloto é baixo, o desempenho não é prioridade, o uso futuro é imprevisível e a meta é o menor custo. Qual solução atende a esses requisitos?",
+        explanation:
+            "No Bedrock sob demanda, a cobrança acompanha as chamadas feitas, sem capacidade reservada, o que mantém o custo baixo no piloto e se ajusta à demanda incerta. Instâncias EC2 com GPU e endpoints do JumpStart geram custo mesmo ociosos, e o Provisioned Throughput cobra por capacidade que o uso baixo desperdiçaria.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Usar o Amazon Bedrock com precificação sob demanda, pagando só pelas chamadas feitas",
+                true,
+            ],
+            [
+                "Usar instâncias do Amazon EC2 com GPU para hospedar o modelo de linguagem da redação",
+                false,
+            ],
+            [
+                "Usar o Amazon Bedrock com Provisioned Throughput, reservando capacidade para o piloto",
+                false,
+            ],
+            [
+                "Usar o Amazon SageMaker JumpStart para implantar o modelo em um endpoint dedicado",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa fez fine-tuning de um LLM no Amazon Bedrock e vai colocá-lo em produção com volume de requisições alto, constante e previsível o dia todo, aceitando um compromisso de seis meses. Qual opção é a MAIS econômica?",
+        explanation:
+            "Para carga alta, constante e previsível, o Provisioned Throughput com compromisso reduz o preço por hora da capacidade dedicada e sai mais barato que pagar por uso. A inferência sob demanda compensa em tráfego variável, e EC2 e Lambda não são a forma de o Bedrock servir modelos customizados, além de exigirem administrar a infraestrutura.",
+        topic: "RAG e customização",
+        options: [
+            ["Comprar Provisioned Throughput para o modelo customizado no Amazon Bedrock", true],
+            ["Usar o modelo customizado com inferência sob demanda no Amazon Bedrock", false],
+            ["Implantar o modelo em uma instância do Amazon EC2 otimizada para computação", false],
+            ["Guardar o modelo no Amazon S3 e servi-lo com funções do AWS Lambda", false],
+        ],
+    },
+    {
+        statement:
+            "Uma clínica médica quer uma ferramenta de IA generativa com reconhecimento de fala que ajude os médicos a registrar as consultas e criar notas clínicas. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O AWS HealthScribe combina reconhecimento de fala e IA generativa para transcrever conversas entre médico e paciente e gerar notas clínicas preliminares. O Polly faz o caminho inverso, de texto para fala, o Rekognition analisa imagens e o Lex cria bots de conversa, sem produzir documentação clínica.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "AWS HealthScribe, que transcreve a consulta e gera notas clínicas preliminares",
+                true,
+            ],
+            [
+                "Amazon Polly, que converte texto em fala com vozes naturais em vários idiomas",
+                false,
+            ],
+            [
+                "Amazon Rekognition, que analisa imagens e vídeos para identificar objetos e rostos",
+                false,
+            ],
+            ["Amazon Lex, que cria interfaces de conversa por voz e texto para atendimento", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor está aprendendo como os LLMs representam o texto internamente. O que os embeddings vetoriais tornam possível?",
+        explanation:
+            "Embeddings transformam texto em vetores que capturam significado, então dois textos podem ser comparados matematicamente pela distância ou pela similaridade entre eles, base de busca e agrupamento. Dividir textos em partes é chunking, agrupar caracteres em unidades é tokenização e contar palavras é apenas contagem de frequência.",
+        topic: "IA generativa",
+        options: [
+            ["Comparar textos matematicamente, medindo a distância entre os vetores", true],
+            ["Dividir textos longos em partes menores e mais fáceis de processar", false],
+            ["Agrupar um conjunto de caracteres para ser tratado como uma única unidade", false],
+            ["Contar quantas vezes cada palavra aparece no texto de entrada", false],
+        ],
+    },
+    {
+        statement:
+            "Ao revisar a documentação de um projeto de busca semântica, uma analista encontra várias definições para embeddings. Qual afirmação descreve corretamente os embeddings em IA generativa?",
+        explanation:
+            "Embeddings mapeiam palavras ou documentos para vetores de muitas dimensões, em que significados parecidos ficam próximos, o que permite ao modelo trabalhar com semelhança. Pesquisar dados para responder é a etapa de recuperação do RAG, usar tipos menos precisos é quantização e armazenar dados é papel do banco de dados vetorial.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Representam dados como vetores de muitas dimensões que capturam relações de significado",
+                true,
+            ],
+            [
+                "Pesquisam os dados para encontrar a informação mais útil para responder a uma pergunta",
+                false,
+            ],
+            [
+                "Reduzem a exigência de hardware usando um tipo de dado menos preciso para os pesos do modelo",
+                false,
+            ],
+            [
+                "Armazenam e recuperam os dados usados pelas aplicações de IA generativa em produção",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa escolher um modelo de IA generativa para um aplicativo que deve responder aos usuários em tempo real. Qual característica do modelo é a mais importante nesse caso?",
+        explanation:
+            "A velocidade de inferência define quanto o modelo demora para gerar a resposta, o fator decisivo quando o usuário espera retorno em tempo real. A complexidade influencia capacidade e custo, o tempo de treinamento é uma etapa de construção e o ritmo de inovação trata da evolução da família de modelos, não da latência.",
+        topic: "IA generativa",
+        options: [
+            ["Velocidade de inferência, o tempo que o modelo leva para gerar cada resposta", true],
+            ["Complexidade do modelo, a quantidade de camadas e parâmetros da arquitetura", false],
+            ["Tempo de treinamento, o período necessário para treinar o modelo do zero", false],
+            [
+                "Ritmo de inovação, a frequência com que a família do modelo ganha versões novas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de suporte está aprendendo a usar um foundation model (FM) e quer saber como se chamam as instruções que ela escreve para orientar o modelo a dar uma resposta mais precisa. Qual é esse termo?",
+        explanation:
+            "Prompt é a entrada que traz a instrução, o contexto e os exemplos que orientam o que o modelo deve fazer, e um prompt bem escrito aumenta a precisão da resposta. Direção e diálogo não são os nomes técnicos dessa entrada, e tradução é um tipo de tarefa, não a instrução em si.",
+        topic: "Prompt engineering",
+        options: [
+            ["Prompt, a entrada com as instruções e o contexto enviados ao modelo", true],
+            ["Direção, a configuração que define o rumo que o modelo deve seguir", false],
+            ["Diálogo, o registro das conversas anteriores guardado pelo modelo", false],
+            ["Tradução, a conversão das instruções para a linguagem interna do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma produtora de conteúdo em vídeo quer usar IA generativa para criar clipes novos e reduzir o tempo de produção, com o mínimo de etapas manuais. Qual abordagem atende a esses requisitos com a MAIOR eficiência operacional?",
+        explanation:
+            "Um modelo de geração de vídeo produz os clipes direto do prompt, sem etapas intermediárias, o que dá a maior eficiência operacional. Gerar imagens ou quadros e montar o vídeo em um editor acrescenta trabalho manual, e um LLM multimodal de uso geral entende imagens e documentos, mas responde em texto, sem gerar vídeo.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Usar um modelo de geração de vídeo que cria os clipes direto a partir de um prompt de texto",
+                true,
+            ],
+            [
+                "Gerar imagens intermediárias com um modelo de texto para imagem e montar os vídeos em um editor",
+                false,
+            ],
+            [
+                "Criar quadros com um modelo de edição de imagem e animá-los manualmente em um software de vídeo",
+                false,
+            ],
+            [
+                "Pedir os clipes a um LLM multimodal de uso geral, como os que analisam imagens e documentos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma loja online usa um assistente de IA generativa no Amazon Bedrock para recomendar produtos e quer medir o impacto direto dele nas vendas. Qual métrica atende a esse requisito?",
+        explanation:
+            "A taxa de conversão mostra quantos clientes compram depois de usar o assistente e liga o uso diretamente ao resultado de vendas. O número de interações mede uso, a pontuação de sentimento mede satisfação e a acurácia do entendimento mede qualidade técnica; nenhuma delas mede vendas.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Taxa de conversão dos clientes que compram depois de interagir com o assistente",
+                true,
+            ],
+            [
+                "Número de interações que os clientes fazem com o assistente de IA ao longo do mês",
+                false,
+            ],
+            [
+                "Pontuação de sentimento das avaliações que os clientes deixam após cada interação",
+                false,
+            ],
+            [
+                "Acurácia do entendimento de linguagem natural nas perguntas feitas ao assistente",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer oferecer aos funcionários um assistente de IA para o trabalho que responda perguntas com base em documentos, e-mails e aplicativos internos, sem desenvolver uma aplicação própria. Qual serviço da AWS atende a esse objetivo?",
+        explanation:
+            "O Amazon Quick é o assistente de IA para o trabalho da AWS: conecta documentos, e-mails e aplicativos da empresa e fundamenta as respostas nesses dados, sem exigir desenvolvimento. SageMaker AI serve para treinar modelos próprios, Comprehend analisa textos e Transcribe converte fala em texto, e nenhum deles é um assistente pronto.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Amazon Quick, assistente de IA que responde com base nos dados conectados da empresa",
+                true,
+            ],
+            [
+                "Amazon SageMaker AI, plataforma para treinar e implantar modelos de ML próprios",
+                false,
+            ],
+            [
+                "Amazon Comprehend, que extrai entidades, frases-chave e sentimentos de textos internos",
+                false,
+            ],
+            [
+                "Amazon Transcribe, que converte em texto o áudio de reuniões e de chamadas da equipe",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer analisar fotos e vídeos curtos enviados por clientes de vários países e responder em texto no idioma de cada um. Entre os modelos Amazon Nova no Amazon Bedrock, qual atende a esses requisitos com o MENOR custo?",
+        explanation:
+            "O Amazon Nova Lite é o modelo multimodal de baixo custo da família: entende texto, imagem e vídeo e responde em texto em mais de 200 idiomas. O Nova Pro também é multimodal, mas custa mais; o Nova Micro aceita só texto; e o Nova Multimodal Embeddings gera vetores para busca, não respostas em texto.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Amazon Nova Lite", true],
+            ["Amazon Nova Pro", false],
+            ["Amazon Nova Micro", false],
+            ["Amazon Nova Multimodal Embeddings", false],
+        ],
+    },
+    {
+        statement:
+            "Uma edtech desenvolve um aplicativo de leitura em que cada aluno desenha um esboço simples e descreve a cena em uma frase. O aplicativo precisa transformar esse esboço e essa frase em uma ilustração para a história. Qual solução atende a esse requisito?",
+        explanation:
+            "O Stable Image Control Sketch, da Stability AI no Amazon Bedrock, gera imagens guiadas por um esboço e por um prompt de texto, o que produz a ilustração da história. O Polly converte texto em fala, o Rekognition apenas analisa imagens existentes e o Translate traduz textos, e nenhum deles cria ilustrações.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Usar o Stable Image Control Sketch no Amazon Bedrock para gerar a ilustração do esboço",
+                true,
+            ],
+            [
+                "Usar o Amazon Polly para transformar o texto de cada história em um audiolivro narrado",
+                false,
+            ],
+            [
+                "Usar o Amazon Rekognition para detectar e rotular os objetos desenhados em cada esboço",
+                false,
+            ],
+            [
+                "Usar o Amazon Translate para traduzir cada história e publicá-la em outros idiomas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor quer gerar rapidamente casos de teste e documentação para o código de um projeto, com o MENOR esforço. Qual solução atende a esse requisito?",
+        explanation:
+            "O Kiro é o ambiente de desenvolvimento agêntico da AWS: gera testes e documentação direto no projeto, inclusive com hooks que criam esses arquivos automaticamente. Colar o código em um chat na web exige cópia manual e expõe o código, criar uma aplicação própria no Bedrock dá muito mais trabalho e escrever tudo à mão é o maior esforço.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Usar o Kiro, ambiente de desenvolvimento agêntico da AWS, para criar testes e documentos",
+                true,
+            ],
+            [
+                "Colar o código em um assistente de chat genérico na web e copiar de volta cada resposta",
+                false,
+            ],
+            [
+                "Criar uma aplicação própria que chama foundation models no Amazon Bedrock para gerar tudo",
+                false,
+            ],
+            [
+                "Pesquisar exemplos, escrever os casos de teste à mão e depois redigir toda a documentação",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um e-commerce precisa gerar milhares de descrições de produto originais por dia, com estilo e tom consistentes. Que tipo de modelo generativo atende a esses requisitos?",
+        explanation:
+            "Modelos baseados em transformer, como os LLMs, geram texto fluente e coerente e mantêm o estilo e o tom pedidos no prompt, em grande escala. Modelos de difusão, GANs e VAEs são usados principalmente para gerar imagens e outros dados, e não parágrafos de texto com tom consistente.",
+        topic: "IA generativa",
+        options: [
+            ["Um modelo transformer, que usa autoatenção sobre os tokens da sequência", true],
+            ["Um modelo de difusão, que remove ruído aos poucos até formar a saída", false],
+            ["Uma GAN, em que um gerador e um discriminador competem entre si", false],
+            ["Um VAE, que codifica os dados em um espaço latente e decodifica amostras", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer criar uma aplicação de IA generativa usando foundation models de vários provedores por meio de uma API, sem gerenciar servidores nem treinar modelos do zero. Qual serviço da AWS foi criado para esse fim?",
+        explanation:
+            "O Amazon Bedrock é o serviço totalmente gerenciado para criar aplicações de IA generativa: dá acesso por API a foundation models de vários provedores, com recursos como Knowledge Bases e Guardrails. O EC2 exige gerenciar a infraestrutura, o Comprehend analisa textos sem gerar conteúdo e o S3 apenas armazena dados.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Amazon Bedrock, com acesso gerenciado a foundation models de vários provedores",
+                true,
+            ],
+            [
+                "Amazon EC2, com instâncias de GPU para hospedar e treinar modelos por conta própria",
+                false,
+            ],
+            [
+                "Amazon Comprehend, com modelos prontos para análise de sentimento e de entidades",
+                false,
+            ],
+            [
+                "Amazon S3, com armazenamento durável para os conjuntos de dados de treinamento",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Em um treinamento interno, uma equipe discute o conceito de espaço latente de um modelo de IA generativa. Quais DUAS afirmações sobre esse espaço estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O espaço latente é a representação interna em que o modelo organiza o que aprendeu: conceitos relacionados ficam próximos, o que permite calcular a similaridade semântica entre entradas. Ele não depende de um banco de dados específico, não se limita a imagens e suas dimensões não formam uma tabela legível por pessoas.",
+        topic: "IA generativa",
+        options: [
+            ["Representa as relações entre conceitos que o modelo aprendeu", true],
+            ["Permite calcular a similaridade semântica entre entradas diferentes", true],
+            ["Precisa ser guardado em um tipo específico de banco de dados", false],
+            ["Existe apenas em modelos de imagem, sem uso em modelos de texto", false],
+            ["É uma tabela de consulta legível, com um significado claro por dimensão", false],
+        ],
+    },
+    {
+        statement:
+            "No ciclo de vida de um foundation model, uma equipe roda testes com dados que o modelo não viu no treinamento para medir a qualidade das respostas antes de liberá-lo em produção. Em qual etapa essa atividade acontece?",
+        explanation:
+            "Na avaliação, o modelo é testado com dados de validação ou de teste e com métricas de qualidade antes de ir para produção. O pré-treinamento cria o modelo base, o fine-tuning o adapta a uma tarefa e a implantação disponibiliza o modelo pronto para uso, e nenhuma delas é a etapa de teste.",
+        topic: "IA generativa",
+        options: [
+            ["Avaliação", true],
+            ["Pré-treinamento", false],
+            ["Fine-tuning", false],
+            ["Implantação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de ciência de dados avalia o Amazon SageMaker JumpStart para acelerar o início de um novo projeto de IA generativa. Qual é o principal benefício desse recurso?",
+        explanation:
+            "O SageMaker JumpStart oferece modelos pré-treinados, incluindo foundation models, além de modelos de solução e notebooks de exemplo que a equipe implanta, ajusta e avalia com poucos passos. Otimizar o custo de inferência, ajustar hiperparâmetros automaticamente e rotular dados com pessoas são funções de outros recursos do SageMaker AI.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Oferecer modelos pré-treinados e soluções prontas para implantar e ajustar", true],
+            ["Reduzir automaticamente o custo de inferência dos endpoints já implantados", false],
+            ["Ajustar sozinho os hiperparâmetros de modelos treinados pela própria equipe", false],
+            [
+                "Gerenciar a rotulagem de dados com uma força de trabalho humana especializada",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe melhora as respostas de um assistente reescrevendo as instruções, incluindo exemplos do resultado esperado e definindo o formato da saída, sem alterar o modelo. Como se chama essa prática?",
+        explanation:
+            "Prompt engineering é a prática de criar e refinar o prompt, com contexto, restrições e exemplos, para guiar o modelo a respostas melhores sem mudar seus pesos. Fine-tuning altera os pesos com novos dados, quantização comprime o modelo e rotulagem de dados prepara exemplos para o treinamento supervisionado.",
+        topic: "Prompt engineering",
+        options: [
+            ["Prompt engineering, que ajusta a entrada para guiar a saída do modelo", true],
+            ["Fine-tuning, que atualiza os pesos do modelo com novos dados rotulados", false],
+            ["Quantização, que comprime o modelo para executar a inferência mais rápido", false],
+            ["Rotulagem de dados, que marca exemplos para o treinamento supervisionado", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA usa um LLM para escrever textos de marketing. O resultado soa plausível e factual, mas traz afirmações incorretas sobre o produto. Qual problema o modelo está apresentando?",
+        explanation:
+            "Alucinação é quando um LLM produz conteúdo que parece plausível e factual, mas é incorreto ou inventado, como no texto de marketing descrito. Vazamento de dados é a exposição indevida de informação, overfitting é decorar o treino e generalizar mal e underfitting é não captar os padrões dos dados.",
+        topic: "IA generativa",
+        options: [
+            ["Alucinação", true],
+            ["Vazamento de dados", false],
+            ["Overfitting", false],
+            ["Underfitting", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem uma aplicação que coleta reclamações de consumidores em fontes públicas e as processa com regras complexas codificadas à mão. Ela quer levar essa lógica a novos mercados e linhas de produto. Qual vantagem dos modelos de IA generativa se aplica a esse cenário?",
+        explanation:
+            "A adaptabilidade permite que o modelo generalize o que aprendeu para novos mercados e produtos com pouca reconfiguração, sem reescrever regras complexas. Saídas previsíveis e baixa sensibilidade a mudanças na entrada não são pontos fortes da IA generativa, que é não determinística, e a explicabilidade não resolve a expansão da lógica.",
+        topic: "IA generativa",
+        options: [
+            ["Adaptabilidade", true],
+            ["Saídas previsíveis", false],
+            ["Menor sensibilidade a mudanças na entrada", false],
+            ["Explicabilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA percebe que um LLM retorna respostas diferentes cada vez que recebe exatamente a mesma entrada. Que risco da IA generativa esse comportamento descreve?",
+        explanation:
+            "Não determinismo é a característica de um LLM gerar respostas diferentes para a mesma entrada, por causa da amostragem aleatória na escolha dos tokens. Alucinação é produzir conteúdo falso com aparência plausível, viés algorítmico é tratar grupos de forma injusta e multimodalidade é trabalhar com vários tipos de dado.",
+        topic: "IA generativa",
+        options: [
+            ["Não determinismo", true],
+            ["Alucinação", false],
+            ["Viés algorítmico", false],
+            ["Multimodalidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de qualidade classifica as falhas registradas em um assistente de IA generativa. Qual das situações a seguir caracteriza uma alucinação do modelo?",
+        explanation:
+            "Alucinação é uma saída incorreta ou inventada apresentada como fato, como citar uma norma que não existe. Mudar a redação entre chamadas é não determinismo, a resposta cortada decorre do limite máximo de tokens de saída e a recusa de um tema barrado é o funcionamento esperado dos filtros de conteúdo.",
+        topic: "IA generativa",
+        options: [
+            ["O assistente cita uma norma com número e data que nunca existiu", true],
+            ["O assistente muda a redação ao responder duas vezes à mesma pergunta", false],
+            ["A resposta termina cortada ao atingir o limite de tokens de saída", false],
+            ["O assistente se recusa a tratar um tema barrado pelos filtros de conteúdo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma diretoria avalia os riscos antes de adotar uma solução de IA generativa no atendimento ao cliente. Qual das características a seguir é uma possível desvantagem desse tipo de solução?",
+        explanation:
+            "A imprecisão é uma desvantagem conhecida da IA generativa: o modelo pode gerar informações incorretas, enviesadas ou inventadas, o que exige validação e supervisão humana. Adaptabilidade, rapidez nas respostas e capacidade conversacional são vantagens desse tipo de solução, e não desvantagens.",
+        topic: "IA generativa",
+        options: [
+            ["Imprecisão das respostas", true],
+            ["Adaptabilidade a novas tarefas", false],
+            ["Rapidez nas respostas", false],
+            ["Capacidade conversacional", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de mídia quer usar foundation models desenvolvidos pela própria Amazon para gerar textos de marketing e resumir vídeos de campanhas. Qual opção da AWS reúne esses modelos próprios da Amazon?",
+        explanation:
+            "O Amazon Nova é a família de foundation models desenvolvida pela Amazon e oferecida no Amazon Bedrock, capaz de gerar texto e de entender imagens e vídeos. Rekognition analisa imagens e vídeos, Comprehend extrai informações de textos e Polly converte texto em fala, e nenhum deles é um foundation model generativo da Amazon.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Amazon Nova, família de foundation models criados pela Amazon", true],
+            ["Amazon Rekognition, que detecta objetos e rostos em imagens e vídeos", false],
+            ["Amazon Comprehend, que extrai sentimentos e entidades de textos", false],
+            ["Amazon Polly, que converte textos em fala com vozes naturais", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe cria no Amazon Bedrock um assistente de suporte que precisa lembrar dados da conta citados antes na conversa, consultar artigos de ajuda relevantes e seguir as diretrizes da empresa. Que conceito descreve a gestão de todas essas informações enviadas ao foundation model a cada chamada?",
+        explanation:
+            "Context engineering é a prática de montar dinamicamente tudo o que o modelo recebe na inferência: instruções de sistema, histórico da conversa, documentos recuperados e resultados de ferramentas. Prompt engineering foca no texto da instrução, a destilação cria um modelo menor a partir de um maior e o pré-treinamento contínuo atualiza os pesos com novos dados.",
+        topic: "Prompt engineering",
+        options: [
+            ["Context engineering", true],
+            ["Prompt engineering", false],
+            ["Destilação de modelo", false],
+            ["Pré-treinamento contínuo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe constrói agentes de IA que precisam acessar ferramentas, APIs e fontes de dados de diferentes sistemas sem criar uma integração sob medida para cada um. Qual é o papel do Model Context Protocol (MCP) nesse cenário?",
+        explanation:
+            "O Model Context Protocol (MCP) é um padrão aberto que define como aplicações e agentes de IA se comunicam com ferramentas, APIs e fontes de dados externas, evitando integrações sob medida. Comprimir modelos é papel de técnicas como a quantização, criptografar pesos é prática de segurança e medir acurácia em benchmarks é avaliação de modelos.",
+        topic: "IA generativa",
+        options: [
+            ["Padronizar a conexão dos agentes com ferramentas e fontes de dados externas", true],
+            [
+                "Comprimir o modelo para reduzir a latência das respostas geradas pelos agentes",
+                false,
+            ],
+            ["Criptografar os pesos do modelo durante o treinamento e o armazenamento", false],
+            ["Medir a acurácia dos agentes em conjuntos de dados de benchmark públicos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de serviços financeiros quer que vários agentes de IA especializados colaborem em solicitações complexas de clientes: um cuida das consultas de conta, outro processa transações e um terceiro verifica a conformidade. Que conceito de IA agêntica essa arquitetura representa?",
+        explanation:
+            "Um sistema multiagente usa agentes especializados que se comunicam e colaboram, cada um responsável por uma capacidade, como contas, transações e conformidade. Aprendizado por reforço com agente único treina um só agente por recompensas, a classificação supervisionada atribui rótulos e a inferência em lote processa dados em massa, sem colaboração entre agentes.",
+        topic: "IA generativa",
+        options: [
+            ["Padrão de sistema multiagente", true],
+            ["Aprendizado por reforço com agente único", false],
+            ["Pipeline de classificação supervisionada", false],
+            ["Fluxo de inferência em lote", false],
+        ],
+    },
+    {
+        statement:
+            "Um agente de IA apoia uma pesquisadora da área da saúde em várias sessões ao longo de dias e precisa recuperar as descobertas das sessões anteriores para não repetir trabalho. Qual capacidade de IA agêntica permite isso?",
+        explanation:
+            "O gerenciamento de memória permite que o agente guarde e recupere informações entre sessões, como as descobertas anteriores, e continue de onde parou. O uso de ferramentas chama APIs externas, a orquestração coordena a sequência de passos do agente e o pré-treinamento forma o conhecimento geral do modelo, sem lembrar as sessões de um usuário.",
+        topic: "IA generativa",
+        options: [
+            ["Gerenciamento de memória", true],
+            ["Uso de ferramentas", false],
+            ["Orquestração de fluxos de trabalho", false],
+            ["Pré-treinamento do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup quer construir agentes de IA próprios com um SDK de código aberto que ofereça uso de ferramentas, orquestração multiagente e integração com modelos de vários provedores. Qual opção da AWS atende a esse requisito?",
+        explanation:
+            "O Strands Agents é um SDK de código aberto lançado pela AWS, para Python e TypeScript, que cria agentes com uso de ferramentas, padrões multiagente, suporte a MCP e modelos de vários provedores. O Lex cria bots de conversa, o AWS Transform é um serviço agêntico que moderniza aplicações e o Personalize gera recomendações, e nenhum deles é um SDK de agentes.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Strands Agents", true],
+            ["AWS Transform", false],
+            ["Amazon Lex", false],
+            ["Amazon Personalize", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer uma infraestrutura gerenciada para implantar, escalar e monitorar seus agentes de IA em produção, sem cuidar da computação e da rede subjacentes. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Bedrock AgentCore oferece infraestrutura gerenciada para executar agentes em produção, com runtime serverless, memória, identidade, gateway de ferramentas e observabilidade, com qualquer framework e modelo. O SageMaker Canvas cria modelos de ML sem código, o Bedrock Knowledge Bases implementa RAG e o Comprehend analisa textos.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Amazon Bedrock AgentCore", true],
+            ["Amazon SageMaker Canvas", false],
+            ["Amazon Bedrock Knowledge Bases", false],
+            ["Amazon Comprehend", false],
+        ],
+    },
+    {
+        statement:
+            "Uma agência de viagens cria um agente de IA que pesquisa voos disponíveis, reserva passagens e processa pagamentos chamando as APIs da companhia aérea. Qual capacidade de IA agêntica permite que o agente interaja com esses sistemas externos?",
+        explanation:
+            "O uso de ferramentas permite que o agente chame APIs, serviços e sistemas externos para buscar informações e executar ações, como consultar voos, reservar e pagar. O gerenciamento de memória guarda informações entre interações, o fine-tuning altera os pesos no treinamento e o cache de prompts reaproveita trechos repetidos para reduzir custo e latência.",
+        topic: "IA generativa",
+        options: [
+            ["Uso de ferramentas", true],
+            ["Gerenciamento de memória", false],
+            ["Fine-tuning do modelo", false],
+            ["Cache de prompts", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa o Amazon Bedrock em um chatbot de suporte e percebe que os custos estão subindo. A equipe descobre que o histórico completo da conversa é incluído em todo prompt. Qual aspecto do modelo de preços por token explica esse aumento?",
+        explanation:
+            "No preço por token, cada requisição é cobrada pelos tokens de entrada e de saída. Enviar o histórico completo em todo prompt aumenta os tokens de entrada a cada chamada e eleva o custo. O Bedrock sob demanda não cobra valor fixo por chamada, nem por tempo de processamento ou pelo número de usuários simultâneos.",
+        topic: "IA generativa",
+        options: [
+            [
+                "O custo cresce com os tokens de entrada e de saída processados em cada chamada",
+                true,
+            ],
+            [
+                "O custo é fixo por chamada de API, sem relação com o tamanho do conteúdo enviado",
+                false,
+            ],
+            [
+                "O custo depende do tempo que o modelo leva para processar cada uma das chamadas",
+                false,
+            ],
+            [
+                "O custo varia conforme o número de usuários conectados ao chatbot ao mesmo tempo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer reduzir o custo de um aplicativo que gera resumos com um foundation model. Hoje muitas respostas chegam ao limite máximo de tokens de saída, e a equipe decide diminuir esse limite em cada chamada. Qual é o efeito esperado dessa mudança sobre o custo e o desempenho?",
+        explanation:
+            "Com preço por token, as respostas que chegavam ao limite antigo passam a gerar menos tokens de saída, o que reduz o custo e costuma encurtar o tempo de resposta; se o limite ficar baixo demais, o resumo sai cortado. Menos tokens não aumenta o custo, a mudança tem efeito e gerar menos texto não deixa a resposta mais lenta.",
+        topic: "IA generativa",
+        options: [
+            ["Reduz o custo e pode encurtar o tempo de resposta", true],
+            ["Aumenta o custo por token e não muda o tempo de resposta", false],
+            ["Não muda o custo cobrado nem o tempo de resposta", false],
+            ["Reduz o custo, mas deixa as respostas mais lentas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup sem infraestrutura de ML quer lançar rapidamente um recurso de IA generativa. Qual vantagem de usar serviços de IA generativa da AWS, como o Amazon Bedrock, é a mais relevante nesse caso?",
+        explanation:
+            "Serviços como o Amazon Bedrock dão acesso por API a foundation models pré-treinados, com a infraestrutura gerenciada pela AWS, o que reduz a barreira de entrada e acelera o lançamento. Eles não garantem respostas sempre corretas, ainda exigem código para integrar a aplicação e são cobrados conforme o uso, sem gratuidade ilimitada.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Reduzir a barreira de entrada com acesso gerenciado a modelos pré-treinados", true],
+            [
+                "Garantir respostas sempre corretas, sem necessidade de validar as saídas do modelo",
+                false,
+            ],
+            ["Dispensar qualquer código, já que o serviço cria a aplicação inteira sozinho", false],
+            [
+                "Oferecer uso gratuito e ilimitado dos modelos durante o lançamento do produto",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de saúde avalia construir sua aplicação de IA generativa na AWS. Para esse setor regulado, qual benefício da infraestrutura da AWS é o mais importante?",
+        explanation:
+            "Setores regulados, como saúde, precisam dos controles de segurança, das certificações e programas de conformidade (como a elegibilidade HIPAA) e dos recursos de proteção de dados da AWS. Nenhum provedor garante a menor latência em todo lugar, nenhum modelo está livre de erros e a empresa continua responsável pela própria governança de dados.",
+        topic: "Segurança e governança",
+        options: [
+            ["Controles de segurança, certificações de conformidade e proteção de dados", true],
+            ["A menor latência de inferência possível em todas as regiões do mundo", false],
+            ["A garantia de que os modelos de IA nunca produzem saídas incorretas", false],
+            [
+                "O fim da necessidade de a empresa manter políticas próprias de governança de dados",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista implantou um chatbot de IA generativa há seis meses e quer medir o valor de negócio dele. Qual métrica indica melhor o impacto do chatbot na receita?",
+        explanation:
+            "A receita média por usuário (ARPU) mede quanto cada cliente gera de receita; acompanhar sua evolução depois do chatbot mostra o impacto dele no faturamento. O número de parâmetros descreve o tamanho do modelo, as épocas são configuração de treinamento e a latência mede a velocidade das respostas, sem relação direta com a receita.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Receita média por usuário (ARPU)", true],
+            ["Número de parâmetros do modelo", false],
+            ["Quantidade de épocas de treinamento", false],
+            ["Latência de inferência", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa um assistente de IA generativa para apoiar a equipe de suporte e quer medir os ganhos de eficiência operacional. Qual métrica ela deve acompanhar?",
+        explanation:
+            "A redução do tempo médio de atendimento por chamado mostra quanto mais rápido a equipe resolve os casos com o apoio do assistente, um ganho direto de eficiência operacional. ROUGE e BERTScore medem a qualidade do texto gerado em relação a referências e a perplexidade mede o ajuste do modelo à linguagem, e nenhuma delas mede eficiência.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Redução do tempo médio de atendimento por chamado", true],
+            ["Pontuação ROUGE dos resumos gerados pelo assistente", false],
+            ["BERTScore das respostas em relação a textos de referência", false],
+            ["Perplexidade do modelo de linguagem usado no assistente", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe vai criar um foundation model e, antes de qualquer treinamento, precisa escolher as fontes de dados adequadas e prepará-las. Qual etapa do ciclo de vida do modelo envolve essa atividade?",
+        explanation:
+            "A seleção de dados é a primeira etapa do ciclo de vida de um foundation model: identificar e curar as fontes de dados antes do pré-treinamento, já que a qualidade e a amplitude desses dados moldam o que o modelo aprende. A implantação, a avaliação e a coleta de feedback acontecem depois que o modelo já foi treinado.",
+        topic: "IA generativa",
+        options: [
+            ["Seleção de dados", true],
+            ["Implantação do modelo", false],
+            ["Avaliação do modelo", false],
+            ["Coleta de feedback", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa investiu em uma solução de IA generativa para automatizar a redação de relatórios. Qual métrica mede melhor se esse investimento gerou valor financeiro?",
+        explanation:
+            "O retorno sobre o investimento (ROI) compara os benefícios financeiros da solução, como horas economizadas e mais produtividade, com o custo de construí-la e operá-la, mostrando se o investimento valeu a pena. A acurácia mede a qualidade das previsões, e o número de parâmetros e o volume de dados são detalhes técnicos sem relação com retorno.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Retorno sobre o investimento (ROI)", true],
+            ["Acurácia do modelo", false],
+            ["Número de parâmetros do modelo", false],
+            ["Volume de dados usados no treinamento", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep-d3.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep-d3.ts
@@ -1,0 +1,1175 @@
+// Questões do simulado AWS Certified AI Practitioner (AIF-C01), domínio 3 da prova
+// (Applications of Foundation Models), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aif-c01-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D3: Questao[] = [
+    {
+        statement:
+            "Uma agência de viagens usa um LLM pré-treinado em um assistente de reservas e precisa que as respostas sejam curtas e escritas em um idioma específico. Qual abordagem alinha melhor a saída do modelo a essas exigências?",
+        explanation:
+            "Refinar o prompt permite declarar de forma direta o tamanho esperado e o idioma da resposta, e o modelo passa a seguir essas instruções. Trocar o tamanho do modelo muda capacidade e custo, não o formato, e aumentar a temperatura ou o top-k só deixa a escolha dos tokens mais variada.",
+        topic: "Prompt engineering",
+        options: [
+            ["Refinar o prompt, indicando o tamanho da resposta e o idioma desejado", true],
+            ["Trocar o LLM por outro modelo de tamanho diferente do usado hoje", false],
+            ["Aumentar a temperatura para o modelo variar mais nas respostas geradas", false],
+            ["Aumentar o valor de top-k para ampliar os tokens candidatos a cada passo", false],
+        ],
+    },
+    {
+        statement:
+            "Um fabricante precisa de um conjunto de imagens rotuladas com alta precisão para treinar um modelo de detecção de defeitos e quer reduzir ao mínimo os rótulos errados. Qual abordagem atende melhor a esses requisitos?",
+        explanation:
+            "Com revisão humana (human-in-the-loop), especialistas conferem e corrigem os rótulos, o que gera a maior precisão com menos erros. A rotulagem automática sem revisão propaga erros, imagens sintéticas não validam rótulos e o aprendizado ativo reduz esforço, mas deixa passar mais rótulos errados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Rotulagem com revisão humana, em que especialistas conferem e corrigem cada rótulo",
+                true,
+            ],
+            [
+                "Rotulagem automática por um modelo de visão pré-treinado, sem nenhuma revisão humana",
+                false,
+            ],
+            [
+                "Geração de imagens sintéticas por um foundation model, com rótulos já atribuídos",
+                false,
+            ],
+            [
+                "Rotulagem automática com aprendizado ativo, em que o modelo rotula a maior parte das imagens",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de engenharia quer usar o Amazon OpenSearch Service como base de uma aplicação de busca vetorial. Qual recurso do serviço torna isso possível?",
+        explanation:
+            "A busca k-NN (k vizinhos mais próximos) indexa embeddings e devolve os vetores mais parecidos com a consulta, que é a base de uma aplicação de busca vetorial. O BM25 casa palavras-chave, a indexação geoespacial trata localização e a replicação entre clusters cuida da recuperação de desastres.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Busca k-NN, que encontra os vizinhos mais próximos entre vetores de alta dimensão",
+                true,
+            ],
+            [
+                "Busca textual por palavras-chave, com ranqueamento BM25 dos documentos indexados",
+                false,
+            ],
+            [
+                "Indexação geoespacial, que responde a consultas por localização e por distância",
+                false,
+            ],
+            [
+                "Replicação entre clusters, que mantém cópias do índice para recuperação de desastres",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa um LLM no Amazon Bedrock para classificar trechos de texto como positivos ou negativos, mas, enviando só a instrução e o trecho, as classificações saem inconsistentes. Qual estratégia de prompt engineering melhora a precisão?",
+        explanation:
+            "Exemplos rotulados no prompt (few-shot) mostram ao modelo o padrão entre trecho e rótulo e deixam a classificação mais consistente. Explicar a teoria não dá exemplos a seguir, reforçar a instrução continua sendo zero-shot e exemplos de outras tarefas desviam o modelo da classificação.",
+        topic: "Prompt engineering",
+        options: [
+            [
+                "Incluir no prompt alguns trechos de exemplo, cada um já rotulado como positivo ou negativo",
+                true,
+            ],
+            [
+                "Incluir no prompt uma explicação detalhada sobre análise de sentimento e sobre como os LLMs funcionam",
+                false,
+            ],
+            [
+                "Reescrever a instrução com mais ênfase e repetir o pedido, ainda sem exemplos no prompt",
+                false,
+            ],
+            [
+                "Incluir no prompt exemplos resolvidos de outras tarefas, como resumos e traduções",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma startup vai lançar um agente virtual baseado em LLM e quer impedir que usuários o convençam a executar ações inseguras ou a revelar suas instruções internas. Qual ação reduz esse risco de forma mais direta?",
+        explanation:
+            "Um modelo de prompt (template) com instruções de sistema que ensinam o LLM a identificar e recusar padrões de manipulação é uma defesa direta contra injeção de prompt e vazamento de instruções. Temperatura e top-p só mudam a aleatoriedade da amostragem, e limitar os tokens de saída apenas encurta as respostas.",
+        topic: "Prompt engineering",
+        options: [
+            [
+                "Usar um modelo de prompt com instruções de sistema para reconhecer e recusar manipulações",
+                true,
+            ],
+            [
+                "Aumentar a temperatura do modelo para que as respostas variem mais entre as chamadas",
+                false,
+            ],
+            [
+                "Aumentar o valor de top-p para ampliar o conjunto de tokens considerados na amostragem",
+                false,
+            ],
+            [
+                "Reduzir o número máximo de tokens de saída permitido em cada uma das requisições ao modelo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma fabricante de eletrodomésticos quer oferecer um chat que responda perguntas sobre os manuais dos produtos, em PDF, usando LLMs no Amazon Bedrock com o menor custo possível. Qual abordagem atende melhor?",
+        explanation:
+            "A base de conhecimento recupera só os trechos relevantes para cada pergunta, então o modelo recebe o contexto certo sem pagar pelos manuais inteiros a cada chamada nem por treino. Colar todos os manuais no prompt infla o custo em tokens, o fine-tuning soma custo de treino e o pré-treinamento contínuo é o mais caro.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Usar o Amazon Bedrock Knowledge Bases e recuperar só os trechos relevantes dos manuais",
+                true,
+            ],
+            [
+                "Incluir o texto completo de todos os manuais no prompt de cada pergunta enviada ao modelo",
+                false,
+            ],
+            [
+                "Fazer fine-tuning de um modelo com os manuais e servir esse modelo customizado no Bedrock",
+                false,
+            ],
+            [
+                "Fazer pré-treinamento contínuo do modelo base com todo o conteúdo dos manuais",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "O chatbot de uma empresa de biotecnologia já recupera os trechos certos de artigos de pesquisa clínica, mas, mesmo após vários ajustes no prompt, o modelo continua interpretando mal a terminologia especializada. O que melhora mais esse resultado?",
+        explanation:
+            "O fine-tuning de adaptação ao domínio treina o modelo com o corpus especializado, e ele passa a entender a terminologia clínica, que é a origem do problema. Few-shot e temperatura menor só moldam a resposta, e recuperar mais trechos não ensina o vocabulário que o modelo ainda não domina.",
+        topic: "RAG e customização",
+        options: [
+            ["Fazer fine-tuning de adaptação ao domínio com os artigos especializados", true],
+            ["Usar few-shot prompting com exemplos de perguntas e respostas no prompt", false],
+            ["Aumentar o número de trechos que a etapa de RAG recupera por pergunta", false],
+            ["Reduzir a temperatura para deixar as respostas do modelo mais focadas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de ensino on-line mantém um assistente de perguntas e respostas e quer que o estilo das respostas combine com a faixa etária de cada aluno, informação que o aplicativo já envia ao modelo. Qual abordagem exige MENOS esforço?",
+        explanation:
+            "Incluir no prompt uma instrução de papel e de público com a faixa etária é uma mudança simples de prompt engineering que ajusta o estilo quase sem trabalho extra. Fine-tuning por faixa etária, um pipeline de RAG com conteúdo por idade e um segundo modelo para reescrever o tom exigem dados, infraestrutura ou processamento a mais.",
+        topic: "Prompt engineering",
+        options: [
+            [
+                "Incluir no prompt uma instrução de papel e público com a faixa etária do aluno",
+                true,
+            ],
+            ["Fazer fine-tuning de um modelo separado para cada uma das faixas etárias", false],
+            ["Montar um pipeline de RAG com conteúdos específicos de cada faixa etária", false],
+            [
+                "Pós-processar cada resposta com um segundo modelo que reescreva o tom para o aluno",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe envia uma vez por dia a um modelo base do Amazon Bedrock um prompt few-shot com 10 exemplos. O desempenho é bom, mas a equipe quer reduzir o custo mensal. Qual mudança ajuda?",
+        explanation:
+            "O custo sob demanda acompanha os tokens processados, então enxugar exemplos e tokens do prompt reduz a conta mantendo o bom desempenho. Provisioned Throughput cobra por hora e compensa com volume alto e constante, o fine-tuning soma custo de treino e de armazenamento do modelo customizado, e um modelo maior encarece cada chamada.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Reduzir a quantidade de exemplos e de tokens enviados em cada prompt", true],
+            ["Comprar Provisioned Throughput para o modelo usado na chamada diária", false],
+            ["Fazer fine-tuning do modelo para dispensar os exemplos no prompt", false],
+            ["Migrar a carga para um modelo maior e com mais capacidade de raciocínio", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de turismo traduz seus artigos de ajuda para vários idiomas com um LLM e compara cada tradução automática com uma tradução de referência feita por pessoas. Qual métrica foi criada especificamente para tradução automática?",
+        explanation:
+            "O BLEU foi criado para tradução automática: mede a sobreposição de n-gramas entre a tradução gerada e uma ou mais traduções de referência. O ROUGE é voltado a resumos, o BERTScore mede similaridade semântica de forma geral e a taxa de erro de palavras avalia transcrição de fala.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["BLEU (Bilingual Evaluation Understudy)", true],
+            ["ROUGE (Recall-Oriented Understudy for Gisting Evaluation)", false],
+            ["BERTScore", false],
+            ["Taxa de erro de palavras (WER)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe avalia fazer pré-treinamento contínuo de um foundation model. Qual é um benefício dessa abordagem?",
+        explanation:
+            "O pré-treinamento contínuo segue treinando o foundation model com dados novos, em geral sem rótulos, e mantém o conhecimento dele atualizado ao longo do tempo. Adaptar a uma tarefa com dados rotulados é fine-tuning, comprimir o modelo é destilação ou quantização, e nenhuma técnica de treino dispensa a avaliação.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Atualizar o conhecimento do modelo, treinando-o com dados novos ao longo do tempo",
+                true,
+            ],
+            [
+                "Adaptar o modelo a uma tarefa específica usando um conjunto de dados rotulados",
+                false,
+            ],
+            [
+                "Comprimir o modelo para reduzir seu tamanho em memória e acelerar a inferência",
+                false,
+            ],
+            [
+                "Dispensar a etapa de avaliação do modelo antes de cada nova versão ir para produção",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de segurança revisa ataques baseados em prompt contra o assistente da empresa. Qual ataque tem como objetivo específico fazer o modelo revelar as instruções de sistema ocultas?",
+        explanation:
+            "Na extração do modelo de prompt, o atacante pede que o modelo imprima as instruções do template, expondo o prompt de sistema que configura o comportamento. O jailbreak contorna as proteções, mandar ignorar o template tenta desviar o comportamento e a troca de persona impõe um novo papel, sem mirar as instruções em si.",
+        topic: "Prompt engineering",
+        options: [
+            ["Extração do modelo de prompt (template)", true],
+            ["Jailbreak das proteções do modelo", false],
+            ["Instrução para ignorar o modelo de prompt", false],
+            ["Troca de persona induzida pelo prompt", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede social quer comparar a toxicidade das respostas de vários LLMs candidatos disponíveis no Amazon Bedrock com o MENOR esforço operacional. Qual abordagem de avaliação atende?",
+        explanation:
+            "A avaliação automática do Amazon Bedrock pontua as respostas com métricas prontas de toxicidade e não exige recrutar nem coordenar pessoas, o que dá o menor esforço operacional. Revisores próprios e crowdsourcing exigem gerenciar avaliadores, e o teste A/B com usuários reais expõe o público a respostas tóxicas.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Avaliação automática no Amazon Bedrock, com as métricas prontas de toxicidade", true],
+            ["Avaliação de modelos com uma equipe própria de revisores humanos da empresa", false],
+            [
+                "Classificação das respostas por avaliadores humanos recrutados em crowdsourcing",
+                false,
+            ],
+            [
+                "Teste A/B dos modelos candidatos com usuários reais da plataforma em produção",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer fortalecer um modelo contra ataques de injeção de prompt antes de publicá-lo. Qual abordagem de prompting é usada para isso?",
+        explanation:
+            "O prompting adversarial cria e testa entradas hostis de propósito, para detectar e neutralizar tentativas de injeção antes que cheguem aos usuários. Chain-of-thought, few-shot e zero-shot só mudam como o modelo raciocina ou recebe exemplos e não oferecem defesa contra prompts maliciosos.",
+        topic: "Prompt engineering",
+        options: [
+            [
+                "Prompting adversarial, testando o modelo com entradas maliciosas criadas de propósito",
+                true,
+            ],
+            [
+                "Chain-of-thought, pedindo que o modelo explique cada etapa do raciocínio antes de responder",
+                false,
+            ],
+            [
+                "Few-shot prompting, incluindo alguns exemplos resolvidos da tarefa no próprio prompt",
+                false,
+            ],
+            [
+                "Zero-shot prompting, enviando apenas a instrução da tarefa sem nenhum exemplo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de suporte de TI fez fine-tuning de um LLM para responder dúvidas do help desk e quer confirmar se o ajuste deixou as respostas mais corretas, comparando-as com respostas de referência. Qual métrica deve usar?",
+        explanation:
+            "O F1 score equilibra precisão e recall em um único valor e mostra se as respostas ficaram corretas e completas em relação às de referência, medindo o ganho do fine-tuning. A precisão sozinha ignora respostas certas que faltaram, o tempo até o primeiro token mede latência e a perplexidade mede ajuste ao texto, não acerto na tarefa.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["F1 score, que equilibra precisão e recall em um único valor", true],
+            ["Precisão, que mede a fração de acertos entre as respostas dadas", false],
+            ["Tempo até o primeiro token, que indica a latência da resposta", false],
+            ["Perplexidade, que mede o quanto o modelo prevê bem um texto", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa gera imagens de produtos com um modelo de difusão, mas os resultados saem aleatórios e ignoram detalhes pedidos no prompt. A equipe quer que as imagens sigam o prompt mais de perto. Qual ajuste ajuda?",
+        explanation:
+            "A escala CFG controla o quanto o modelo segue o texto do prompt, então aumentá-la faz a imagem respeitar mais os detalhes pedidos. Mais etapas refinam a remoção de ruído, fixar a semente só torna o resultado reproduzível e pesar mais o prompt negativo reforça o que evitar, não a aderência ao prompt principal.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Aumentar a escala de orientação sem classificador (CFG scale)", true],
+            ["Aumentar o número de etapas de geração (steps) de remoção de ruído", false],
+            ["Fixar a semente aleatória (seed) usada nas gerações de imagem", false],
+            ["Aumentar o peso do prompt negativo que descreve o que evitar", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa criou uma solução de resumo de textos no Amazon Bedrock e vai avaliá-la com um job de avaliação automática do Amazon Bedrock Evaluations. Qual métrica essa avaliação usa para medir a qualidade dos resumos?",
+        explanation:
+            "Na avaliação automática do Amazon Bedrock, a exatidão de resumos é medida com o BERTScore, que compara o resumo gerado com o texto de referência por embeddings contextuais e capta similaridade semântica. AUC avalia classificação binária, MSE mede erro de regressão e perplexidade mede o ajuste do modelo à linguagem.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["BERTScore", true],
+            ["Área sob a curva ROC (AUC)", false],
+            ["Erro quadrático médio (MSE)", false],
+            ["Perplexidade", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de idiomas usa um LLM para reescrever textos com mais clareza e tem exemplos de referência das versões melhoradas. A equipe quer que a saída do modelo se pareça com esses exemplos. Qual métrica deve usar?",
+        explanation:
+            "O ROUGE mede a sobreposição de n-gramas e de sequências entre a saída do modelo e os textos de referência, então mostra o quanto a reescrita se aproxima das versões melhoradas. A perplexidade reflete o ajuste do modelo à linguagem, a robustez semântica mede estabilidade diante de variações na entrada e a latência mede velocidade.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Pontuação ROUGE dos textos reescritos", true],
+            ["Perplexidade dos textos reescritos", false],
+            ["Pontuação de robustez semântica do modelo", false],
+            ["Latência média de cada resposta gerada", false],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista de eletrônicos quer que um LLM escreva descrições curtas de produtos, focadas nos principais recursos de cada item. Qual abordagem de prompt engineering funciona melhor?",
+        explanation:
+            "Prompts por categoria que apontam os recursos principais e fixam formato e tamanho levam o modelo a descrições consistentes, curtas e focadas, com pouco retrabalho. Um prompt genérico exige muita edição manual, listar todos os atributos gera texto longo e sem foco, e pedir o máximo de criatividade para depois cortar desperdiça esforço.",
+        topic: "Prompt engineering",
+        options: [
+            [
+                "Criar prompts por categoria com os recursos principais, o formato e o tamanho da saída",
+                true,
+            ],
+            [
+                "Escrever um único prompt genérico para todos os produtos e editar manualmente cada resultado",
+                false,
+            ],
+            [
+                "Listar todos os atributos do produto em um único prompt e pedir uma descrição completa",
+                false,
+            ],
+            [
+                "Pedir ao modelo a descrição mais criativa possível e depois cortar o texto no tamanho certo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma seguradora quer uma aplicação de IA que permita aos funcionários consultar os sinistros em aberto, obter os detalhes de um sinistro específico e buscar os documentos dele. Qual solução atende melhor?",
+        explanation:
+            "Um agente no Amazon Bedrock AgentCore chama as APIs de sinistros por meio de ferramentas para listar os abertos e obter os detalhes, e usa a base de conhecimento para buscar os documentos. Guardrails só filtram conteúdo, a base de conhecimento sozinha não executa ações e treinar um modelo do zero é esforço demais.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Amazon Bedrock AgentCore com ferramentas de API e uma base do Knowledge Bases", true],
+            [
+                "Amazon Bedrock AgentCore com políticas de conteúdo do Amazon Bedrock Guardrails",
+                false,
+            ],
+            ["Uma base do Amazon Bedrock Knowledge Bases sozinha, sem nenhum agente", false],
+            ["Um modelo de ML novo, treinado do zero com os dados no Amazon SageMaker AI", false],
+        ],
+    },
+    {
+        statement:
+            "Uma companhia aérea quer um chatbot de texto que responda dúvidas sobre horários de voos, regras de bagagem e formas de pagamento, usando LLMs e uma base com os documentos da empresa, com o MENOR esforço de desenvolvimento. Qual solução atende?",
+        explanation:
+            "O Amazon Bedrock já oferece LLMs gerenciados e, com o Amazon Bedrock Knowledge Bases, a equipe monta um RAG sobre os documentos sem treinar nem hospedar modelos. O Autopilot treina modelos de ML tradicionais com dados tabulares, o fine-tuning no JumpStart exige preparar dados e treinar, e um orquestrador próprio com modelo hospedado é o que dá mais trabalho.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Usar um LLM do Amazon Bedrock com o Amazon Bedrock Knowledge Bases, em um fluxo de RAG",
+                true,
+            ],
+            [
+                "Treinar modelos de ML a partir de dados tabulares com o Amazon SageMaker Autopilot",
+                false,
+            ],
+            [
+                "Fazer fine-tuning de modelos no Amazon SageMaker JumpStart com os documentos da empresa",
+                false,
+            ],
+            [
+                "Criar um orquestrador próprio com AWS Lambda sobre um modelo hospedado pela equipe",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma editora tem uma aplicação de RAG que precisa responder quase em tempo real, e novos artigos são publicados todos os dias. Quais DUAS etapas do pipeline podem rodar como jobs em lote, fora do fluxo de cada consulta? (Selecione DUAS opções.)",
+        explanation:
+            "Gerar os embeddings dos artigos e criar ou atualizar o índice dependem só dos documentos, então rodam em lotes periódicos conforme chegam artigos novos, fora do caminho de tempo real. Gerar o embedding da pergunta, ranquear os resultados e detectar o idioma da consulta acontecem a cada requisição e precisam rodar em tempo real.",
+        topic: "RAG e customização",
+        options: [
+            ["Gerar os embeddings dos novos artigos publicados no acervo", true],
+            ["Criar ou atualizar o índice de busca vetorial com os artigos", true],
+            ["Gerar o embedding de cada pergunta que chega do usuário", false],
+            ["Ranquear e devolver os resultados de cada consulta do usuário", false],
+            ["Detectar o idioma de cada pergunta enviada pelo usuário", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer dividir uma tarefa complexa em subtarefas menores enviadas a um LLM em sequência, em que cada etapa usa o resultado da anterior. Qual técnica descreve essa abordagem?",
+        explanation:
+            "No prompt chaining, a tarefa complexa vira subtarefas enviadas ao LLM uma após a outra, e cada etapa usa a saída da anterior. O chain-of-thought raciocina passo a passo dentro de uma única resposta, o tree of thoughts explora vários ramos de raciocínio e o few-shot fornece exemplos, sem sequenciar subtarefas.",
+        topic: "Prompt engineering",
+        options: [
+            ["Prompt chaining (encadeamento de prompts)", true],
+            ["Chain-of-thought (cadeia de raciocínio)", false],
+            ["Tree of thoughts (árvore de pensamentos)", false],
+            ["Few-shot prompting (prompt com poucos exemplos)", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA precisa melhorar a exatidão das respostas de um modelo de geração de texto que depende de dados de estoque que mudam rapidamente. Qual técnica ajuda mais?",
+        explanation:
+            "Com RAG, os dados atuais de estoque são buscados no momento da inferência e entram no contexto, então a resposta reflete a informação mais recente sem retreino. Fine-tuning com histórico, transfer learning e pré-treinamento contínuo fixam os dados no treino e ficam desatualizados à medida que o estoque muda.",
+        topic: "RAG e customização",
+        options: [
+            ["RAG, recuperando os dados atuais de estoque no momento da inferência", true],
+            ["Fine-tuning do modelo com o histórico de dados de estoque da empresa", false],
+            ["Transfer learning a partir de um modelo já treinado em outra tarefa", false],
+            ["Pré-treinamento contínuo com snapshots periódicos dos dados de estoque", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe apresenta à diretoria as vantagens de usar RAG em tarefas de processamento de linguagem natural (PLN). Qual afirmação descreve corretamente uma vantagem dessa abordagem?",
+        explanation:
+            "O RAG recupera documentos externos relevantes no momento da inferência e condiciona a geração a eles, enriquecendo as respostas com conhecimento atual e do domínio sem retreinar o modelo. Ele não acelera o treinamento, não reduz os parâmetros do modelo e não torna determinística a saída de um modelo generativo.",
+        topic: "RAG e customização",
+        options: [
+            ["Usa fontes externas de conhecimento para dar respostas mais precisas e úteis", true],
+            ["Acelera o treinamento do modelo de linguagem que está por trás da aplicação", false],
+            ["Reduz o número de parâmetros do modelo para economizar memória na inferência", false],
+            ["Garante saídas determinísticas, que se repetem igualmente a cada execução", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer adaptar um modelo de IA à terminologia e aos requisitos específicos do seu setor, treinando-o com um conjunto de dados rotulados. Qual técnica descreve essa abordagem?",
+        explanation:
+            "O fine-tuning continua o treino de um modelo pré-treinado com um conjunto rotulado do domínio, e ele aprende a terminologia e os requisitos do setor com esses exemplos. O pré-treinamento contínuo usa grandes volumes sem rótulos, o aprendizado em contexto põe exemplos no prompt sem treinar e a destilação transfere conhecimento para um modelo menor.",
+        topic: "RAG e customização",
+        options: [
+            ["Fine-tuning (ajuste fino)", true],
+            ["Pré-treinamento contínuo", false],
+            ["Aprendizado em contexto", false],
+            ["Destilação do modelo base", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe criou um agente com o Amazon Bedrock AgentCore e quer melhorar a precisão das decisões dele fornecendo alguns exemplos específicos de entrada e saída. Qual abordagem atende?",
+        explanation:
+            "Colocar os exemplos de entrada e saída no prompt de sistema do agente é few-shot prompting, que orienta o comportamento sem retreino nem serviço extra. Fine-tuning é pesado demais para poucos exemplos, a base de conhecimento fornece contexto recuperado e não exemplos de comportamento, e o guardrail aplica políticas de segurança.",
+        topic: "Prompt engineering",
+        options: [
+            ["Incluir os exemplos no prompt de sistema do agente, no estilo few-shot", true],
+            ["Fazer fine-tuning do modelo usado pelo agente com esses poucos exemplos", false],
+            ["Adicionar os exemplos a uma base do Amazon Bedrock Knowledge Bases", false],
+            ["Criar um guardrail no Amazon Bedrock Guardrails contendo os exemplos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe discute adotar fine-tuning em um foundation model que a empresa já usa. Qual é um benefício dessa abordagem?",
+        explanation:
+            "O fine-tuning atualiza os pesos do modelo com dados relevantes para a tarefa e melhora a exatidão e a relevância das respostas nela. Buscar dados externos na inferência é RAG, comprimir o modelo é destilação ou quantização, e renovar o conhecimento geral com dados novos é pré-treinamento contínuo.",
+        topic: "RAG e customização",
+        options: [
+            ["Melhorar o desempenho em uma tarefa específica, treinando com dados da tarefa", true],
+            [
+                "Permitir que o modelo busque dados externos atualizados no momento da inferência",
+                false,
+            ],
+            ["Comprimir o modelo, reduzindo o tamanho em disco e acelerando as respostas", false],
+            [
+                "Renovar o conhecimento geral do modelo com pré-treinamento em dados mais novos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai armazenar embeddings em um banco de dados vetorial, como o Amazon OpenSearch Service. Quais são DOIS casos de uso principais para isso? (Selecione DUAS opções.)",
+        explanation:
+            "Busca semântica e recomendações por similaridade dependem de comparar embeddings pelos vizinhos mais próximos, que é justamente o que um banco de dados vetorial oferece. A correspondência exata de palavras-chave é léxica, não semântica, e consultas por chave primária e jobs de ETL em lote são operações comuns de banco que não usam similaridade vetorial.",
+        topic: "RAG e customização",
+        options: [
+            ["Busca semântica em documentos, encontrando textos de significado parecido", true],
+            ["Recomendações baseadas em similaridade entre itens e perfis de usuários", true],
+            ["Correspondência exata das palavras-chave digitadas pelo usuário na busca", false],
+            ["Execução de jobs de ETL em lote agendados para rodar todas as noites", false],
+            ["Consultas transacionais por chave primária em tabelas de pedidos de clientes", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe vai usar o Amazon Aurora PostgreSQL com a extensão pgvector em uma aplicação de IA generativa. Quais DUAS capacidades dessa combinação são as mais importantes para a aplicação? (Selecione DUAS opções.)",
+        explanation:
+            "A busca por similaridade vetorial encontra o conteúdo semanticamente mais próximo, etapa central de recuperação em RAG, e combinar vetores com dados relacionais permite fazer essa busca junto dos registros que já estão no banco. O Aurora não treina foundation models, não hospeda o endpoint do modelo e não filtra conteúdo tóxico, papel de serviços como o Amazon Bedrock Guardrails.",
+        topic: "RAG e customização",
+        options: [
+            ["Busca por similaridade entre os vetores de embeddings guardados no banco", true],
+            ["Combinar vetores com dados relacionais estruturados em uma mesma consulta", true],
+            ["Treinar foundation models diretamente dentro do cluster do banco de dados", false],
+            ["Hospedar o endpoint de inferência que serve o foundation model da aplicação", false],
+            ["Filtrar conteúdo tóxico das respostas geradas pelo modelo antes de exibi-las", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de supermercados quer um chatbot que consulte o estoque em tempo real e diga ao cliente em que corredor da loja o produto está. Qual técnica de prompt engineering deve usar?",
+        explanation:
+            "O ReAct intercala o raciocínio do modelo com ações explícitas, como chamar a API de estoque, e usa os dados devolvidos para responder, o que permite checar o estoque e informar a localização em tempo real. Few-shot, chain-of-thought e zero-shot orientam o raciocínio ou dão exemplos, mas não oferecem mecanismo para consultar sistemas externos.",
+        topic: "Prompt engineering",
+        options: [
+            ["Prompting ReAct (raciocínio e ação)", true],
+            ["Few-shot prompting (poucos exemplos)", false],
+            ["Chain-of-thought (cadeia de raciocínio)", false],
+            ["Zero-shot prompting (sem exemplos)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer comparar a qualidade da sua ferramenta de tradução automática com a de tradutores humanos, usando traduções de referência dos mesmos documentos. Qual estratégia de avaliação deve usar?",
+        explanation:
+            "O BLEU mede a sobreposição de n-gramas com traduções de referência, então aplicá-lo às saídas da ferramenta e dos tradutores nos mesmos documentos gera pontuações comparáveis para dizer qual método é melhor. O BLEU serve para comparação relativa, não como medida absoluta de qualidade, e o ROUGE foi feito para resumos, não para tradução.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Usar o BLEU para estimar a qualidade relativa dos dois métodos de tradução", true],
+            ["Usar o BLEU para estimar a qualidade absoluta dos dois métodos de tradução", false],
+            ["Usar o ROUGE para estimar a qualidade relativa dos dois métodos de tradução", false],
+            ["Usar o ROUGE para estimar a qualidade absoluta dos dois métodos de tradução", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando um chatbot sobre políticas de RH com base em um LLM e em um grande acervo de documentos digitais, volumoso demais para caber na janela de contexto. A equipe quer otimizar a qualidade das respostas. Qual técnica atende melhor?",
+        explanation:
+            "O RAG busca a cada pergunta os trechos certos e atuais das políticas e fundamenta as respostas neles, melhorando a exatidão sem estourar a janela de contexto. Temperatura 1 só aumenta a aleatoriedade, o fine-tuning é caro, não garante fidelidade ao texto e fica desatualizado, e cortar tokens de entrada tira contexto de que o modelo precisa.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Usar RAG para recuperar os trechos de política mais relevantes a cada pergunta",
+                true,
+            ],
+            ["Definir a temperatura em 1 para o modelo variar mais nas respostas geradas", false],
+            [
+                "Fazer fine-tuning do modelo com os documentos para ele memorizar as políticas",
+                false,
+            ],
+            [
+                "Reduzir o número máximo de tokens de entrada enviados ao modelo em cada chamada",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer um chatbot que responda às dúvidas dos funcionários sobre as políticas internas. As políticas mudam com frequência e as respostas precisam refletir cada atualização quase em tempo real. Qual solução atende a esse requisito?",
+        explanation:
+            "Com RAG, o Amazon Bedrock Knowledge Bases recupera os trechos das políticas no momento da pergunta, então basta atualizar os documentos para a resposta mudar. Fine-tuning e pré-treinamento contínuo exigem novo treino a cada mudança, e um prompt fixo congela o texto do dia do lançamento.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Criar um fluxo de RAG com o Amazon Bedrock Knowledge Bases, que consulta as políticas a cada pergunta",
+                true,
+            ],
+            [
+                "Fazer fine-tuning de um LLM no Amazon SageMaker AI com o texto das políticas vigentes a cada nova versão",
+                false,
+            ],
+            [
+                "Fazer pré-treinamento contínuo de um LLM com os documentos de políticas sempre que houver mudança",
+                false,
+            ],
+            [
+                "Criar um modelo de prompt fixo com o texto das políticas em vigor no dia do lançamento do chatbot",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa aprendizado supervisionado para continuar o treino de um foundation model já pré-treinado, com um conjunto pequeno de dados rotulados voltado a uma tarefa específica. A qual etapa do ciclo de vida do FM isso corresponde?",
+        explanation:
+            "Fine-tuning continua o treino de um modelo já pré-treinado com um conjunto pequeno de exemplos rotulados para uma tarefa específica. Pré-treinamento e pré-treinamento contínuo usam grandes volumes de dados em geral não rotulados, e a implantação coloca o modelo pronto em produção.",
+        topic: "RAG e customização",
+        options: [
+            ["Pré-treinamento", false],
+            ["Pré-treinamento contínuo", false],
+            ["Fine-tuning", true],
+            ["Implantação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de streaming quer que os usuários encontrem imagens do catálogo descrevendo em linguagem natural o que procuram. A solução precisa guardar embeddings em um banco de dados vetorial e fazer buscas por similaridade de vizinhos mais próximos. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon OpenSearch Service funciona como banco de dados vetorial e faz busca k-NN por similaridade sobre embeddings, base da busca em linguagem natural. O Rekognition detecta rótulos em imagens, o Personalize gera recomendações e o Redshift é um data warehouse para análises.",
+        topic: "RAG e customização",
+        options: [
+            ["Amazon OpenSearch Service, com índices k-NN sobre os embeddings", true],
+            ["Amazon Rekognition, com detecção de rótulos nas imagens do catálogo", false],
+            ["Amazon Personalize, com recomendações baseadas no histórico de uso", false],
+            ["Amazon Redshift, com consultas SQL sobre as tabelas do catálogo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer gerar, para o catálogo de produtos, imagens e também descrições em texto, e está comparando foundation models pelos tipos de saída que cada um suporta. Qual característica dos modelos ela está avaliando?",
+        explanation:
+            "Modalidade indica os tipos de entrada e saída que o modelo aceita, como texto, imagem ou áudio, então comparar quem gera imagens e texto é avaliar modalidade. Latência é o tempo de resposta, a janela de contexto limita quantos tokens cabem e o suporte a idiomas trata das línguas atendidas.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Latência", false],
+            ["Tamanho da janela de contexto", false],
+            ["Modalidade", true],
+            ["Suporte a vários idiomas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma loja online quer avaliar um modelo que marca cada comentário de cliente como positivo, negativo ou neutro. Que tipo de tarefa de avaliação de modelo corresponde a esse caso?",
+        explanation:
+            "Classificação atribui cada entrada a uma categoria de um conjunto fixo, como os três sentimentos, e é avaliada com métricas de classificação. Geração aberta produz texto livre, resumo condensa um texto longo e perguntas e respostas devolve uma resposta a uma pergunta, sem rótulos predefinidos.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Geração de texto aberta", false],
+            ["Resumo de texto", false],
+            ["Classificação de texto", true],
+            ["Perguntas e respostas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando uma solução de IA generativa no Amazon Bedrock e precisa de um serviço que armazene embeddings como banco de dados vetorial e execute buscas vetoriais sobre eles. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon OpenSearch Service oferece armazenamento vetorial e busca k-NN por similaridade sobre embeddings, e é um dos bancos vetoriais aceitos pelo Amazon Bedrock Knowledge Bases. O Redshift é um data warehouse, o Glue faz ETL e catálogo de dados e o EMR processa big data, e nenhum deles funciona como banco de dados vetorial.",
+        topic: "RAG e customização",
+        options: [
+            ["Amazon OpenSearch Service, que indexa vetores para busca por similaridade", true],
+            [
+                "Amazon Redshift, que armazena dados tabulares para consultas analíticas em SQL",
+                false,
+            ],
+            ["AWS Glue, que cataloga e transforma dados em pipelines de ETL", false],
+            ["Amazon EMR, que processa grandes volumes de dados com Apache Spark", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está escrevendo os prompts de um assistente de IA generativa e quer respostas mais precisas e no formato esperado. Quais DUAS práticas ela deve adotar? (Selecione DUAS opções.)",
+        explanation:
+            "Contexto e instruções claras dizem ao modelo o que se espera, e exemplos relevantes (few-shot) mostram o formato e o estilo da saída. Encher o prompt de texto irrelevante, usar termos ambíguos ou omitir instruções só acrescenta ruído e ambiguidade e piora as respostas.",
+        topic: "Prompt engineering",
+        options: [
+            ["Dar contexto e instruções claras sobre a tarefa e o resultado esperado", true],
+            ["Incluir exemplos relevantes da saída desejada quando eles ajudarem", true],
+            [
+                "Deixar o prompt o mais longo possível, mesmo com trechos sem relação com a tarefa",
+                false,
+            ],
+            ["Usar termos ambíguos de propósito para estimular a criatividade do modelo", false],
+            ["Omitir as instruções e confiar no comportamento padrão do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa medir a qualidade dos textos gerados por um modelo de IA generativa, comparando as saídas com textos de referência escritos por pessoas. Quais DUAS métricas são comuns nessa avaliação? (Selecione DUAS opções.)",
+        explanation:
+            "BLEU avalia traduções e ROUGE avalia resumos comparando o texto gerado com textos de referência, por isso medem a qualidade da saída. Uso de memória da GPU, vazão de requisições e número de parâmetros são métricas de infraestrutura ou de tamanho do modelo e não dizem nada sobre a qualidade do texto.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["BLEU, usada para medir a qualidade de traduções", true],
+            ["ROUGE, usada para medir a qualidade de resumos", true],
+            ["Uso de memória da GPU durante cada chamada de inferência", false],
+            ["Vazão de requisições atendidas por segundo no endpoint", false],
+            ["Número de parâmetros do modelo, usado para comparar tamanho", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe vai usar o Amazon OpenSearch Service como base da busca semântica de uma aplicação de RAG. Quais DUAS capacidades do serviço são as mais relevantes para esse uso? (Selecione DUAS opções.)",
+        explanation:
+            "Na busca semântica, o OpenSearch guarda os embeddings em índices vetoriais e encontra os mais parecidos com a busca k-NN. BM25 é busca lexical por palavras, não por significado, consultas geoespaciais tratam de localização e o serviço não treina nem faz fine-tuning de foundation models.",
+        topic: "RAG e customização",
+        options: [
+            ["Busca k-NN por vizinhos mais próximos sobre vetores", true],
+            ["Indexação de embeddings como banco de dados vetorial", true],
+            ["Busca textual por palavras-chave com ranqueamento BM25", false],
+            ["Consultas geoespaciais por distância entre coordenadas", false],
+            ["Treinamento e fine-tuning de foundation models dentro do cluster", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer um assistente de IA que consulte fontes de dados específicas, chame APIs externas e depois gere, compare e priorize opções de resposta em várias etapas. Qual recurso da AWS atende a esses requisitos?",
+        explanation:
+            "O Amazon Bedrock AgentCore executa agentes que raciocinam em várias etapas, chamam APIs como ferramentas pelo Gateway e consultam dados antes de responder. O Knowledge Bases só recupera contexto, o Prompt Management guarda e versiona prompts e as avaliações medem modelos, sem orquestrar ações.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Amazon Bedrock AgentCore, para executar agentes que usam ferramentas", true],
+            ["Amazon Bedrock Knowledge Bases, para recuperar trechos dos documentos", false],
+            ["Prompt Management do Amazon Bedrock, para versionar os prompts", false],
+            ["Avaliações do Amazon Bedrock, para comparar o desempenho de modelos", false],
+        ],
+    },
+    {
+        statement:
+            "Ao estudar técnicas de prompt, uma equipe encontra os termos zero-shot, one-shot e few-shot. O que diferencia essas três abordagens?",
+        explanation:
+            "Zero-shot não traz exemplos no prompt, one-shot traz um e few-shot traz alguns, sempre sem treinar o modelo de novo. Os termos não se referem à arquitetura, ao número de etapas de raciocínio (ideia ligada ao chain-of-thought) nem ao volume de dados de fine-tuning.",
+        topic: "Prompt engineering",
+        options: [
+            ["A quantidade de exemplos incluídos no próprio prompt", true],
+            ["A arquitetura de rede neural usada pelo modelo", false],
+            ["O número de etapas de raciocínio que o modelo executa", false],
+            ["O volume de dados usado no fine-tuning do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de ML está treinando um foundation model e a acurácia ainda está abaixo do patamar exigido, sem sinais de overfitting. O que a equipe deve fazer para aumentar a acurácia?",
+        explanation:
+            "Mais épocas fazem o modelo passar mais vezes pelos dados de treino, o que tende a elevar a acurácia enquanto não houver overfitting. Menos épocas dão menos treino, reduzir o batch size mexe na dinâmica e na memória do treino sem garantir ganho, e temperatura é parâmetro de inferência, sem efeito no treino.",
+        topic: "RAG e customização",
+        options: [
+            ["Aumentar o número de épocas de treinamento", true],
+            ["Reduzir o número de épocas de treinamento", false],
+            ["Reduzir o tamanho do lote (batch size)", false],
+            ["Aumentar o parâmetro de temperatura do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma marca de cosméticos quer usar um modelo de IA generativa já pré-treinado para escrever textos de campanha no tom de voz e com as mensagens da marca. Qual abordagem atende a esse objetivo com menor esforço?",
+        explanation:
+            "Prompts claros, com instruções e contexto sobre o tom e as mensagens da marca, orientam o modelo pré-treinado sem mexer nele. Adicionar camadas ou ajustar arquitetura e hiperparâmetros exige reengenharia e novo treino, e pré-treinar um modelo do zero é ainda mais caro e desnecessário aqui.",
+        topic: "Prompt engineering",
+        options: [
+            ["Escrever prompts claros, com instruções e contexto sobre o tom da marca", true],
+            ["Adicionar mais camadas à arquitetura do modelo para aumentar sua capacidade", false],
+            ["Ajustar a arquitetura e os hiperparâmetros para melhorar o desempenho geral", false],
+            ["Coletar um grande conjunto de dados e pré-treinar um novo modelo do zero", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consultoria vai escolher um modelo do Amazon Bedrock para uso interno, e seus analistas dão muito peso ao estilo de escrita das respostas. Como a empresa deve escolher o modelo?",
+        explanation:
+            "Estilo de escrita é preferência subjetiva, então o melhor caminho é uma avaliação humana, com os próprios analistas comparando as respostas dos modelos a prompts da empresa. Conjuntos integrados e rankings públicos medem desempenho geral, não o estilo que os analistas preferem, e o InvocationLatency mede tempo de resposta.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Avaliar os modelos com uma equipe humana e prompts próprios da empresa", true],
+            ["Avaliar os modelos automaticamente com os conjuntos de prompts integrados", false],
+            ["Escolher o modelo mais bem colocado nos rankings públicos de modelos", false],
+            ["Comparar os modelos pela métrica InvocationLatency no Amazon CloudWatch", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer medir a acurácia de um foundation model que classifica imagens antes de colocá-lo em produção. Qual estratégia ela deve usar?",
+        explanation:
+            "Medir a acurácia em um conjunto de benchmark com rótulos conhecidos compara as previsões com as respostas certas, que é o jeito padrão de avaliar um classificador. Contar camadas descreve a arquitetura, o custo dos recursos mede gasto e a fidelidade das cores não tem relação com acertar a classe.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Medir a acurácia em um conjunto de benchmark com rótulos conhecidos", true],
+            ["Contar o número de camadas da rede neural que compõe a arquitetura do modelo", false],
+            ["Calcular o custo total dos recursos consumidos pelo modelo", false],
+            ["Verificar a fidelidade das cores das imagens que o modelo processa", false],
+        ],
+    },
+    {
+        statement:
+            "O chatbot de uma operadora de telecomunicações usa um LLM no Amazon Bedrock para identificar a intenção de cada mensagem do usuário, e a equipe quer melhorar a precisão com few-shot. Que dados de exemplo a equipe precisa incluir no prompt?",
+        explanation:
+            "No few-shot, o prompt traz exemplos de entrada e saída da própria tarefa, e detectar intenção é ligar uma mensagem a uma intenção, então os pares são mensagem e intenção correta. Pares que envolvem respostas do chatbot ensinam outra relação e não mostram como reconhecer a intenção.",
+        topic: "Prompt engineering",
+        options: [
+            ["Pares de mensagens de usuários e as intenções corretas de cada uma", true],
+            ["Pares de mensagens de usuários e as respostas corretas do chatbot", false],
+            ["Pares de respostas do chatbot e as intenções corretas dos usuários", false],
+            ["Pares de intenções dos usuários e as respostas corretas do chatbot", false],
+        ],
+    },
+    {
+        statement:
+            "Durante um teste de red team de um foundation model, um engenheiro tenta contornar os filtros de segurança do modelo para fazê-lo gerar conteúdo nocivo. Como se chama essa técnica?",
+        explanation:
+            "Jailbreak é a tentativa de driblar as proteções de segurança de um modelo com prompts elaborados para obter conteúdo restrito ou nocivo. Fuzzing envia entradas malformadas para achar falhas de software, o pentest autorizado avalia a segurança de sistemas e a negação de serviço ataca a disponibilidade.",
+        topic: "Prompt engineering",
+        options: [
+            ["Jailbreak do modelo por meio de prompts", true],
+            ["Fuzzing dos dados de treinamento do modelo", false],
+            ["Teste de invasão (pentest) autorizado", false],
+            ["Ataque de negação de serviço (DoS)", false],
+        ],
+    },
+    {
+        statement:
+            "Para um recurso de busca conversacional, uma equipe precisa guardar os embeddings gerados pelo modelo em um banco de dados e consultar os vetores mais parecidos com cada pergunta. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon Aurora PostgreSQL com a extensão pgvector armazena embeddings, cria índices vetoriais e executa consultas de similaridade, e também serve de banco vetorial para o Amazon Bedrock Knowledge Bases. O Redshift é um data warehouse analítico, o EMR processa big data e o Glue faz ETL, sem papel de banco vetorial.",
+        topic: "RAG e customização",
+        options: [
+            ["Amazon Aurora PostgreSQL, com a extensão pgvector", true],
+            ["Amazon Redshift, com tabelas colunares para análise", false],
+            ["Amazon EMR, com clusters de processamento Spark", false],
+            ["AWS Glue, com jobs de ETL e catálogo de dados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa adotou um foundation model e agora quer saber se ele realmente atende aos objetivos de negócio que motivaram o projeto. Como a equipe deve fazer essa verificação?",
+        explanation:
+            "Verificar se o modelo resolve os casos de uso específicos que ele precisa atender mostra se as saídas trazem valor para o negócio. Benchmarks medem desempenho geral, não aderência ao caso da empresa, arquitetura e hiperparâmetros são detalhes técnicos e recursos computacionais tratam de custo e viabilidade.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Avaliar se o modelo atende aos casos de uso que ele precisa suportar", true],
+            ["Avaliar o desempenho do modelo em conjuntos de dados de benchmark públicos", false],
+            ["Analisar a arquitetura e os hiperparâmetros usados na construção do modelo", false],
+            ["Medir os recursos computacionais que o modelo exige na implantação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer manter seu foundation model atualizado, treinando-o periodicamente com os dados mais recentes em vez de treinar um modelo do zero a cada vez. Qual estratégia de treinamento atende a esse requisito?",
+        explanation:
+            "O pré-treinamento contínuo retoma o treino do modelo com os dados novos de tempos em tempos e atualiza os pesos sem recomeçar do zero. Aprendizado em lote só descreve como os dados são processados, treinamento estático gera um modelo que não muda e a destilação transfere conhecimento para um modelo menor.",
+        topic: "RAG e customização",
+        options: [
+            ["Pré-treinamento contínuo", true],
+            ["Aprendizado em lote (batch learning)", false],
+            ["Treinamento estático", false],
+            ["Destilação de modelo", false],
+        ],
+    },
+    {
+        statement:
+            "O LLM usado por uma empresa gera alucinações com frequência. Qual mudança pode reduzir esse problema?",
+        explanation:
+            "Reduzir a temperatura diminui a aleatoriedade na escolha dos tokens, e o modelo fica com as saídas mais prováveis, o que tende a reduzir alucinações. O AgentCore executa agentes e não supervisiona treino, não dá para isolar os dados que causam alucinação e nenhum modelo garante que nunca vai alucinar.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Diminuir o valor da temperatura nos parâmetros de inferência do modelo", true],
+            ["Usar o Amazon Bedrock AgentCore para supervisionar o treinamento do modelo", false],
+            ["Pré-processar os dados para remover os trechos que causam alucinações", false],
+            ["Trocar para um foundation model treinado para nunca alucinar", false],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista tem 100 conversas de alta qualidade entre atendentes e clientes e quer que as respostas do seu chatbot sigam o mesmo tom da empresa. Qual solução atende a esse requisito?",
+        explanation:
+            "Um job de fine-tuning no Amazon Bedrock ajusta um foundation model com exemplos rotulados, e as conversas ensinam o tom da empresa. O Personalize é um serviço de recomendações, pré-treinar no HyperPod é treino em larga escala, exagerado para 100 exemplos, e o TensorRT acelera a inferência sem mudar o tom.",
+        topic: "RAG e customização",
+        options: [
+            ["Criar um job de fine-tuning no Amazon Bedrock com as conversas de exemplo", true],
+            ["Usar o Amazon Personalize para gerar as respostas do chatbot", false],
+            ["Criar um job de pré-treinamento no Amazon SageMaker HyperPod", false],
+            [
+                "Hospedar o modelo no Amazon SageMaker AI e otimizar a inferência com TensorRT",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Ao configurar a inferência de um LLM, uma equipe compara a amostragem top-p (nucleus sampling) com o ajuste de temperatura. O que distingue o top-p?",
+        explanation:
+            "O top-p mantém só o menor grupo de tokens mais prováveis cuja probabilidade acumulada chega a p e sorteia entre eles, enquanto a temperatura reescala a distribuição sem cortar candidatos. O top-p não depende de arquitetura, continua sorteando, então a saída pode variar, e não se limita a um único token.",
+        topic: "Aplicações de foundation models",
+        options: [
+            [
+                "Corta os candidatos ao menor grupo cuja probabilidade somada chega a p, enquanto a temperatura reescala a distribuição",
+                true,
+            ],
+            [
+                "Só funciona com algumas arquiteturas de modelo, enquanto a temperatura pode ser usada em qualquer LLM do mercado",
+                false,
+            ],
+            [
+                "Sempre devolve a mesma saída para o mesmo prompt, enquanto a temperatura faz as respostas variarem entre as execuções",
+                false,
+            ],
+            [
+                "Limita a escolha a exatamente um token em cada passo, enquanto a temperatura permite sortear entre todos os tokens candidatos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está integrando um LLM ao seu aplicativo e precisa que as respostas para a mesma entrada sejam tão determinísticas e estáveis quanto possível. Qual solução atende a esse requisito?",
+        explanation:
+            "Com temperatura 0, o modelo escolhe sempre o token mais provável, então a mesma entrada tende a gerar a mesma resposta. Temperatura 1 mantém a aleatoriedade, pedir determinismo no texto do prompt não controla a amostragem e reduzir o número máximo de tokens só encurta a resposta.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Definir o parâmetro temperatura como 0 ao enviar o prompt", true],
+            ["Definir o parâmetro temperatura como 1 ao enviar o prompt", false],
+            ["Acrescentar ao fim do prompt a instrução 'responda de forma determinística'", false],
+            ["Reduzir o número máximo de tokens de saída de cada resposta", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer limitar, a cada passo da geração, quantos tokens candidatos o LLM pode considerar para escolher o próximo token. Qual parâmetro de inferência controla isso?",
+        explanation:
+            "O top-k restringe a amostragem, a cada passo, aos k tokens mais prováveis, então define quantos candidatos o modelo considera. O número máximo de tokens limita o tamanho total da resposta, a temperatura muda a aleatoriedade da distribuição e o tamanho do lote trata de quantas entradas são processadas juntas.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Número máximo de tokens", false],
+            ["Parâmetro temperatura", false],
+            ["Parâmetro top-k", true],
+            ["Tamanho do lote", false],
+        ],
+    },
+    {
+        statement:
+            "Uma agência usa um LLM para sugerir slogans e acha as respostas repetitivas demais. Como ajustar os parâmetros para obter saídas mais diversas e criativas?",
+        explanation:
+            "Temperatura mais alta achata a distribuição de probabilidades e dá mais chance a tokens menos prováveis, o que gera respostas mais variadas e criativas. Diminuir o top-k reduz os candidatos e deixa a saída mais focada, aumentar o tamanho da resposta só a alonga e encurtar o prompt tira contexto sem trazer criatividade.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Aumentar o valor da temperatura", true],
+            ["Diminuir o valor de top-k", false],
+            ["Aumentar o tamanho máximo da resposta", false],
+            ["Diminuir o tamanho do prompt", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai fazer fine-tuning de um LLM no Amazon Bedrock para refinar o estilo das mensagens que seu aplicativo gera. De que tipo de dado a empresa precisa?",
+        explanation:
+            "Para ajustar o estilo, o fine-tuning precisa de exemplos rotulados que liguem cada entrada à saída desejada, e é com esses pares que o modelo aprende o padrão. Só entradas ou só saídas não mostram essa relação, e conjuntos separados sem pareamento não indicam qual saída corresponde a cada entrada.",
+        topic: "RAG e customização",
+        options: [
+            ["Exemplos pareados de mensagens de entrada e das saídas correspondentes", true],
+            ["Amostras apenas das mensagens de entrada, sem as saídas correspondentes", false],
+            ["Amostras apenas das mensagens de saída, sem as entradas que as geraram", false],
+            ["Mensagens de entrada e de saída em conjuntos separados, sem pareamento", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer ajustar, no momento da inferência, o quanto as respostas de um modelo de IA generativa variam entre si. Quais DOIS parâmetros de amostragem servem para controlar essa diversidade? (Selecione DUAS opções.)",
+        explanation:
+            "Top-k restringe o sorteio aos k tokens mais prováveis e top-p ao menor grupo cuja probabilidade acumulada chega a p, e os dois equilibram diversidade e qualidade da saída. Tamanho do modelo, volume de dados de treino e hardware afetam capacidade, custo ou velocidade, mas não são parâmetros de inferência.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Top-k, que limita a escolha aos k tokens mais prováveis", true],
+            ["Tamanho do modelo, medido pelo número total de parâmetros", false],
+            ["Top-p, que limita a escolha pela probabilidade acumulada", true],
+            ["Tamanho do conjunto de dados usado no treinamento", false],
+            ["Configuração do hardware usado para servir o modelo em produção", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de design usa um modelo de difusão para gerar imagens e quer controlar o nível de refinamento de cada imagem, de mais detalhada a mais esboçada. Qual parâmetro de inferência ela deve ajustar?",
+        explanation:
+            "Em modelos de difusão, o número de etapas define quantas vezes a imagem é refinada a partir do ruído: mais etapas trazem mais detalhe, menos etapas deixam a imagem mais crua. O checkpoint escolhe a versão do modelo, o tamanho do lote define quantas imagens saem por vez e o limite de tokens vale para texto.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Número de etapas de geração (steps)", true],
+            ["Checkpoint do modelo carregado na memória", false],
+            ["Tamanho do lote de imagens", false],
+            ["Comprimento máximo em tokens", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe gera imagens com um modelo de difusão e precisa impedir que certos elementos apareçam nos resultados. Qual solução atende a esse requisito?",
+        explanation:
+            "O prompt negativo (negative_prompt) lista os elementos que o modelo deve deixar de fora, então é o jeito direto de excluí-los. Mais aleatoriedade não remove nada, um prompt mais detalhado descreve o que incluir mas não garante a exclusão, e trocar de modelo não cria um mecanismo para isso.",
+        topic: "Prompt engineering",
+        options: [
+            ["Usar um prompt negativo com os elementos a evitar", true],
+            ["Usar um valor de temperatura mais alto na geração", false],
+            ["Escrever um prompt mais detalhado sobre a cena", false],
+            ["Trocar por outro foundation model de imagens", false],
+        ],
+    },
+    {
+        statement:
+            "Uma central de atendimento adotou um chatbot com LLM para reduzir as etapas que os atendentes percorrem ao responder dúvidas de clientes. Qual métrica de negócio mostra melhor se o chatbot está fazendo diferença?",
+        explanation:
+            "Se o chatbot corta etapas do atendente, cada atendimento termina mais rápido, e o tempo médio de atendimento mostra esse efeito diretamente. Responsabilidade social e conformidade regulatória são temas da organização sem relação com a agilidade, e o engajamento no site mede visitantes, não a central.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Tempo médio de atendimento", true],
+            ["Responsabilidade social corporativa", false],
+            ["Conformidade regulatória", false],
+            ["Taxa de engajamento no site", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa já guarda os dados de seus produtos no Amazon Aurora PostgreSQL e pensa em habilitar a extensão pgvector para uma aplicação de IA. Qual é o principal benefício dessa combinação?",
+        explanation:
+            "Com o pgvector, o Aurora PostgreSQL armazena embeddings ao lado dos dados relacionais e faz busca por similaridade com SQL, sem um banco vetorial separado. O Aurora não gera nem treina modelos, não fornece modelos de linguagem, e a opção serverless é forma de implantação, não o benefício do pgvector.",
+        topic: "RAG e customização",
+        options: [
+            ["Fazer busca por similaridade vetorial no próprio banco relacional", true],
+            ["Gerar e treinar modelos de IA automaticamente a partir das tabelas", false],
+            ["Oferecer modelos de linguagem pré-treinados prontos para consulta", false],
+            ["Ganhar capacidade de computação serverless para rodar a aplicação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa mantém vários aplicativos de IA generativa no Amazon Bedrock e quer versionar seus prompts, comparar variantes e voltar a uma versão anterior se a qualidade cair. Qual recurso do Amazon Bedrock atende a esses requisitos?",
+        explanation:
+            "O Prompt Management do Amazon Bedrock cria e guarda prompts, permite testar e comparar variantes e salvar versões, e a aplicação pode apontar de novo para uma versão anterior. Knowledge Bases serve ao RAG, Guardrails filtra conteúdo e as avaliações medem modelos, e nenhum deles controla versões de prompts.",
+        topic: "Prompt engineering",
+        options: [
+            ["Prompt Management, que guarda versões e variantes de prompts", true],
+            ["Knowledge Bases, que indexa documentos para consultas de RAG", false],
+            ["Guardrails, que filtra conteúdo nocivo nas entradas e saídas", false],
+            ["Avaliações, que medem e comparam o desempenho de modelos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa colocou no ar um assistente de IA no Amazon Bedrock para atender solicitações de clientes e quer medir o quanto ele resolve os problemas sem precisar escalar para um atendente humano. Qual métrica captura melhor isso?",
+        explanation:
+            "A taxa de conclusão de tarefas mostra a porcentagem de solicitações que o assistente resolve por completo sem escalar para uma pessoa, o que se liga direto ao objetivo de negócio. BLEU mede qualidade de tradução, perplexidade mede o quanto o modelo prevê bem o texto e o número de parâmetros só indica tamanho.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Taxa de conclusão de tarefas", true],
+            ["Pontuação BLEU", false],
+            ["Perplexidade", false],
+            ["Número de parâmetros do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer saber se sua aplicação de IA generativa está trazendo resultado para o negócio, e não só se o texto gerado é bom. Quais DUAS métricas atendem a esse objetivo? (Selecione DUAS opções.)",
+        explanation:
+            "Satisfação dos usuários mostra se a aplicação atende quem a usa e custo por interação mostra quanto cada atendimento custa, e as duas se ligam a resultados de negócio. BERTScore e ROUGE medem a qualidade técnica do texto contra referências, e o tempo de treinamento é métrica operacional, sem dizer se a meta foi atingida.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Satisfação dos usuários com as respostas recebidas", true],
+            ["BERTScore das respostas em relação a textos de referência", false],
+            ["Custo médio de cada interação atendida", true],
+            ["Pontuação ROUGE dos resumos gerados pelo modelo", false],
+            ["Tempo gasto no treinamento do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está montando um grafo de conhecimento e precisa guardar embeddings e fazer buscas por similaridade junto com as travessias do grafo, no mesmo banco. Qual serviço de banco de dados da AWS oferece consultas de grafo e busca vetorial?",
+        explanation:
+            "O Amazon Neptune Analytics guarda o grafo e um índice vetorial no mesmo lugar, então dá para combinar travessias com busca por vizinhos mais próximos. DynamoDB e ElastiCache até oferecem busca vetorial, mas não consultas de grafo, e o Redshift é um data warehouse analítico.",
+        topic: "RAG e customização",
+        options: [
+            ["Amazon Neptune Analytics, grafos com índice vetorial", true],
+            ["Amazon DynamoDB, banco chave-valor com índices vetoriais", false],
+            ["Amazon Redshift, data warehouse com tabelas colunares", false],
+            ["Amazon ElastiCache, cache em memória com busca vetorial", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa gera textos longos de marketing com um foundation model e quer avaliar a qualidade em grande escala sem depender de revisores humanos. Qual abordagem usa um segundo LLM para dar nota às respostas?",
+        explanation:
+            "Na abordagem de LLM como juiz, um segundo modelo avalia e pontua as respostas segundo critérios definidos, o que escala sem revisores humanos, e as avaliações do Amazon Bedrock oferecem esse tipo de job. BLEU depende de textos de referência, o benchmark usa respostas conhecidas e o teste A/B precisa de usuários reais.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["LLM como juiz (LLM-as-a-judge)", true],
+            ["Pontuação BLEU contra textos de referência", false],
+            ["Comparação com um conjunto de dados de benchmark", false],
+            ["Teste A/B com usuários reais", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa colocou em produção um assistente de suporte baseado em RAG e quer verificar se a etapa de recuperação traz documentos relevantes para as perguntas dos usuários. Qual abordagem a equipe deve usar?",
+        explanation:
+            "Avaliar a recuperação é conferir se os trechos trazidos para perguntas de teste batem com os documentos que deveriam vir, medindo precisão e recall, como faz a avaliação de RAG do Amazon Bedrock com dados de referência. Perplexidade mede o modelo de linguagem, contar chamadas mede uso e BLEU avalia texto gerado.",
+        topic: "RAG e customização",
+        options: [
+            [
+                "Comparar trechos recuperados com os documentos esperados em perguntas de teste",
+                true,
+            ],
+            [
+                "Medir a perplexidade do modelo de linguagem em um conjunto de dados separado para teste",
+                false,
+            ],
+            ["Contar o total de chamadas de API feitas ao Amazon Bedrock no período", false],
+            ["Calcular a pontuação BLEU das respostas finais geradas pelo modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa envia milhares de vezes por dia o mesmo prompt de sistema longo, e só a pergunta do usuário muda entre as chamadas. Ao escolher o foundation model, qual critério mais ajuda a reduzir latência e custo nesse cenário?",
+        explanation:
+            "Com cache de prompt, o prefixo repetido fica guardado e não é reprocessado a cada chamada, o que reduz latência e custo de tokens de entrada, e o suporte varia por modelo no Amazon Bedrock. Suporte a idiomas trata de cobertura linguística, complexidade da arquitetura liga-se à capacidade e difusão serve para imagens.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Suporte a cache de prompt", true],
+            ["Suporte a vários idiomas", false],
+            ["Complexidade da arquitetura do modelo", false],
+            ["Capacidade de difusão", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa um foundation model grande no Amazon Bedrock, mas o custo de inferência ficou alto demais. Ela quer um modelo menor e mais barato que mantenha a maior parte da qualidade do modelo grande. Qual abordagem de customização atende a esse requisito?",
+        explanation:
+            "Na destilação, um modelo menor (student) aprende a imitar as respostas de um modelo maior (teacher) e fica mais rápido e barato, mantendo boa parte da qualidade, recurso do Amazon Bedrock Model Distillation. RAG traz documentos sem encolher o modelo, o pré-treinamento contínuo atualiza conhecimento e o aprendizado em contexto aumenta os tokens do prompt.",
+        topic: "RAG e customização",
+        options: [
+            ["Destilação de modelo", true],
+            ["Geração aumentada por recuperação (RAG)", false],
+            ["Pré-treinamento contínuo", false],
+            ["Aprendizado em contexto", false],
+        ],
+    },
+    {
+        statement:
+            "Uma agência de viagens quer que, a partir de um único pedido do cliente, um sistema de IA consulte a disponibilidade de voos, compare preços entre companhias aéreas, emita as passagens e envie o e-mail de confirmação. Qual solução atende a esse requisito?",
+        explanation:
+            "Um agente de IA divide o pedido em etapas (buscar voos, comparar preços, emitir passagens e enviar a confirmação) e executa cada uma chamando as ferramentas e APIs certas. Um modelo de sumarização só condensa texto, a classificação só encaminha pedidos e a recomendação só sugere itens, sem executar ações.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Um agente de IA que orquestra as etapas chamando ferramentas e APIs", true],
+            ["Um modelo de sumarização que resume as ofertas de voos disponíveis", false],
+            ["Um modelo de classificação que encaminha o pedido ao setor responsável", false],
+            ["Um mecanismo de recomendação que sugere os voos mais procurados", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista percebe que as respostas de um foundation model mudam muito de qualidade conforme a forma como ele redige o pedido. Quais DUAS práticas de prompt engineering tendem a melhorar esses resultados? (Selecione DUAS opções.)",
+        explanation:
+            "Instruções específicas e concisas deixam claro o que se espera, e testar estruturas diferentes e iterar mostra o que funciona melhor em cada tarefa. Linguagem vaga cria ambiguidade, encher o prompt até o limite de tokens gasta tokens com conteúdo irrelevante e tirar todo o contexto priva o modelo de informação necessária.",
+        topic: "Prompt engineering",
+        options: [
+            ["Ser específico e conciso nas instruções da tarefa", true],
+            ["Usar linguagem vaga para dar mais liberdade criativa ao modelo", false],
+            ["Testar estruturas diferentes de prompt e iterar sobre elas", true],
+            ["Preencher sempre o prompt até o limite máximo de tokens", false],
+            ["Evitar qualquer contexto para manter o prompt curto", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep-d4.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep-d4.ts
@@ -1,0 +1,569 @@
+// Questões do simulado AWS Certified AI Practitioner (AIF-C01), domínio 4 da prova
+// (Guidelines for Responsible AI), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aif-c01-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D4: Questao[] = [
+    {
+        statement:
+            "Uma empresa de logística usa modelos de ML para prever a demanda a cada trimestre. Um analista prepara um relatório para que as partes interessadas entendam como os modelos treinados chegam às previsões. O que o analista deve incluir para atender às necessidades de transparência e explicabilidade?",
+        explanation:
+            "Gráficos de dependência parcial (PDPs) mostram como uma ou mais variáveis de entrada influenciam a previsão, o que explica às partes interessadas como os modelos chegam aos resultados. Código-fonte e amostras de treino mostram implementação e insumos, não a influência das variáveis, e tabelas de convergência descrevem o treino, não o comportamento do modelo.",
+        topic: "IA responsável",
+        options: [
+            ["Gráficos de dependência parcial (PDPs) das variáveis de entrada", true],
+            ["Amostras dos dados usados no treinamento dos modelos de demanda", false],
+            ["Tabelas de convergência registradas durante o treinamento dos modelos", false],
+            ["Código-fonte usado para treinar os modelos de previsão da demanda", false],
+        ],
+    },
+    {
+        statement:
+            "Um laboratório de pesquisa precisa classificar amostras genéticas em 20 categorias de acordo com suas características. A equipe exige um algoritmo cuja lógica interna possa ser documentada como uma sequência de regras legíveis que leva a cada resultado. Qual algoritmo atende a essa necessidade?",
+        explanation:
+            "Árvores de decisão expõem a lógica interna como uma sequência de divisões legíveis, então a equipe documenta o caminho de cada amostra até uma das 20 categorias. Redes neurais são opacas, a regressão linear prevê valores contínuos e a regressão logística se explica por coeficientes, não por regras de decisão encadeadas.",
+        topic: "IA responsável",
+        options: [
+            ["Árvores de decisão", true],
+            ["Regressão logística", false],
+            ["Redes neurais", false],
+            ["Regressão linear", false],
+        ],
+    },
+    {
+        statement:
+            "Uma plataforma de mídia vai usar um large language model (LLM) na moderação de conteúdo e quer verificar se as saídas do modelo têm viés ou tratam grupos específicos de forma injusta. Qual fonte de dados permite essa avaliação com o menor esforço administrativo?",
+        explanation:
+            "Conjuntos de dados de benchmark são padronizados e curados justamente para medir viés e justiça, então permitem avaliar as saídas do LLM de forma consistente e com pouco esforço. Registros de moderação e conteúdo de usuários exigiriam rotulagem e revisão manuais, e diretrizes internas são documentos de política, não dados para medir viés.",
+        topic: "IA responsável",
+        options: [
+            ["Conjuntos de dados de benchmark, padronizados e já curados", true],
+            ["Registros de moderação, com as decisões tomadas pela equipe", false],
+            ["Conteúdo gerado pelos usuários, coletado direto da plataforma", false],
+            ["Diretrizes internas de moderação, com as regras da empresa", false],
+        ],
+    },
+    {
+        statement:
+            "Uma financeira está criando uma solução de IA generativa que oferece descontos a novos clientes com base em regras de negócio. Para usar o modelo de forma responsável e limitar vieses que possam prejudicar parte dos clientes, quais duas ações a empresa deve tomar? (Selecione DUAS opções.)",
+        explanation:
+            "Verificar desequilíbrios nos dados revela e reduz vieses que prejudicariam alguns clientes, e avaliar o comportamento do modelo permite explicar as decisões com transparência. Frequência de execução e tempo de inferência são questões operacionais, e a ROUGE mede a sobreposição do texto gerado com uma referência, sem detectar viés.",
+        topic: "IA responsável",
+        options: [
+            ["Verificar nos dados desequilíbrios ou disparidades entre grupos de clientes", true],
+            [
+                "Avaliar o comportamento do modelo para dar transparência às partes interessadas",
+                true,
+            ],
+            ["Executar o modelo com a maior frequência possível ao longo do dia", false],
+            [
+                "Usar a métrica ROUGE para medir a qualidade dos textos gerados pelo modelo nas ofertas",
+                false,
+            ],
+            ["Manter o tempo de inferência do modelo dentro dos limites aceitos", false],
+        ],
+    },
+    {
+        statement:
+            "Um estudante entrega redações copiando textos produzidos por uma ferramenta de IA generativa, sem indicar a origem. Qual desafio de IA responsável essa situação ilustra?",
+        explanation:
+            "Reaproveitar texto gerado por IA como trabalho próprio, sem indicar a origem, é plágio, um risco de IA responsável ligado à propriedade intelectual. Toxicidade é conteúdo ofensivo ou nocivo, alucinação é informação inventada com aparência plausível e violação de privacidade envolve expor dados pessoais.",
+        topic: "IA responsável",
+        options: [
+            ["Plágio de conteúdo", true],
+            ["Toxicidade do conteúdo", false],
+            ["Alucinação do modelo", false],
+            ["Violação de privacidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma loja usa um modelo de ML, treinado com imagens gravadas em poucas unidades de bairros com público pouco diverso, para analisar as câmeras em busca de possíveis furtos. O modelo sinaliza pessoas de um grupo étnico com frequência muito maior do que as de outros grupos. Que tipo de viés está influenciando o resultado do modelo?",
+        explanation:
+            "Viés de amostragem surge quando os dados de treinamento não representam bem toda a população, o que leva o modelo a sinalizar um grupo étnico muito mais que os outros. Viés de medição vem de erros sistemáticos no registro dos dados, e os vieses de confirmação e do observador tratam de como pessoas interpretam ou rotulam resultados.",
+        topic: "IA responsável",
+        options: [
+            ["Viés de medição", false],
+            ["Viés de amostragem", true],
+            ["Viés de confirmação", false],
+            ["Viés do observador", false],
+        ],
+    },
+    {
+        statement:
+            "Um hospital colocou em produção no Amazon Bedrock um modelo de detecção de doenças. Para cumprir as regras de privacidade, o modelo nunca pode expor dados pessoais de pacientes nas respostas, e a equipe deve ser avisada sempre que houver uma tentativa de exposição. Qual solução atende a esses requisitos?",
+        explanation:
+            "O Amazon Bedrock Guardrails, com filtros de informações sensíveis, bloqueia ou mascara dados pessoais nas respostas, e alarmes do CloudWatch sobre a métrica InvocationsIntervened avisam a equipe. O Macie descobre dados sensíveis no Amazon S3, o CloudTrail registra chamadas de API e o Inspector procura vulnerabilidades em cargas de trabalho, e nenhum deles filtra respostas.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Aplicar o Amazon Bedrock Guardrails às respostas e criar alarmes no Amazon CloudWatch",
+                true,
+            ],
+            [
+                "Usar o Amazon Macie para verificar as respostas do modelo e gerar alertas de exposição",
+                false,
+            ],
+            [
+                "Configurar o AWS CloudTrail para inspecionar as respostas e alertar sobre dados pessoais",
+                false,
+            ],
+            [
+                "Usar o Amazon Inspector para verificar vulnerabilidades no modelo e alertar a equipe",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma seguradora vai implantar um large language model (LLM) para automatizar o processamento de documentos e quer fazer isso de forma responsável, evitando danos causados por decisões enviesadas. Quais duas ações a empresa deve tomar? (Selecione DUAS opções.)",
+        explanation:
+            "Métricas de justiça (fairness) na avaliação mostram se o modelo trata os casos de forma equitativa, e ajustar os dados de treinamento ataca o viés na origem. Temperatura e prompt engineering mudam o estilo e a qualidade das respostas, e evitar overfitting melhora a generalização, mas nenhum desses limita resultados enviesados.",
+        topic: "IA responsável",
+        options: [
+            ["Incluir métricas de justiça (fairness) na avaliação do modelo", true],
+            ["Ajustar os dados de treinamento para reduzir o viés", true],
+            ["Ajustar o parâmetro de temperatura para respostas mais previsíveis", false],
+            ["Evitar overfitting nos dados de treinamento do modelo", false],
+            ["Aplicar técnicas de prompt engineering nas instruções", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de pesquisa cria modelos de ML próprios e compartilha os artefatos dos modelos com outras equipes, mas mantém consigo o código e os dados de treinamento. A equipe quer uma forma padronizada de documentar cada modelo publicado e auditá-lo depois. Qual solução a equipe deve usar?",
+        explanation:
+            "Os Amazon SageMaker Model Cards padronizam a documentação do modelo, com usos pretendidos, detalhes de treinamento e avaliação, e guardam versões para auditoria. Documentos soltos no S3 não seguem um padrão, o Git versiona código e não metadados do modelo, e os AWS AI Service Cards descrevem os serviços de IA da própria AWS.",
+        topic: "IA responsável",
+        options: [
+            [
+                "Criar Amazon SageMaker Model Cards com usos pretendidos e detalhes de treinamento",
+                true,
+            ],
+            [
+                "Descrever os modelos em documentos de texto e armazená-los em um bucket do Amazon S3",
+                false,
+            ],
+            [
+                "Versionar os scripts de treinamento dos modelos em um repositório Git compartilhado",
+                false,
+            ],
+            [
+                "Usar os AWS AI Service Cards para descrever os modelos criados e publicados pela equipe",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um banco quer criar um sistema de ML para ajudar a equipe de risco a decidir a concessão de empréstimos para diferentes grupos demográficos. O que o banco deve fazer para desenvolver um modelo sem viés?",
+        explanation:
+            "Medir o desequilíbrio de classes e adaptar o treinamento, por exemplo com reamostragem ou pesos por classe, faz o modelo tratar com equidade os grupos sub-representados. Reduzir os dados tira informação e pode piorar o viés, reproduzir resultados históricos carrega discriminação passada e modelos separados por grupo aprofundam disparidades.",
+        topic: "IA responsável",
+        options: [
+            ["Medir o desequilíbrio de classes nos dados de treino e ajustar o treinamento", true],
+            ["Reduzir o tamanho do conjunto de dados de treino para acelerar o processo", false],
+            [
+                "Garantir que as previsões do modelo reproduzam os resultados históricos do banco",
+                false,
+            ],
+            ["Criar um modelo separado para cada grupo demográfico atendido pelo banco", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando um aplicativo que usa a câmera do celular para avaliar picadas de insetos. Para treinar o modelo de classificação de imagens, a empresa reúne fotos de picadas em pessoas de diferentes gêneros, etnias e regiões. Qual princípio de IA responsável essa prática reflete?",
+        explanation:
+            "Reunir fotos de pessoas de diferentes gêneros, etnias e regiões evita que o modelo funcione melhor para alguns grupos do que para outros, o que reflete o princípio de justiça (fairness). Explicabilidade e transparência tratam de revelar como o modelo chega às saídas, e governança trata de políticas e supervisão.",
+        topic: "IA responsável",
+        options: [
+            ["Explicabilidade", false],
+            ["Transparência", false],
+            ["Justiça", true],
+            ["Governança", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco está criando uma solução de decisão de empréstimos com base em um foundation model. Para fins de auditoria e supervisão, as decisões do modelo precisam ser explicáveis. Qual fator mais afeta a explicabilidade dessas decisões?",
+        explanation:
+            "A complexidade do modelo é o que mais pesa na explicabilidade: modelos simples, como regressão linear e árvores de decisão, são fáceis de interpretar, enquanto redes neurais profundas funcionam como caixas-pretas. Tempo de treinamento, número de hiperparâmetros e tempo de implantação dizem respeito a construir e operar o modelo, não a interpretá-lo.",
+        topic: "IA responsável",
+        options: [
+            ["Complexidade do modelo", true],
+            ["Tempo de treinamento", false],
+            ["Número de hiperparâmetros", false],
+            ["Tempo de implantação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer um aplicativo de pontuação de leads em que os funcionários possam ver e ajustar o peso dado a cada variável de entrada, com base no conhecimento que têm do negócio. Que tipo de modelo de ML atende a esse requisito?",
+        explanation:
+            "A regressão logística atribui um peso explícito (coeficiente) a cada variável de entrada, então os funcionários veem a contribuição de cada uma e podem ajustá-la. O k-NN prevê a partir de vizinhos próximos, sem pesos por variável, e redes neurais e deep learning sobre componentes principais não expõem pesos simples e ajustáveis.",
+        topic: "IA responsável",
+        options: [
+            ["Modelo de regressão logística", true],
+            ["Modelo k-nearest neighbors (k-NN)", false],
+            ["Modelo de rede neural", false],
+            ["Modelo de deep learning sobre componentes principais", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer reduzir o viés e a toxicidade das respostas de sua aplicação de IA generativa. Qual técnica ela pode aplicar na etapa de pós-processamento do ciclo de vida de ML?",
+        explanation:
+            "No pós-processamento, a revisão humana (human-in-the-loop) avalia as saídas antes que cheguem aos usuários e corrige respostas enviesadas ou tóxicas. Aumento de dados e engenharia de features atuam nos dados antes ou durante o treino, e o treinamento adversarial fortalece o modelo durante o treino, não depois da geração.",
+        topic: "IA responsável",
+        options: [
+            ["Revisão humana das saídas (human-in-the-loop)", true],
+            ["Aumento de dados (data augmentation)", false],
+            ["Engenharia de features (feature engineering)", false],
+            ["Treinamento adversarial (adversarial training)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados vai documentar seus modelos de IA com o Amazon SageMaker Model Cards. Qual é um benefício dessa prática?",
+        explanation:
+            "Os Amazon SageMaker Model Cards padronizam o registro da finalidade, do desempenho e das limitações de cada modelo, o que apoia transparência, governança e acompanhamento ao longo do tempo. Eles não reduzem requisitos computacionais nem armazenam modelos para arquivamento, e um resumo visual atraente é detalhe de apresentação, não o benefício central.",
+        topic: "IA responsável",
+        options: [
+            ["Padronizar as informações sobre finalidade, desempenho e limitações do modelo", true],
+            ["Reduzir os requisitos computacionais gerais do modelo em produção", false],
+            [
+                "Gerar um resumo visualmente atraente das capacidades do modelo para o público",
+                false,
+            ],
+            ["Armazenar fisicamente os artefatos dos modelos para fins de arquivamento", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa desenvolve um modelo de IA em parceria com vários institutos de pesquisa e precisa de uma documentação padronizada que acompanhe as versões do modelo e registre como ele foi desenvolvido. Qual solução atende a esses requisitos?",
+        explanation:
+            "Os Amazon SageMaker Model Cards oferecem um formato padronizado para documentar o modelo, e cada edição gera uma nova versão do card, com registro imutável das mudanças. O Git versiona código, não documentação padronizada do modelo, o Comprehend faz processamento de linguagem natural e o S3 só armazena objetos, sem estrutura de documentação.",
+        topic: "IA responsável",
+        options: [
+            ["Acompanhar as mudanças do modelo com o Amazon SageMaker Model Cards", true],
+            ["Acompanhar as mudanças do modelo em um repositório Git compartilhado", false],
+            ["Acompanhar as mudanças do modelo com análises do Amazon Comprehend", false],
+            ["Acompanhar as mudanças do modelo em planilhas guardadas no Amazon S3", false],
+        ],
+    },
+    {
+        statement:
+            "Um hospital criou um sistema de IA que faz recomendações de tratamento personalizadas para pacientes. O sistema precisa explicar o raciocínio por trás de cada recomendação e tornar essas informações acessíveis a médicos e pacientes. Qual princípio de design centrado no ser humano isso reflete?",
+        explanation:
+            "Explicar o raciocínio de cada recomendação e torná-lo acessível a médicos e pacientes é explicabilidade, princípio de design centrado no ser humano que torna as decisões da IA compreensíveis. Privacidade e segurança protegem os dados, justiça busca resultados equitativos entre grupos e governança de dados define políticas de gestão dos dados.",
+        topic: "IA responsável",
+        options: [
+            ["Governança de dados", false],
+            ["Privacidade e segurança", false],
+            ["Explicabilidade", true],
+            ["Justiça", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de varejo quer criar um modelo de recomendação de produtos seguindo práticas responsáveis. Qual prática ela deve adotar na coleta de dados para reduzir o viés do modelo?",
+        explanation:
+            "Coletar dados que representem toda a base de clientes evita que o modelo favoreça um grupo e ajuda a tratar todos com equidade, o que reduz o viés. Usar só os clientes mais ativos ou um único segmento de alto valor gera dados distorcidos, e o menor conjunto que treina rápido tende a sub-representar grupos.",
+        topic: "IA responsável",
+        options: [
+            ["Garantir que os dados representem toda a base de clientes da empresa", true],
+            ["Usar apenas os dados dos clientes mais ativos e frequentes da empresa", false],
+            ["Coletar dados de um único segmento de clientes de alto valor", false],
+            ["Usar o menor conjunto de dados que permita treinar o modelo rápido", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de alimentos está montando um conjunto de dados para prever as preferências alimentares dos clientes e quer que as preferências de todos os grupos demográficos estejam representadas nos dados. Que característica do conjunto de dados isso descreve?",
+        explanation:
+            "Garantir que todos os grupos demográficos estejam representados é cuidar da diversidade do conjunto de dados, para que o modelo aprenda com uma ampla variedade de preferências. Acurácia e confiabilidade tratam da correção e da consistência dos dados, e viés de recência é a falha de dar peso demais a dados recentes.",
+        topic: "IA responsável",
+        options: [
+            ["Acurácia", false],
+            ["Diversidade", true],
+            ["Viés de recência", false],
+            ["Confiabilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA está criando um modelo de ML e quer dar às partes interessadas transparência e explicabilidade sobre as previsões do modelo. Qual solução atende a esse requisito?",
+        explanation:
+            "Os valores de Shapley (SHAP) quantificam quanto cada variável contribuiu para uma previsão específica, o que mostra às partes interessadas por que o modelo chegou àquele resultado. Acurácia e matriz de confusão medem o desempenho geral sem explicar previsões, e um endpoint de inferência seguro trata de implantação e acesso.",
+        topic: "IA responsável",
+        options: [
+            ["Apresentar os valores de Shapley (SHAP) das previsões do modelo", true],
+            ["Informar a medida de acurácia obtida pelo modelo nos testes", false],
+            ["Apresentar a matriz de confusão calculada na avaliação do modelo", false],
+            ["Disponibilizar um endpoint de inferência seguro para o modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco está criando uma aplicação de IA generativa para decisões de aprovação de empréstimos e precisa que as saídas sejam responsáveis e justas. Qual solução atende a esses requisitos?",
+        explanation:
+            "Revisar os dados de treino quanto a viés e incluir todos os grupos demográficos reduz resultados enviesados na origem, base de uma aplicação de crédito responsável e justa. Muitas camadas ocultas reduzem a explicabilidade sem tratar a justiça, manter o processo em segredo fere a transparência e um teste estático único não detecta nem corrige viés nos dados.",
+        topic: "IA responsável",
+        options: [
+            [
+                "Revisar os dados de treino quanto a viés e incluir todos os grupos demográficos",
+                true,
+            ],
+            [
+                "Usar um modelo de deep learning com muitas camadas ocultas para ganhar precisão",
+                false,
+            ],
+            [
+                "Manter em segredo o processo de decisão do modelo para proteger algoritmos proprietários",
+                false,
+            ],
+            [
+                "Monitorar o modelo continuamente com um único conjunto de dados de teste estático",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem um modelo de ML e quer entender como ele chega às suas previsões. Qual termo descreve essa compreensão das previsões de um modelo?",
+        explanation:
+            "Interpretabilidade do modelo é a capacidade de entender como o modelo chega às previsões, exatamente o que a empresa busca. Treinamento é o processo de ajustar o modelo aos dados, desempenho preditivo mede o quanto ele acerta e interoperabilidade trata de funcionar com outros sistemas, e nenhum descreve compreender o raciocínio.",
+        topic: "IA responsável",
+        options: [
+            ["Interpretabilidade do modelo", true],
+            ["Treinamento do modelo", false],
+            ["Desempenho preditivo do modelo", false],
+            ["Interoperabilidade do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco usa um modelo de IA generativa para definir limites de crédito de novos clientes e quer tornar o processo de decisão do modelo mais transparente para esses clientes. Qual solução atende a esse requisito?",
+        explanation:
+            "Técnicas de IA explicável revelam os fatores que pesaram em cada limite de crédito, tornando o raciocínio do modelo transparente para os clientes. Trocar o modelo por regras muda a abordagem em vez de explicá-la, explicações técnicas detalhadas não mostram quais fatores definiram a decisão e mais acurácia não torna o processo transparente.",
+        topic: "IA responsável",
+        options: [
+            ["Aplicar técnicas de IA explicável que mostrem os fatores de cada decisão", true],
+            ["Substituir o modelo de ML por um sistema baseado em regras fixas de crédito", false],
+            [
+                "Criar uma interface interativa com explicações técnicas detalhadas sobre o sistema",
+                false,
+            ],
+            ["Aumentar a acurácia do modelo para reduzir a necessidade de transparência", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai lançar um assistente de IA generativa no Amazon Bedrock e quer reduzir o risco de conteúdo nocivo: medir a toxicidade dos modelos candidatos antes do lançamento e filtrar entradas e respostas em produção. Quais dois recursos do Amazon Bedrock atendem a esses requisitos? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Bedrock Evaluations mede toxicidade e robustez dos modelos antes do lançamento, e o Amazon Bedrock Guardrails filtra conteúdo nocivo nas entradas e respostas em produção. Fine-tuning, Prompt Management e Knowledge Bases melhoram a capacidade, o reúso de prompts e o contexto das respostas, mas nenhum mede toxicidade nem filtra conteúdo.",
+        topic: "IA responsável",
+        options: [
+            ["Amazon Bedrock Guardrails, com filtros de conteúdo nas entradas e respostas", true],
+            ["Amazon Bedrock Evaluations, com métricas de toxicidade e robustez", true],
+            ["Personalização de modelos com fine-tuning em dados da empresa", false],
+            ["Amazon Bedrock Prompt Management, para versionar e reutilizar prompts", false],
+            ["Amazon Bedrock Knowledge Bases, para buscar contexto em documentos internos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa farmacêutica vai treinar o próprio large language model (LLM) com dados privados e quer limitar a pegada de carbono do treinamento. Qual família de instâncias do Amazon EC2 tem o menor impacto ambiental para treinar LLMs?",
+        explanation:
+            "As instâncias Trn usam o AWS Trainium, chip criado para treinar modelos grandes com eficiência energética, e a AWS as indica para reduzir o impacto ambiental do treino. As famílias P e G usam GPUs otimizadas para desempenho, não para eficiência energética, e a família C usa CPUs de computação geral, sem aceleração para LLMs.",
+        topic: "IA responsável",
+        options: [
+            ["Instâncias Amazon EC2 Trn, com chips AWS Trainium", true],
+            ["Instâncias Amazon EC2 P, com GPUs de alto desempenho", false],
+            ["Instâncias Amazon EC2 G, com GPUs para gráficos e ML", false],
+            ["Instâncias Amazon EC2 C, otimizadas para computação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma comunidade de jogos online usa o Amazon Bedrock Guardrails para barrar entradas de usuários e respostas do modelo com conteúdo nocivo. Quais duas opções são categorias predefinidas dos filtros de conteúdo do Guardrails? (Selecione DUAS opções.)",
+        explanation:
+            "Os filtros de conteúdo do Amazon Bedrock Guardrails têm categorias predefinidas, como ódio, insultos, sexual, violência, má conduta e ataque de prompt, aplicadas a entradas e respostas. Política, apostas e criptomoedas não são categorias predefinidas; assuntos assim só seriam barrados com tópicos negados criados pela empresa.",
+        topic: "IA responsável",
+        options: [
+            ["Ódio", true],
+            ["Violência", true],
+            ["Política", false],
+            ["Apostas", false],
+            ["Criptomoedas", false],
+        ],
+    },
+    {
+        statement:
+            "O responsável por um fórum online quer impedir que usuários publiquem conteúdo discriminatório e planeja usar o Amazon Bedrock. Como ele pode usar o Amazon Bedrock para atender a esse requisito?",
+        explanation:
+            "Com o Amazon Bedrock Guardrails, o fórum define tópicos negados e usa filtros de conteúdo, como a categoria de ódio, para bloquear entradas e saídas discriminatórias. Restringir as conversas a tópicos permitidos limitaria o uso normal sem mirar o conteúdo nocivo, e interagir por preferência ou escolher entre respostas não filtra nada.",
+        topic: "IA responsável",
+        options: [
+            ["Bloquear interações ligadas a tópicos ou categorias proibidos de antemão", true],
+            [
+                "Restringir as conversas a uma lista de tópicos permitidos definida previamente",
+                false,
+            ],
+            ["Permitir que os usuários interajam conforme suas preferências pessoais", false],
+            [
+                "Oferecer várias respostas possíveis para que os usuários escolham a mais adequada",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe treina um modelo que gera imagens de pessoas em diversas profissões, mas dados desbalanceados distorcem certos atributos e introduzem viés. Qual técnica resolve esse problema?",
+        explanation:
+            "Aumentar os dados para equilibrar as classes sub-representadas reduz a distorção que causa o viés, atacando o problema na origem. Monitorar a distribuição só detecta o desequilíbrio, treinar mais épocas nos mesmos dados reforça o viés e filtros de saída barram resultados sem corrigir o conjunto de dados.",
+        topic: "IA responsável",
+        options: [
+            ["Aumentar os dados para equilibrar as classes sub-representadas", true],
+            ["Monitorar a distribuição das classes depois da implantação", false],
+            ["Treinar por mais épocas com os mesmos dados desbalanceados", false],
+            ["Aplicar filtros de saída mais rígidos às imagens geradas pelo modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma auditoria descobriu que o modelo de aprovação de empréstimos de um banco, ajustado com fine-tuning, favorece um grupo demográfico. Qual é a correção de melhor custo-benefício?",
+        explanation:
+            "Adicionar dados diversos e representativos e refazer o fine-tuning do modelo existente ensina o modelo a tratar os grupos de forma justa, com custo bem menor. RAG traz contexto externo sem corrigir o viés aprendido, pré-treinar um modelo novo é muito mais caro e o Guardrails filtra conteúdo nocivo, não o viés demográfico das decisões.",
+        topic: "IA responsável",
+        options: [
+            ["Adicionar dados diversos e representativos e refazer o fine-tuning", true],
+            ["Usar Retrieval Augmented Generation (RAG) com o modelo já ajustado", false],
+            ["Pré-treinar um modelo totalmente novo com dados mais diversos", false],
+            ["Aplicar o Amazon Bedrock Guardrails para bloquear as saídas enviesadas", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de newsletter com Retrieval Augmented Generation (RAG) no Amazon Bedrock está trazendo conteúdo com viés político. Qual recurso do Amazon Bedrock Guardrails pode filtrar esse conteúdo?",
+        explanation:
+            "Tópicos negados permitem definir assuntos que o modelo deve evitar, como política, e o Guardrails bloqueia entradas e respostas sobre eles. Filtros de palavras barram só termos exatos, filtros de conteúdo cobrem categorias como ódio e violência, e filtros de informações sensíveis bloqueiam ou mascaram dados como PII.",
+        topic: "IA responsável",
+        options: [
+            ["Filtros de palavras (word filters)", false],
+            ["Filtros de conteúdo (content filters)", false],
+            ["Tópicos negados (denied topics)", true],
+            ["Filtros de informações sensíveis (sensitive information filters)", false],
+        ],
+    },
+    {
+        statement:
+            "O chatbot de uma loja online precisa filtrar conteúdo nocivo tanto nos prompts dos usuários quanto nas próprias respostas. Qual recurso do Amazon Bedrock atende a esse requisito?",
+        explanation:
+            "O Amazon Bedrock Guardrails aplica filtros de conteúdo nocivo tanto aos prompts de entrada quanto às respostas do modelo, as salvaguardas de que o chatbot precisa. O AgentCore executa e orquestra agentes, as Knowledge Bases recuperam contexto para RAG e os modelos personalizados ajustam o comportamento, e nenhum deles filtra conteúdo.",
+        topic: "IA responsável",
+        options: [
+            ["Amazon Bedrock Guardrails", true],
+            ["Amazon Bedrock AgentCore", false],
+            ["Amazon Bedrock Knowledge Bases", false],
+            ["Modelos personalizados no Amazon Bedrock", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa large language models (LLMs) em aplicativos de tutoria e precisa de salvaguardas configuráveis que imponham regras de segurança padronizadas com o menor esforço. Qual solução atende a esse requisito?",
+        explanation:
+            "O Amazon Bedrock Guardrails oferece salvaguardas configuráveis que aplicam regras de segurança às entradas e saídas dos LLMs com pouca configuração. Os SageMaker Model Cards documentam os modelos, o Amazon Bedrock Evaluations mede a qualidade e a toxicidade dos modelos sem bloquear nada e o SageMaker JumpStart oferece modelos pré-treinados.",
+        topic: "IA responsável",
+        options: [
+            ["Amazon Bedrock Guardrails", true],
+            ["Amazon SageMaker Model Cards", false],
+            ["Amazon Bedrock Evaluations", false],
+            ["Amazon SageMaker JumpStart", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa criou um chatbot que responde a perguntas em linguagem natural com imagens. Ela quer garantir que o chatbot nunca retorne imagens inadequadas ou indesejadas. Qual solução atende a esse requisito?",
+        explanation:
+            "APIs de moderação de conteúdo analisam cada imagem antes de chegar ao usuário e bloqueiam material inadequado ou indesejado, o que garante o requisito em tempo de execução. Retreinar com dados públicos não filtra nada e pode trazer mais conteúdo indesejado, a validação só confere o modelo no desenvolvimento e o feedback dos usuários chega depois do problema.",
+        topic: "IA responsável",
+        options: [
+            ["Integrar APIs de moderação de conteúdo às imagens retornadas", true],
+            ["Retreinar o modelo com um grande conjunto de dados público", false],
+            ["Automatizar a coleta de feedback dos usuários sobre as respostas", false],
+            ["Realizar a validação do modelo antes de colocá-lo em produção", false],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista de eletrônicos criou um assistente de IA que responde a dúvidas de clientes com base nos manuais dos produtos. Qual abordagem tem mais chance de aumentar a confiança dos clientes nas respostas do assistente?",
+        explanation:
+            "Links para os trechos do manual que embasam cada resposta permitem que o cliente confira a informação na fonte, o que gera confiança por transparência. A pontuação de confiança é difícil de interpretar e engana quando está alta numa resposta errada, o avatar é só apresentação e o tom de voz da marca não mostra se a informação está correta.",
+        topic: "IA responsável",
+        options: [
+            ["Incluir links para os trechos do manual que embasam cada resposta", true],
+            ["Exibir a pontuação de confiança do modelo junto de cada resposta", false],
+            ["Dar ao assistente um avatar robótico exibido na tela do atendimento", false],
+            ["Ajustar o assistente para usar o tom de voz da marca nas respostas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma editora usa um modelo de IA generativa para criar ilustrações para seus livros e descobre que algumas imagens geradas se parecem muito com obras de outras editoras protegidas por direitos autorais. Que preocupação de IA responsável isso representa?",
+        explanation:
+            "Gerar imagens muito parecidas com obras protegidas cria risco de violação de propriedade intelectual, um risco legal da IA generativa que exige curadoria dos dados e revisão das saídas. Alucinação é inventar conteúdo plausível e incorreto, data drift é a mudança dos dados de entrada com o tempo e overfitting é memorizar o treino e generalizar mal.",
+        topic: "IA responsável",
+        options: [
+            ["Alucinação do modelo", false],
+            ["Violação de propriedade intelectual", true],
+            ["Desvio de dados (data drift)", false],
+            ["Overfitting aos dados de treinamento", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco implanta um chatbot de IA generativa que dá orientações financeiras incorretas a vários clientes, o que gera reclamações e cobertura negativa na imprensa. Qual risco legal da IA generativa o banco está enfrentando?",
+        explanation:
+            "A perda da confiança dos clientes é um dos riscos legais da IA generativa: respostas incorretas ou nocivas abalam a confiança na empresa e trazem reclamações, dano à reputação e escrutínio regulatório. Viés de amostragem é problema de qualidade dos dados, underfitting é um modelo simples demais e latência é questão de desempenho.",
+        topic: "IA responsável",
+        options: [
+            ["Viés de amostragem nos dados de treinamento", false],
+            ["Perda da confiança dos clientes", true],
+            ["Underfitting do modelo", false],
+            ["Aumento da latência de inferência", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai disponibilizar aos clientes uma aplicação de IA generativa. Qual destes é um risco legal que ela deve considerar antes do lançamento?",
+        explanation:
+            "Saídas incorretas ou enviesadas podem causar danos reais aos usuários finais, como orientações erradas ou decisões injustas, e isso gera responsabilização, multas regulatórias e processos, um risco legal a considerar. Tempo de treinamento, uso de hardware e custos de nuvem são questões operacionais e financeiras, não riscos legais para os usuários.",
+        topic: "IA responsável",
+        options: [
+            ["Danos aos usuários finais por saídas incorretas ou enviesadas", true],
+            ["Aumento do tempo de treinamento dos modelos usados na aplicação", false],
+            ["Uso mais intenso de hardware durante a inferência do modelo", false],
+            ["Custos maiores de computação em nuvem para rodar a aplicação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está decidindo entre uma rede neural profunda e uma árvore de decisão para uma aplicação voltada a clientes. A rede neural é mais precisa, mas a empresa precisa explicar cada decisão aos órgãos reguladores. Que trade-off essa escolha representa?",
+        explanation:
+            "No trade-off entre interpretabilidade e desempenho, modelos complexos como redes neurais profundas costumam acertar mais, mas são difíceis de explicar, enquanto árvores de decisão são fáceis de interpretar e podem perder precisão. Custo e latência, tempo de treino e acurácia, e volume de dados e tamanho do modelo são outros trade-offs.",
+        topic: "IA responsável",
+        options: [
+            ["Interpretabilidade versus desempenho", true],
+            ["Custo versus latência", false],
+            ["Tempo de treinamento versus acurácia", false],
+            ["Volume de dados versus tamanho do modelo", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep-d5.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep-d5.ts
@@ -1,0 +1,737 @@
+// Questões do simulado AWS Certified AI Practitioner (AIF-C01), domínio 5 da prova
+// (Security, Compliance, and Governance), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aif-c01-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D5: Questao[] = [
+    {
+        statement:
+            "Uma startup mantém um chatbot baseado em um foundation model (FM) do Amazon Bedrock que precisa ler arquivos de um bucket do Amazon S3. Os objetos estão criptografados com SSE-KMS usando uma chave gerenciada pelo cliente no AWS KMS, e toda tentativa de leitura falha com acesso negado. O que resolve o problema?",
+        explanation:
+            "Com SSE-KMS, ler o objeto exige, além do acesso ao bucket, a permissão kms:Decrypt na chave usada, e o papel do IAM que o Amazon Bedrock assume não a tinha. Prompt engineering não concede acesso, remover dados sensíveis não resolve a permissão ausente e abrir o bucket à internet é inseguro e também não dá acesso à chave.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Dar ao papel do IAM que o Amazon Bedrock assume a permissão de descriptografar os objetos com a chave do AWS KMS",
+                true,
+            ],
+            [
+                "Usar prompt engineering para indicar ao modelo em qual prefixo do bucket do Amazon S3 os arquivos estão guardados",
+                false,
+            ],
+            [
+                "Remover os dados sensíveis dos arquivos do Amazon S3 antes de o chatbot tentar ler o conteúdo novamente",
+                false,
+            ],
+            [
+                "Alterar a política do bucket do Amazon S3 para permitir acesso público pela internet aos arquivos do chatbot",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa audita periodicamente suas operações em conjunto com fornecedores independentes de software (ISVs). Ela precisa acessar sob demanda os relatórios de conformidade desses ISVs e ser avisada por email quando a AWS publicar relatórios novos. Qual serviço da AWS atende a esses requisitos?",
+        explanation:
+            "O AWS Artifact reúne relatórios de conformidade da AWS e de ISVs que vendem no AWS Marketplace, e permite configurar notificações por email quando surgem documentos novos. O AWS Data Exchange trata de conjuntos de dados de terceiros, o Trusted Advisor recomenda boas práticas e o AWS Config avalia a configuração dos recursos.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "AWS Artifact, que reúne relatórios de conformidade da AWS e de ISVs e envia notificações",
+                true,
+            ],
+            [
+                "AWS Data Exchange, que distribui conjuntos de dados de terceiros para consumo nas contas AWS",
+                false,
+            ],
+            [
+                "AWS Trusted Advisor, que verifica a conta e recomenda boas práticas de custo e segurança",
+                false,
+            ],
+            [
+                "AWS Config, que registra as configurações dos recursos e avalia a conformidade com regras",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma seguradora está classificando seus projetos de IA generativa segundo a Generative AI Security Scoping Matrix da AWS. Qual escopo deixa a seguradora com a MAIOR responsabilidade de segurança?",
+        explanation:
+            "Na matriz, o escopo 5 (modelo treinado do zero com dados próprios) dá à empresa controle total sobre dados, treino, implantação e proteções, e por isso a maior responsabilidade. Fine-tuning de FM de terceiros (escopo 4), aplicação sobre FM de terceiros (escopo 3) e aplicação corporativa pronta (escopo 2) passam parte crescente dessa responsabilidade ao provedor.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Construir e treinar do zero um modelo de IA generativa com dados próprios da empresa",
+                true,
+            ],
+            [
+                "Fazer fine-tuning de um foundation model (FM) de terceiros com os dados da própria empresa",
+                false,
+            ],
+            [
+                "Criar uma aplicação própria sobre um foundation model (FM) de terceiros já existente",
+                false,
+            ],
+            [
+                "Usar uma aplicação corporativa de terceiros que já traz recursos de IA generativa embutidos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA usa um modelo base do Amazon Bedrock para resumir conversas do atendimento e quer guardar registros com os dados de entrada e de saída do modelo para monitoramento. Qual estratégia ele deve adotar?",
+        explanation:
+            "O registro de invocações do Amazon Bedrock, desativado por padrão, grava a requisição, a resposta e os metadados de cada chamada no CloudWatch Logs ou no Amazon S3. O CloudTrail registra a chamada de API, mas não o conteúdo do prompt e da resposta, o EventBridge só roteia eventos e o AWS Config acompanha configurações de recursos.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Ativar o registro de invocações de modelos (model invocation logging) no Amazon Bedrock",
+                true,
+            ],
+            [
+                "Definir o AWS CloudTrail como destino dos registros de entrada e saída do modelo",
+                false,
+            ],
+            [
+                "Configurar o registro de invocações de modelos a partir de regras do Amazon EventBridge",
+                false,
+            ],
+            ["Definir o AWS Config como destino dos registros de entrada e saída do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai criar uma aplicação de LLM com o Amazon Bedrock usando dados de clientes guardados no Amazon S3. A política interna determina que cada equipe acesse somente os registros dos próprios clientes. Qual solução atende a esses requisitos?",
+        explanation:
+            "Um papel de serviço personalizado por equipe, com permissão só para os dados dos clientes daquela equipe, aplica o menor privilégio e impede acesso cruzado. Um papel compartilhado com acesso total ao S3 continua amplo, depender de a equipe informar o cliente não é um controle efetivo e mascarar dados abrindo o bucket não separa o acesso por equipe.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Criar para cada equipe um papel de serviço personalizado do Amazon Bedrock limitado aos dados dos seus clientes",
+                true,
+            ],
+            [
+                "Criar um único papel de serviço do Amazon Bedrock com acesso total ao S3 e papéis do IAM por equipe para as pastas",
+                false,
+            ],
+            [
+                "Criar um único papel de serviço com acesso ao S3 e exigir que cada equipe informe o cliente em toda requisição",
+                false,
+            ],
+            [
+                "Mascarar os dados pessoais no S3 e alterar a política do bucket para liberar às equipes os dados dos clientes",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de IA fez fine-tuning de um modelo personalizado no Amazon Bedrock com um conjunto de dados que continha registros confidenciais. Agora ele precisa garantir que as respostas de inferência do modelo nunca se baseiem nesses dados. O que ele deve fazer?",
+        explanation:
+            "Como os dados confidenciais entraram no treino, o modelo pode reproduzi-los, e a própria AWS orienta excluir o modelo, filtrar os dados e criar um novo. Mascarar ou criptografar as respostas atua depois que o modelo já aprendeu com os dados, e criptografar o modelo com o AWS KMS protege em repouso, mas não muda o que ele gera.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Excluir o modelo personalizado, tirar os dados confidenciais do conjunto de treino e treinar de novo",
+                true,
+            ],
+            [
+                "Mascarar os dados confidenciais nas respostas de inferência com mascaramento dinâmico de dados antes da entrega",
+                false,
+            ],
+            [
+                "Criptografar os dados confidenciais presentes nas respostas de inferência usando o Amazon SageMaker AI",
+                false,
+            ],
+            [
+                "Criptografar os dados confidenciais armazenados no modelo personalizado com chaves do AWS KMS",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe cria e treina modelos de ML em notebooks do Amazon SageMaker Studio e guarda os dados em um bucket do Amazon S3. Ela precisa controlar o caminho que os dados percorrem entre o Amazon S3 e os notebooks. Qual solução atende a esse requisito?",
+        explanation:
+            "Com o Studio em modo somente VPC e um endpoint de VPC para o Amazon S3, o tráfego entre os notebooks e o bucket segue por um caminho privado que a equipe controla, sem passar pela internet. O Macie descobre dados sensíveis e o Inspector busca vulnerabilidades, sem controlar o caminho, e o Glacier Deep Archive é só uma classe de arquivamento.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Configurar o SageMaker AI para usar uma VPC com um endpoint de VPC para o Amazon S3",
+                true,
+            ],
+            [
+                "Usar o Amazon Macie para monitorar os dados acessados pelos notebooks do SageMaker Studio",
+                false,
+            ],
+            [
+                "Usar o Amazon Inspector para monitorar o tráfego dos notebooks do SageMaker Studio",
+                false,
+            ],
+            [
+                "Configurar o SageMaker AI para gravar os dados na classe S3 Glacier Deep Archive",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa modelos personalizados no Amazon Bedrock em uma aplicação de IA generativa e quer que os artefatos de modelo gerados pelos jobs de customização sejam criptografados com uma chave controlada por ela. Qual serviço da AWS atende a esses requisitos?",
+        explanation:
+            "O Amazon Bedrock criptografa modelos personalizados com chaves da AWS por padrão, mas aceita uma chave gerenciada pelo cliente no AWS KMS, que a empresa cria, controla e pode revogar. O Macie descobre dados sensíveis, o Inspector procura vulnerabilidades e o Secrets Manager guarda credenciais, e nenhum deles fornece a chave que cifra os artefatos.",
+        topic: "Segurança e governança",
+        options: [
+            ["AWS Key Management Service (AWS KMS), com uma chave gerenciada pelo cliente", true],
+            ["Amazon Macie, que descobre e classifica dados sensíveis armazenados no S3", false],
+            ["AWS Secrets Manager, que armazena e alterna credenciais e outros segredos", false],
+            [
+                "Amazon Inspector, que verifica vulnerabilidades de software nas cargas de trabalho",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa registrar todas as chamadas feitas à API do Amazon Bedrock e guardar esses registros com segurança por cinco anos, pelo menor custo possível, sem saber com que frequência eles serão consultados. Quais opções, um serviço da AWS e uma classe de armazenamento do Amazon S3, atendem a esses requisitos? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CloudTrail registra as chamadas à API do Amazon Bedrock, como InvokeModel, e entrega os logs em um bucket do S3, onde o Intelligent-Tiering move os objetos para camadas mais baratas conforme o acesso. O CloudWatch foca métricas e alarmes, o AWS Config acompanha configurações e o S3 Standard custa mais para dados pouco acessados por anos.",
+        topic: "Segurança e governança",
+        options: [
+            ["AWS CloudTrail, que registra as chamadas de API feitas aos serviços da AWS", true],
+            ["Amazon S3 Intelligent-Tiering, que move os objetos entre camadas de acesso", true],
+            ["Amazon CloudWatch, que coleta métricas e alarmes operacionais dos recursos", false],
+            ["AWS Config, que registra as mudanças de configuração dos recursos da conta", false],
+            [
+                "Amazon S3 Standard, que mantém os objetos sempre na camada de acesso frequente",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um hospital está criando um sistema de IA que ajuda médicos a diagnosticar doenças a partir de prontuários e imagens médicas. Por lei, os dados sensíveis dos pacientes precisam permanecer no país onde estão armazenados. Qual estratégia de governança de dados garante a conformidade e protege a privacidade?",
+        explanation:
+            "Residência de dados define a localização geográfica em que os dados são armazenados e processados, atendendo à lei que exige manter os dados dos pacientes no país. Qualidade trata de precisão e completude, enriquecimento acrescenta informações e descoberta ajuda a encontrar conjuntos, sem controlar onde os dados ficam.",
+        topic: "Segurança e governança",
+        options: [
+            ["Residência de dados, definindo a localização geográfica onde os dados ficam", true],
+            [
+                "Qualidade de dados, garantindo a precisão e a completude dos registros clínicos",
+                false,
+            ],
+            ["Enriquecimento de dados, acrescentando informações externas aos prontuários", false],
+            [
+                "Descoberta de dados, facilitando que as equipes encontrem os conjuntos disponíveis",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um banco global criou uma aplicação de ML que analisa dados de mercado para identificar tendências. Durante todo o desenvolvimento, o banco quer verificar continuamente se as configurações dos recursos seguem suas políticas internas e os frameworks regulatórios do setor. Qual serviço da AWS ajuda o banco a avaliar essa conformidade?",
+        explanation:
+            "O AWS Config avalia continuamente a configuração dos recursos com regras, e os conformance packs trazem modelos prontos de frameworks como PCI DSS e HIPAA. O CloudWatch acompanha métricas e alarmes, o CloudTrail registra chamadas de API que servem de evidência, mas não avalia conformidade, e o Inspector procura vulnerabilidades de software.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "AWS Config, com regras e conformance packs que avaliam os recursos continuamente",
+                true,
+            ],
+            [
+                "Amazon CloudWatch, com métricas e alarmes sobre o desempenho dos recursos em uso",
+                false,
+            ],
+            ["AWS CloudTrail, com o histórico das chamadas de API feitas na conta do banco", false],
+            [
+                "Amazon Inspector, com varreduras contínuas de vulnerabilidades de software nas cargas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de saúde quer treinar um modelo na AWS com dados de vários hospitais parceiros, mas os dados de cada hospital não podem sair do ambiente dele por questões de privacidade e conformidade. Qual técnica de machine learning atende a esse requisito?",
+        explanation:
+            "No aprendizado federado, cada participante treina o modelo localmente e só compartilha atualizações, então os dados brutos de cada hospital nunca saem do ambiente dele. Transferência reaproveita um modelo pronto, não supervisionado busca padrões sem rótulos e reforço aprende com recompensas, e nenhuma delas foi feita para manter os dados isolados.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Aprendizado federado, que treina um modelo único sem centralizar os dados brutos",
+                true,
+            ],
+            [
+                "Aprendizado por transferência, que reaproveita um modelo já treinado em outra tarefa",
+                false,
+            ],
+            [
+                "Aprendizado não supervisionado, que encontra padrões em dados sem rótulos definidos",
+                false,
+            ],
+            [
+                "Aprendizado por reforço, que aprende por tentativa e erro a partir de recompensas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um hospital quer fazer fine-tuning de um foundation model (FM) com serviços da AWS, mantendo os dados privados e dentro da Região da AWS onde estão armazenados. Quais medidas atendem a esses requisitos da forma MAIS econômica? (Selecione DUAS opções.)",
+        explanation:
+            "Chamar a API do Amazon Bedrock mantém o fine-tuning no serviço gerenciado e na Região escolhida, e o AWS PrivateLink leva o tráfego da VPC ao Bedrock pela rede privada da AWS, sem infraestrutura extra. Outposts e servidores locais somam custo de hardware e operação, e mover os dados para outra Região descumpre o requisito.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Usar a API do Amazon Bedrock para fazer o fine-tuning na mesma Região dos dados",
+                true,
+            ],
+            ["Usar o AWS PrivateLink com uma VPC para chegar ao Amazon Bedrock sem internet", true],
+            [
+                "Hospedar o modelo no data center do hospital com racks do AWS Outposts dedicados",
+                false,
+            ],
+            ["Implantar a API do Amazon Bedrock em servidores do data center do hospital", false],
+            [
+                "Copiar os dados para outra Região com preço menor e fazer o fine-tuning por lá",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa já usa o Amazon Bedrock e quer controlar quais modelos cada grupo de funcionários pode invocar. Qual solução atende a esses requisitos?",
+        explanation:
+            "Políticas do IAM podem permitir ou negar ações do Amazon Bedrock, como InvokeModel, apontando o ARN de cada foundation model, e assim definir quais modelos cada grupo usa. Papéis de serviço dão permissões a serviços, não a funcionários, o AWS STS só emite credenciais temporárias e o Amazon Inspector procura vulnerabilidades, sem controlar acesso.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Usar políticas do IAM que permitam ou neguem ações do Amazon Bedrock em cada modelo",
+                true,
+            ],
+            [
+                "Usar papéis de serviço do IAM para restringir a assinatura dos modelos no AWS Marketplace",
+                false,
+            ],
+            [
+                "Usar o Amazon Inspector para monitorar quais funcionários acessam cada um dos modelos",
+                false,
+            ],
+            [
+                "Usar o AWS STS para gerar credenciais temporárias sempre que alguém for usar um modelo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa analisa documentos confidenciais com um modelo de terceiros no Amazon Bedrock e está preocupada com a privacidade. Qual afirmação explica como o Amazon Bedrock protege esses dados em relação ao provedor do modelo?",
+        explanation:
+            "Os modelos rodam em contas de implantação operadas pela equipe do Amazon Bedrock, às quais os provedores não têm acesso, então eles não veem prompts, respostas nem logs dos clientes. Por isso as opções que falam em enviar as saídas, anonimizar e compartilhar ou remover dados sensíveis antes do envio estão erradas: nada é repassado ao provedor.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "As entradas e as saídas do modelo não são compartilhadas com os provedores dos modelos",
+                true,
+            ],
+            [
+                "As entradas ficam confidenciais, mas as saídas do modelo são enviadas ao provedor do modelo",
+                false,
+            ],
+            [
+                "As entradas e as saídas são anonimizadas e depois compartilhadas com o provedor do modelo",
+                false,
+            ],
+            [
+                "As entradas e as saídas passam por remoção de dados sensíveis antes de irem ao provedor",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa obtém uma certificação ISO voltada à gestão de riscos de IA e ao uso responsável da tecnologia. O que essa certificação indica sobre a empresa?",
+        explanation:
+            "Uma certificação ISO de gestão de IA, como a ISO/IEC 42001, atesta que o sistema de gestão de IA da organização, com seus processos e controles para desenvolver e governar IA, atende à norma. Ela não certifica automaticamente cada funcionário, cada integrante das equipes nem cada sistema de IA, que exigiriam avaliações próprias.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "O sistema de gestão de IA da empresa foi auditado e certificado segundo a norma",
+                true,
+            ],
+            [
+                "Todos os funcionários da empresa passaram a ter uma certificação ISO individual",
+                false,
+            ],
+            [
+                "Todos os sistemas de IA que a empresa utiliza foram certificados um a um pela ISO",
+                false,
+            ],
+            [
+                "Todos os integrantes das equipes de aplicações de IA ganharam certificação ISO",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa mantém regras que definem por quanto tempo cada tipo de informação deve ser guardado e quando deve ser excluído. Qual estratégia de governança de dados isso descreve?",
+        explanation:
+            "Retenção de dados é o conjunto de políticas que define por quanto tempo os dados ficam guardados e quando devem ser excluídos. Padrões de qualidade tratam de precisão e completude, armazenamento de logs trata de onde os registros ficam e desidentificação remove dados que identificam pessoas, sem fixar prazos de guarda.",
+        topic: "Segurança e governança",
+        options: [
+            ["Retenção de dados, com prazos de guarda e momentos de exclusão definidos", true],
+            ["Padrões de qualidade de dados, com critérios de precisão e completude", false],
+            ["Armazenamento de logs, com a definição de onde os registros ficam guardados", false],
+            [
+                "Desidentificação de dados, com a remoção de informações que identificam pessoas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa criou um chatbot com um modelo do Amazon SageMaker JumpStart ajustado por fine-tuning e precisa atender a vários frameworks regulatórios. Quais capacidades ajudam a empresa a demonstrar conformidade? (Selecione DUAS opções.)",
+        explanation:
+            "Reguladores esperam controles de segurança: proteção de dados (criptografia, controle de acesso) e detecção de ameaças mostram que as informações sensíveis estão protegidas e que os riscos são identificados. Otimização de custos, escalabilidade automática e lançamento mais rápido são metas de negócio e desempenho que não demonstram conformidade.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Proteção de dados, com criptografia e controle de acesso às informações sensíveis",
+                true,
+            ],
+            ["Detecção de ameaças, identificando atividades suspeitas e riscos de segurança", true],
+            ["Otimização de custos, ajustando recursos e contratos ao volume real de uso", false],
+            [
+                "Escalabilidade automática, adaptando a capacidade à demanda de usuários do chatbot",
+                false,
+            ],
+            ["Lançamento mais rápido, acelerando a entrega de novas versões do chatbot", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco vai fazer fine-tuning de um LLM no Amazon Bedrock para responder dúvidas sobre empréstimos. O modelo nunca pode revelar dados privados de clientes, e a política do banco proíbe que esses dados fiquem incorporados ao modelo. Qual solução atende a esses requisitos?",
+        explanation:
+            "Tirar a PII antes do fine-tuning impede que o modelo aprenda e reproduza esses dados, e a AWS alerta que modelos ajustados podem repetir trechos do treino. Os Guardrails mascaram a resposta, mas o dado continua incorporado ao modelo, criptografar no S3 protege em repouso sem impedir o aprendizado e o Top K só muda a amostragem de tokens.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Remover os dados pessoais (PII) do conjunto de dados antes de iniciar o fine-tuning",
+                true,
+            ],
+            [
+                "Aplicar o Amazon Bedrock Guardrails para mascarar dados pessoais nas respostas geradas",
+                false,
+            ],
+            [
+                "Criptografar os dados no Amazon S3 com o AWS KMS antes de iniciar o fine-tuning",
+                false,
+            ],
+            [
+                "Aumentar o parâmetro Top K para diversificar os tokens escolhidos em cada resposta",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer controlar quais foundation models (FMs) disponíveis publicamente os seus funcionários podem acessar. Qual solução atende a esse requisito?",
+        explanation:
+            "Os hubs privados do SageMaker JumpStart permitem que administradores selecionem os FMs aprovados, e os usuários só encontram e implantam os modelos desse catálogo curado. O Cost Explorer analisa gastos, o AWS Artifact oferece documentos de conformidade e o Trusted Advisor recomenda boas práticas, e nenhum deles restringe quais modelos os funcionários acessam.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Criar no Amazon SageMaker JumpStart um hub privado apenas com os FMs aprovados",
+                true,
+            ],
+            [
+                "Analisar o uso de cada FM no AWS Cost Explorer e cortar os que tiverem maior gasto",
+                false,
+            ],
+            [
+                "Baixar do AWS Artifact os relatórios de conformidade dos provedores de cada FM",
+                false,
+            ],
+            [
+                "Revisar as recomendações do AWS Trusted Advisor sobre os FMs usados pela conta",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um chatbot de IA generativa baseado em um foundation model (FM) do Amazon Bedrock está vulnerável a injeção de prompt. Como a empresa pode proteger o chatbot com o MENOR esforço?",
+        explanation:
+            "O filtro de ataques de prompt do Amazon Bedrock Guardrails detecta injeção de prompt e jailbreak nas entradas e é configurado sem retreinar nada. Fine-tuning exige dados e um job de treino, trocar de FM não elimina a injeção e exemplos few-shot orientam o formato das respostas, mas não barram entradas maliciosas.",
+        topic: "Prompt engineering",
+        options: [
+            [
+                "Configurar no Amazon Bedrock Guardrails o filtro de ataques de prompt nas entradas",
+                true,
+            ],
+            [
+                "Fazer fine-tuning do FM com exemplos para que ele evite responder a pedidos nocivos",
+                false,
+            ],
+            [
+                "Trocar o FM atual por outro foundation model disponível no catálogo do Bedrock",
+                false,
+            ],
+            ["Acrescentar mais exemplos few-shot ao prompt mostrando como recusar pedidos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai disponibilizar LLMs do Amazon Bedrock para várias equipes e quer usá-los com segurança desde o início. Qual prática atende a esse objetivo?",
+        explanation:
+            "Papéis e políticas do IAM com menor privilégio limitam quem pode invocar quais modelos e ações do Amazon Bedrock, a base do uso seguro. Jobs de avaliação medem a qualidade das respostas e não protegem o acesso, o Trusted Advisor não avalia modelos e o CloudWatch Logs guarda registros, sem explicar modelos nem detectar viés.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Configurar papéis e políticas do IAM com base no princípio do menor privilégio",
+                true,
+            ],
+            [
+                "Ativar o AWS Trusted Advisor para executar jobs automáticos de avaliação dos modelos",
+                false,
+            ],
+            [
+                "Ativar os jobs automáticos de avaliação de modelos do Amazon Bedrock para cada equipe",
+                false,
+            ],
+            [
+                "Usar o Amazon CloudWatch Logs para tornar os modelos explicáveis e monitorar viés",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está montando um framework de governança de IA para gerar confiança e implantar uma IA centrada nas pessoas. Qual característica é típica desse tipo de framework?",
+        explanation:
+            "Frameworks de governança de IA se caracterizam por políticas e diretrizes sobre uso de dados, transparência, IA responsável e conformidade, o que gera confiança e sustenta uma IA centrada nas pessoas. Expandir iniciativas, alinhar projetos a metas de receita e impulsionar o crescimento são objetivos de negócio, não traços de governança.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Criar políticas e diretrizes de dados, transparência, IA responsável e conformidade",
+                true,
+            ],
+            [
+                "Expandir as iniciativas de IA por todas as unidades de negócio para maximizar o valor",
+                false,
+            ],
+            [
+                "Alinhar os projetos de IA às metas de receita e às expectativas das partes interessadas",
+                false,
+            ],
+            [
+                "Impulsionar a transformação do negócio e o crescimento competitivo por meio da IA",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa IA para gerar o score de crédito dos clientes nos pedidos de empréstimo e planeja expandir para um novo mercado geográfico. Para operar lá, que tipo de legislação de conformidade a empresa deve revisar?",
+        explanation:
+            "O score de crédito por IA é uma decisão automatizada sobre pessoas, então a empresa precisa revisar as leis locais de responsabilização algorítmica, que tratam de justiça, transparência e impacto dessas decisões. Leis sobre dados de saúde, de cartões de pagamento e educacionais cobrem outros tipos de dado e não o uso de algoritmos no crédito.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Leis locais de responsabilização algorítmica que regulam decisões automatizadas",
+                true,
+            ],
+            [
+                "Leis locais de proteção de dados de saúde e de informações clínicas de pacientes",
+                false,
+            ],
+            [
+                "Leis locais de proteção de dados de cartões de pagamento usados pelos clientes",
+                false,
+            ],
+            [
+                "Leis locais de privacidade de dados educacionais de alunos e instituições de ensino",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer garantir que seu sistema de IA seja justo e explicável e decide exigir um treinamento para a equipe de desenvolvimento de IA. Qual treinamento atende a esse requisito?",
+        explanation:
+            "Treinar a equipe em conscientização de viés e IA responsável dá conhecimento e práticas para construir sistemas justos e explicáveis, como avaliar dados desbalanceados e documentar decisões do modelo. Programação avançada, privacidade e criptografia e algoritmos de ML são habilidades úteis, mas não tratam diretamente de justiça e explicabilidade.",
+        topic: "IA responsável",
+        options: [
+            ["Treinamento sobre conscientização de viés e práticas de IA responsável", true],
+            ["Treinamento sobre técnicas avançadas de programação e revisão de código", false],
+            ["Treinamento sobre privacidade de dados e protocolos de criptografia", false],
+            ["Treinamento sobre algoritmos avançados de machine learning e otimização", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está implantando agentes de IA, construídos com foundation models do Amazon Bedrock, que precisam acessar vários sistemas de backend em nome dos usuários. A empresa quer que cada agente se autentique com uma identidade própria, em vez de todos compartilharem as mesmas credenciais. Qual recurso da AWS atende a esse requisito?",
+        explanation:
+            "O AgentCore Identity trata agentes como identidades de carga de trabalho próprias e gerencia a autenticação e as credenciais que eles usam para acessar recursos da AWS e de terceiros em nome dos usuários. O Secrets Manager guarda segredos sem dar identidade a cada agente, o Macie descobre dados sensíveis e o CloudTrail registra chamadas para auditoria.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Amazon Bedrock AgentCore Identity, que gerencia identidades e credenciais de agentes",
+                true,
+            ],
+            [
+                "AWS Secrets Manager, que armazena e faz a rotação das credenciais usadas pelas aplicações",
+                false,
+            ],
+            [
+                "Amazon Macie, que descobre e protege dados sensíveis armazenados no Amazon S3",
+                false,
+            ],
+            [
+                "AWS CloudTrail, que registra as chamadas de API feitas pelos agentes para auditoria",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "A equipe de conformidade de uma farmacêutica usa um assistente de IA generativa para responder dúvidas sobre interações medicamentosas. Para reduzir o risco de o modelo gerar informações médicas incorretas, a equipe quer que toda resposta seja embasada em documentos de referência aprovados. Qual técnica atende a esse requisito?",
+        explanation:
+            "Com RAG, o sistema recupera trechos dos documentos aprovados a cada pergunta e os usa para embasar a resposta, que fica rastreável até a fonte e menos sujeita a alucinação. Temperatura maior aumenta a aleatoriedade, fine-tuning com dados gerais não prende a resposta aos documentos aprovados e um modelo maior não verifica nada contra referências.",
+        topic: "RAG e customização",
+        options: [
+            ["Aplicar RAG, embasando as respostas nos documentos de referência aprovados", true],
+            ["Aumentar o parâmetro de temperatura para o modelo variar mais as respostas", false],
+            [
+                "Fazer fine-tuning do modelo com mais dados médicos gerais coletados na internet",
+                false,
+            ],
+            ["Trocar o modelo atual por um foundation model maior, com mais parâmetros", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer detectar possíveis alucinações do seu assistente de IA generativa antes que as respostas cheguem aos usuários. Quais técnicas atendem a esse objetivo? (Selecione DUAS opções.)",
+        explanation:
+            "A validação compara a resposta com os documentos de origem para confirmar os fatos, e a pontuação de confiança sinaliza respostas de baixa certeza para revisão ou bloqueio, pegando alucinações antes do usuário. Mais dados de treino, menos parâmetros ou mais GPU podem mudar qualidade ou velocidade, mas não verificam cada resposta em tempo real.",
+        topic: "IA responsável",
+        options: [
+            [
+                "Validar cada resposta gerada comparando o conteúdo com os documentos de origem",
+                true,
+            ],
+            ["Atribuir pontuações de confiança e sinalizar as respostas de baixa certeza", true],
+            [
+                "Aumentar o volume de dados usados no treinamento do modelo antes de publicá-lo",
+                false,
+            ],
+            ["Reduzir a quantidade de parâmetros do modelo usado na aplicação em produção", false],
+            ["Adicionar mais capacidade de GPU para acelerar a etapa de inferência", false],
+        ],
+    },
+    {
+        statement:
+            "Uma instituição financeira treina modelos de ML com dados de vários sistemas internos. Os reguladores exigem que ela rastreie cada dado de treinamento até a origem e demonstre que a coleta e o processamento seguiram as políticas. Qual prática atende a esse requisito?",
+        explanation:
+            "O rastreamento de linhagem documenta de onde cada dado veio, por onde passou e como foi transformado, o que permite provar aos reguladores a origem e o tratamento conforme a política. Aumento de dados cria exemplos, normalização ajusta escalas e balanceamento corrige a distribuição de classes, e nenhum deles gera esse histórico rastreável.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Rastreamento de linhagem de dados, registrando origem, movimentação e transformações",
+                true,
+            ],
+            [
+                "Aumento de dados (data augmentation), criando exemplos extras a partir dos existentes",
+                false,
+            ],
+            ["Normalização de dados, colocando as variáveis numéricas em uma escala comum", false],
+            [
+                "Balanceamento de dados, ajustando a distribuição das classes para reduzir viés",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa modelos de IA treinados com dados de clientes e precisa definir regras para as fases dos conjuntos de treino: por quanto tempo ficam em uso, quando são arquivados e quando devem ser excluídos. Qual estratégia de governança de dados isso descreve?",
+        explanation:
+            "A gestão do ciclo de vida dos dados define regras para cada fase, da criação e do armazenamento ao arquivamento e à exclusão, como pede o caso dos conjuntos de treino. Residência trata da localização geográfica, registro guarda eventos para auditoria e monitoramento acompanha qualidade e uso, sem fixar prazos de arquivamento e exclusão.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Gestão do ciclo de vida dos dados, organizando cada fase da criação ao descarte",
+                true,
+            ],
+            [
+                "Residência de dados, definindo a localização geográfica em que os dados ficam",
+                false,
+            ],
+            [
+                "Registro de dados (logging), guardando os eventos de acesso para auditoria posterior",
+                false,
+            ],
+            [
+                "Monitoramento de dados, observando a qualidade e o uso dos dados ao longo do tempo",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "A equipe de governança de dados de uma empresa quer acompanhar continuamente como os dados de treinamento de IA são acessados e usados na organização, para detectar padrões de uso não autorizado. Qual estratégia de governança de dados isso descreve?",
+        explanation:
+            "Observação e monitoramento de dados é acompanhar de forma contínua como os dados são acessados e usados, identificando anomalias e padrões não autorizados. Retenção define prazos de guarda, residência define a localização e o registro (logging) grava eventos de acesso, mas sozinho não faz a vigilância contínua nem detecta padrões.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "Observação e monitoramento de dados, acompanhando acesso e uso de forma contínua",
+                true,
+            ],
+            [
+                "Retenção de dados, definindo por quanto tempo os dados ficam guardados antes da exclusão",
+                false,
+            ],
+            [
+                "Residência de dados, definindo a localização geográfica em que os dados ficam",
+                false,
+            ],
+            [
+                "Registro de dados (logging), gravando cada evento de acesso individual para consulta",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa que desenvolve sistemas de IA na AWS quer registrar cada acesso aos seus conjuntos de dados de treinamento armazenados no Amazon S3, para fins de auditoria. Qual serviço da AWS oferece esse registro?",
+        explanation:
+            "O AWS CloudTrail registra chamadas de API e, com eventos de dados ativados para o Amazon S3, grava leituras e gravações de objetos com quem fez, quando e de onde, formando a trilha de auditoria. O AWS Config acompanha mudanças de configuração, o Trusted Advisor recomenda boas práticas e o Inspector procura vulnerabilidades, sem registrar acessos a dados.",
+        topic: "Segurança e governança",
+        options: [
+            [
+                "AWS CloudTrail, com eventos de dados que registram quem acessou cada objeto e quando",
+                true,
+            ],
+            [
+                "AWS Config, com o histórico das mudanças de configuração dos recursos da conta",
+                false,
+            ],
+            [
+                "AWS Trusted Advisor, com recomendações de boas práticas para os recursos da conta",
+                false,
+            ],
+            [
+                "Amazon Inspector, com varreduras automáticas de vulnerabilidades nas cargas de trabalho",
+                false,
+            ],
+        ],
+    },
+];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
@@ -1,5 +1,6 @@
 // Lotes importados do banco aberto cloudcertprep para o simulado AIF-C01, um
 // arquivo por domínio da prova. Licença MIT: ver LICENSE-cloudcertprep.txt.
 import type { Questao } from "./aif-c01-questoes.ts";
+import { QUESTOES_CLOUDCERTPREP_D1 } from "./aif-c01-questoes-cloudcertprep-d1.ts";
 
-export const QUESTOES_CLOUDCERTPREP: Questao[] = [];
+export const QUESTOES_CLOUDCERTPREP: Questao[] = [...QUESTOES_CLOUDCERTPREP_D1];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
@@ -3,8 +3,10 @@
 import type { Questao } from "./aif-c01-questoes.ts";
 import { QUESTOES_CLOUDCERTPREP_D1 } from "./aif-c01-questoes-cloudcertprep-d1.ts";
 import { QUESTOES_CLOUDCERTPREP_D2 } from "./aif-c01-questoes-cloudcertprep-d2.ts";
+import { QUESTOES_CLOUDCERTPREP_D3 } from "./aif-c01-questoes-cloudcertprep-d3.ts";
 
 export const QUESTOES_CLOUDCERTPREP: Questao[] = [
     ...QUESTOES_CLOUDCERTPREP_D1,
     ...QUESTOES_CLOUDCERTPREP_D2,
+    ...QUESTOES_CLOUDCERTPREP_D3,
 ];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
@@ -2,5 +2,9 @@
 // arquivo por domínio da prova. Licença MIT: ver LICENSE-cloudcertprep.txt.
 import type { Questao } from "./aif-c01-questoes.ts";
 import { QUESTOES_CLOUDCERTPREP_D1 } from "./aif-c01-questoes-cloudcertprep-d1.ts";
+import { QUESTOES_CLOUDCERTPREP_D2 } from "./aif-c01-questoes-cloudcertprep-d2.ts";
 
-export const QUESTOES_CLOUDCERTPREP: Questao[] = [...QUESTOES_CLOUDCERTPREP_D1];
+export const QUESTOES_CLOUDCERTPREP: Questao[] = [
+    ...QUESTOES_CLOUDCERTPREP_D1,
+    ...QUESTOES_CLOUDCERTPREP_D2,
+];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
@@ -4,9 +4,11 @@ import type { Questao } from "./aif-c01-questoes.ts";
 import { QUESTOES_CLOUDCERTPREP_D1 } from "./aif-c01-questoes-cloudcertprep-d1.ts";
 import { QUESTOES_CLOUDCERTPREP_D2 } from "./aif-c01-questoes-cloudcertprep-d2.ts";
 import { QUESTOES_CLOUDCERTPREP_D3 } from "./aif-c01-questoes-cloudcertprep-d3.ts";
+import { QUESTOES_CLOUDCERTPREP_D4 } from "./aif-c01-questoes-cloudcertprep-d4.ts";
 
 export const QUESTOES_CLOUDCERTPREP: Questao[] = [
     ...QUESTOES_CLOUDCERTPREP_D1,
     ...QUESTOES_CLOUDCERTPREP_D2,
     ...QUESTOES_CLOUDCERTPREP_D3,
+    ...QUESTOES_CLOUDCERTPREP_D4,
 ];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
@@ -5,10 +5,12 @@ import { QUESTOES_CLOUDCERTPREP_D1 } from "./aif-c01-questoes-cloudcertprep-d1.t
 import { QUESTOES_CLOUDCERTPREP_D2 } from "./aif-c01-questoes-cloudcertprep-d2.ts";
 import { QUESTOES_CLOUDCERTPREP_D3 } from "./aif-c01-questoes-cloudcertprep-d3.ts";
 import { QUESTOES_CLOUDCERTPREP_D4 } from "./aif-c01-questoes-cloudcertprep-d4.ts";
+import { QUESTOES_CLOUDCERTPREP_D5 } from "./aif-c01-questoes-cloudcertprep-d5.ts";
 
 export const QUESTOES_CLOUDCERTPREP: Questao[] = [
     ...QUESTOES_CLOUDCERTPREP_D1,
     ...QUESTOES_CLOUDCERTPREP_D2,
     ...QUESTOES_CLOUDCERTPREP_D3,
     ...QUESTOES_CLOUDCERTPREP_D4,
+    ...QUESTOES_CLOUDCERTPREP_D5,
 ];

--- a/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aif-c01-questoes-cloudcertprep.ts
@@ -1,0 +1,5 @@
+// Lotes importados do banco aberto cloudcertprep para o simulado AIF-C01, um
+// arquivo por domínio da prova. Licença MIT: ver LICENSE-cloudcertprep.txt.
+import type { Questao } from "./aif-c01-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP: Questao[] = [];

--- a/backend/scripts/data/aif-c01-questoes.ts
+++ b/backend/scripts/data/aif-c01-questoes.ts
@@ -148,22 +148,22 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma cientista de dados quer treinar e implantar um modelo customizado de ML com controle sobre o algoritmo e a infraestrutura. Quais recursos do Amazon SageMaker apoiam DIRETAMENTE esse fluxo? (Selecione DUAS opções.)",
+            "Uma cientista de dados quer treinar e implantar um modelo customizado de ML com controle sobre o algoritmo e a infraestrutura. Quais recursos do Amazon SageMaker AI apoiam DIRETAMENTE esse fluxo? (Selecione DUAS opções.)",
         explanation:
-            "Treinar e implantar modelos customizados são funções de SageMaker Training e SageMaker Endpoints. Polly (voz), Connect (contact center) e Shield (proteção DDoS) não fazem parte desse fluxo de ML.",
+            "O treinamento do SageMaker AI executa o treino em infraestrutura gerenciada, e os endpoints do SageMaker AI hospedam o modelo para servir inferências. Polly (voz), Connect (contact center) e Shield (proteção DDoS) não fazem parte desse fluxo de ML.",
         topic: "Fundamentos de IA e ML",
         options: [
             [
-                "SageMaker Training, para treinar modelos em infraestrutura gerenciada e escalável",
+                "Treinamento do SageMaker AI, para treinar modelos em infraestrutura gerenciada e escalável",
                 true,
             ],
             [
-                "SageMaker Endpoints, para hospedar o modelo e servir inferências em tempo real",
+                "Endpoints do SageMaker AI, para hospedar o modelo e servir inferências em tempo real",
                 true,
             ],
             ["Amazon Polly, para converter os resultados do modelo em áudio de voz natural", false],
             [
-                "Amazon Connect, para distribuir chamadas telefônicas em uma central de atendimento",
+                "Amazon Connect, para distribuir as chamadas telefônicas recebidas em uma central de atendimento",
                 false,
             ],
             ["AWS Shield, para proteger a aplicação contra ataques de negação de serviço", false],
@@ -247,14 +247,14 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma startup precisa transcrever áudios de reuniões para texto rapidamente, sem treinar nenhum modelo. Qual serviço da AWS resolve isso com um modelo pré-treinado?",
+            "Uma startup precisa transcrever áudios de reuniões para texto rapidamente, sem treinar nem implantar nenhum modelo. Qual serviço da AWS resolve isso com um modelo pré-treinado?",
         explanation:
-            "Amazon Transcribe faz speech-to-text pronto para uso. Polly é o inverso (text-to-speech); Comprehend analisa texto escrito; SageMaker exigiria treinar um modelo próprio.",
+            "Amazon Transcribe faz speech-to-text pronto para uso. Polly é o inverso (text-to-speech); Comprehend analisa texto escrito; no SageMaker AI a equipe teria de implantar e operar um modelo próprio.",
         topic: "Fundamentos de IA e ML",
         options: [
             ["Amazon Transcribe, que converte fala em texto com um modelo já pronto", true],
             [
-                "Amazon SageMaker, no qual seria preciso treinar e implantar um modelo próprio",
+                "Amazon SageMaker AI, no qual a equipe teria de implantar e operar um modelo próprio",
                 false,
             ],
             ["Amazon Polly, que faz o caminho inverso, gerando voz a partir de texto", false],
@@ -470,31 +470,6 @@ const AUTORAIS: Questao[] = [
             ],
             [
                 "Limite de um único idioma por modelo, exigindo um modelo separado para cada língua",
-                false,
-            ],
-        ],
-    },
-    {
-        statement:
-            "Uma empresa quer um assistente de IA generativa que responda perguntas dos funcionários com base nos documentos internos, respeitando as permissões de acesso. Qual serviço da AWS é voltado a isso?",
-        explanation:
-            "Q Business é o assistente generativo para dados corporativos que respeita as permissões de acesso dos documentos. Q Developer foca em código, Lex constrói bots de fluxo definido e Kendra é busca corporativa, não assistente de respostas.",
-        topic: "IA generativa",
-        options: [
-            [
-                "Amazon Q Business, um assistente generativo conectado aos dados e às permissões da empresa",
-                true,
-            ],
-            [
-                "Amazon Q Developer, um assistente voltado a tarefas de programação e ao ciclo de desenvolvimento",
-                false,
-            ],
-            [
-                "Amazon Lex, um serviço para construir chatbots com intenções e fluxos definidos manualmente",
-                false,
-            ],
-            [
-                "Amazon Kendra, um serviço de busca corporativa que localiza documentos, sem gerar respostas",
                 false,
             ],
         ],
@@ -800,19 +775,6 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Qual recurso do Amazon Bedrock permite que um foundation model execute tarefas em várias etapas, chamando APIs e sistemas para concluir uma solicitação do usuário?",
-        explanation:
-            "Agents for Amazon Bedrock orquestram tarefas de múltiplas etapas, invocando APIs e fontes de dados. Guardrails filtra conteúdo; Textract extrai de documentos; Macie protege dados sensíveis.",
-        topic: "RAG e customização",
-        options: [
-            ["Agents for Amazon Bedrock, que orquestram ações e chamadas a sistemas", true],
-            ["Amazon Bedrock Guardrails, que restringem os temas e conteúdos das respostas", false],
-            ["Amazon Textract, que extrai texto e dados de documentos digitalizados", false],
-            ["Amazon Macie, que descobre e protege dados sensíveis armazenados no S3", false],
-        ],
-    },
-    {
-        statement:
             "Ao escolher um foundation model para um chatbot de alto volume e baixo custo, qual tradeoff a equipe deve considerar?",
         explanation:
             "O tradeoff real é capacidade contra custo e latência: modelos menores tendem a ser mais baratos e rápidos, com menos capacidade. O tamanho influencia os três fatores e nenhum dos lados vence em todas as tarefas.",
@@ -975,25 +937,6 @@ const AUTORAIS: Questao[] = [
             ],
             ["O tempo que o modelo leva para produzir cada resposta em produção", false],
             ["A quantidade de parâmetros ajustados durante o treino do modelo", false],
-        ],
-    },
-    {
-        statement:
-            "Qual serviço da AWS ajuda a detectar viés nos dados e no modelo e a explicar as previsões?",
-        explanation:
-            "Clarify examina dados e modelo em busca de viés e explica as previsões. Model Monitor observa desvios em produção, Ground Truth rotula dados e Feature Store organiza e serve features, sem análise de viés.",
-        topic: "IA responsável",
-        options: [
-            ["Amazon SageMaker Clarify, voltado à detecção de viés e à explicabilidade", true],
-            [
-                "Amazon SageMaker Model Monitor, voltado a acompanhar desvios do modelo em produção",
-                false,
-            ],
-            ["Amazon SageMaker Ground Truth, voltado à rotulagem de dados de treino", false],
-            [
-                "Amazon SageMaker Feature Store, voltado a armazenar e servir features aos modelos",
-                false,
-            ],
         ],
     },
     {
@@ -1268,20 +1211,6 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Depois de implantar um modelo em produção, quais recursos ajudam a monitorar a operação e a qualidade ao longo do tempo? (Selecione DUAS opções.)",
-        explanation:
-            "Amazon CloudWatch acompanha métricas e logs operacionais, e o SageMaker Model Monitor detecta desvios (drift) na qualidade do modelo. Polly gera voz, AWS Budgets controla gastos e Lex faz chatbots.",
-        topic: "Segurança e governança",
-        options: [
-            ["Amazon CloudWatch, para acompanhar métricas e logs operacionais", true],
-            ["Amazon SageMaker Model Monitor, para detectar desvios na qualidade do modelo", true],
-            ["Amazon Polly, para converter as previsões do modelo em áudio", false],
-            ["AWS Budgets, para definir alertas de gasto financeiro na conta", false],
-            ["Amazon Lex, para criar fluxos de conversa em chatbots", false],
-        ],
-    },
-    {
-        statement:
             "Para que as chamadas a um serviço de IA não trafeguem pela internet pública, mantendo o tráfego dentro da rede da AWS, qual recurso pode ser usado?",
         explanation:
             "PrivateLink cria o endpoint privado que mantém as chamadas dentro da rede da AWS. Internet Gateway é justamente a rota pública, peering liga VPCs entre si e Direct Connect conecta o data center do cliente à AWS, outro escopo.",
@@ -1303,11 +1232,11 @@ const AUTORAIS: Questao[] = [
         statement:
             "Uma empresa regulada precisa obter relatórios de conformidade e certificações da AWS (como ISO e SOC) para uma auditoria. Onde esses documentos ficam disponíveis?",
         explanation:
-            "Os relatórios e certificações da própria AWS, como ISO e SOC, ficam no AWS Artifact. Audit Manager coleta evidências do seu ambiente, Config avalia configurações de recursos e Organizations administra as contas.",
+            "Os relatórios e certificações da própria AWS, como ISO e SOC, ficam no AWS Artifact. CloudTrail registra as chamadas de API da conta, Config avalia configurações de recursos e Organizations administra as contas.",
         topic: "Segurança e governança",
         options: [
             ["AWS Artifact, o portal de relatórios de conformidade e certificações da AWS", true],
-            ["AWS Audit Manager, que coleta evidências das auditorias internas", false],
+            ["AWS CloudTrail, que registra as chamadas de API feitas nas contas", false],
             [
                 "AWS Config, que avalia continuamente a conformidade das configurações dos recursos",
                 false,
@@ -1610,15 +1539,15 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma equipe quer começar rapidamente a partir de modelos pré-treinados e soluções prontas dentro do Amazon SageMaker, com a possibilidade de ajustá-los às suas necessidades. Qual recurso atende a isso?",
+            "Uma equipe quer começar rapidamente a partir de modelos pré-treinados e soluções prontas dentro do Amazon SageMaker AI, com a possibilidade de ajustá-los às suas necessidades. Qual recurso atende a isso?",
         explanation:
-            "O SageMaker JumpStart oferece modelos pré-treinados e soluções prontas para acelerar o início de um projeto e permitir ajustes. O Canvas é voltado a modelos no-code, o Macie protege dados sensíveis e o Ground Truth cuida da rotulagem de dados.",
+            "O SageMaker JumpStart oferece modelos pré-treinados e soluções prontas para acelerar o início de um projeto e permitir ajustes. O Canvas é voltado a modelos no-code, o Macie protege dados sensíveis e o Pipelines orquestra fluxos de trabalho de ML.",
         topic: "Fundamentos de IA e ML",
         options: [
             ["Amazon SageMaker Canvas, para criar modelos em interface no-code", false],
             ["Amazon Macie, para descoberta de dados sensíveis", false],
             ["Amazon SageMaker JumpStart, hub de modelos e soluções prontas", true],
-            ["Amazon SageMaker Ground Truth, para rotulagem de dados de treino", false],
+            ["Amazon SageMaker Pipelines, para orquestrar fluxos de trabalho de ML", false],
         ],
     },
     {
@@ -1743,7 +1672,7 @@ const AUTORAIS: Questao[] = [
     {
         statement: "No Amazon Bedrock, o que é a família de modelos Amazon Titan?",
         explanation:
-            "O Amazon Titan é a família de foundation models desenvolvida pela AWS, disponível no Bedrock para geração de texto, embeddings e imagens. Não são instâncias de GPU, ferramenta de rotulagem nem serviço exclusivo de terceiros.",
+            "O Amazon Titan é a família de foundation models criada pela AWS; no Bedrock, os modelos Titan ativos hoje geram embeddings, como o Titan Text Embeddings V2 e o Titan Multimodal Embeddings G1. Não são instâncias de GPU, ferramenta de rotulagem nem serviço separado de terceiros.",
         topic: "IA generativa",
         options: [
             [
@@ -1751,7 +1680,7 @@ const AUTORAIS: Questao[] = [
                 false,
             ],
             [
-                "Foundation models criados pela própria AWS, oferecidos para tarefas como geração de texto e de embeddings",
+                "Foundation models criados pela própria AWS, usados no Bedrock para gerar embeddings de texto e de imagens",
                 true,
             ],
             [
@@ -1766,17 +1695,17 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma equipe de desenvolvimento quer um assistente de IA integrado ao ambiente de codificação que sugira trechos de código, explique funções e ajude a depurar. Qual serviço da AWS é o mais indicado?",
+            "Uma equipe de desenvolvimento quer um assistente de IA integrado ao ambiente de codificação que sugira trechos de código, explique funções e ajude a depurar. Qual ferramenta da AWS é a mais indicada?",
         explanation:
-            "O Amazon Q Developer é o assistente de IA generativa voltado a desenvolvedores, com sugestão e explicação de código e apoio à depuração. Q Business foca em dados corporativos, Comprehend em NLP e Polly em síntese de voz.",
+            "O Kiro é o ambiente de desenvolvimento agêntico da AWS, com chat, sugestões e geração de código e apoio à depuração. O Amazon Quick responde com base em dados corporativos, o Comprehend faz NLP e o Polly sintetiza voz.",
         topic: "IA generativa",
         options: [
             [
-                "Amazon Q Developer, o assistente para tarefas de código no ciclo de desenvolvimento",
+                "Kiro, o ambiente de desenvolvimento agêntico da AWS para tarefas de programação",
                 true,
             ],
             [
-                "Amazon Q Business, voltado a responder perguntas sobre documentos e dados corporativos internos",
+                "Amazon Quick, voltado a responder perguntas sobre documentos e dados corporativos internos",
                 false,
             ],
             [
@@ -1786,53 +1715,6 @@ const AUTORAIS: Questao[] = [
             [
                 "Amazon Polly, que converte texto em fala com vozes naturais em vários idiomas",
                 false,
-            ],
-        ],
-    },
-    {
-        statement:
-            "Uma pessoa iniciante quer experimentar e prototipar aplicativos de IA generativa em um ambiente pronto, sem escrever código nem provisionar infraestrutura. O que é o PartyRock, da AWS, nesse contexto?",
-        explanation:
-            "O PartyRock é um playground do Amazon Bedrock para construir e explorar apps de IA generativa sem código. Não é banco vetorial, serviço de treino distribuído nem ferramenta de linha de comando para deploy.",
-        topic: "IA generativa",
-        options: [
-            [
-                "Um banco de dados vetorial totalmente gerenciado usado para armazenar embeddings em aplicações de busca semântica de larga escala",
-                false,
-            ],
-            [
-                "Um serviço de treinamento distribuído que particiona grandes modelos entre várias GPUs automaticamente",
-                false,
-            ],
-            [
-                "Um playground no Amazon Bedrock para criar e experimentar apps de IA generativa sem código",
-                true,
-            ],
-            [
-                "Uma ferramenta de linha de comando para implantar modelos treinados em endpoints do SageMaker",
-                false,
-            ],
-        ],
-    },
-    {
-        statement:
-            "Uma cientista de dados quer acessar foundation models e soluções pré-construídas dentro do Amazon SageMaker para implantar e ajustar modelos rapidamente. Qual recurso oferece esse catálogo?",
-        explanation:
-            "O SageMaker JumpStart oferece um hub de foundation models e soluções pré-construídas para acelerar o deploy e o ajuste. Ground Truth faz rotulagem, Feature Store gerencia atributos e Clarify trata viés e explicabilidade.",
-        topic: "IA generativa",
-        options: [
-            [
-                "SageMaker Ground Truth, que gerencia fluxos de rotulagem de dados feita por revisores humanos ou de forma automatizada",
-                false,
-            ],
-            [
-                "SageMaker Feature Store, que armazena e serve atributos de ML de forma centralizada",
-                false,
-            ],
-            ["SageMaker Clarify, que analisa viés e explica as previsões dos modelos", false],
-            [
-                "SageMaker JumpStart, o hub de foundation models e soluções prontas para implantar",
-                true,
             ],
         ],
     },
@@ -2321,14 +2203,14 @@ const AUTORAIS: Questao[] = [
         statement:
             "Ao configurar uma Amazon Bedrock Knowledge Base, a equipe precisa escolher onde armazenar os vetores gerados a partir dos documentos. Qual opção lista serviços que podem servir como banco vetorial nesse cenário?",
         explanation:
-            "Bases de conhecimento do Bedrock podem usar bancos vetoriais como o OpenSearch Serverless e o Aurora PostgreSQL com a extensão pgvector para armazenar e buscar embeddings.",
+            "Bases de conhecimento do Bedrock podem usar bancos vetoriais como o OpenSearch Serverless e o Aurora PostgreSQL com a extensão pgvector para armazenar e buscar embeddings. Polly e Transcribe tratam voz, CloudFront e Route 53 cuidam de entrega e DNS, e o Quick Sight faz BI, sem servir de banco vetorial.",
         topic: "RAG e customização",
         options: [
             ["Amazon Polly e Amazon Transcribe", false],
             ["Amazon CloudFront e Amazon Route 53", false],
             ["Amazon OpenSearch Serverless e Aurora PostgreSQL com pgvector", true],
             [
-                "Amazon QuickSight conectado a um data warehouse Redshift, que indexa os vetores automaticamente para busca por similaridade",
+                "Amazon Quick Sight conectado a um data warehouse Redshift, que indexa os vetores automaticamente para busca por similaridade",
                 false,
             ],
         ],
@@ -2757,9 +2639,9 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Ao configurar um Agent for Amazon Bedrock para automatizar um processo, como a equipe define quais ações o agente pode executar, por exemplo chamar uma função que registra um pedido?",
+            "Ao criar um agente com o Amazon Bedrock AgentCore para automatizar um processo, como a equipe define quais ações o agente pode executar, por exemplo chamar uma função que registra um pedido?",
         explanation:
-            "Nos Agents for Amazon Bedrock, os action groups conectam o agente a funções (por exemplo, via Lambda), definindo as ações que ele pode executar.",
+            "No Amazon Bedrock AgentCore, as ações são ferramentas do agente: o AgentCore Gateway transforma APIs e funções do AWS Lambda em ferramentas compatíveis com MCP. A temperatura não ensina o agente a usar APIs, o banco vetorial só recupera contexto e o prompt negativo apenas restringe o comportamento.",
         topic: "Aplicações de foundation models",
         options: [
             [
@@ -2767,7 +2649,7 @@ const AUTORAIS: Questao[] = [
                 false,
             ],
             [
-                "Definindo action groups que associam o agente a funções, tipicamente via AWS Lambda",
+                "Definindo ferramentas para o agente, como uma função do AWS Lambda exposta pelo AgentCore Gateway",
                 true,
             ],
             [
@@ -2779,9 +2661,9 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Em que situação um agente (Agents for Amazon Bedrock) é mais adequado do que uma solução de RAG simples que apenas responde perguntas?",
+            "Em que situação um agente de IA, como os criados com o Amazon Bedrock AgentCore, é mais adequado do que uma solução de RAG simples que apenas responde perguntas?",
         explanation:
-            "Agentes se justificam quando a solução precisa agir e orquestrar várias etapas, como chamar APIs e sistemas; para apenas responder com base em documentos, o RAG basta.",
+            "Agentes se justificam quando a solução precisa agir e orquestrar várias etapas, como chamar APIs e sistemas; para apenas responder com base em documentos, o RAG basta. Resumir um texto curto, dispensar ações ou só gerar embeddings não pedem um agente.",
         topic: "Aplicações de foundation models",
         options: [
             [
@@ -2840,31 +2722,6 @@ const AUTORAIS: Questao[] = [
             [
                 "Transparência, que envolve comunicar de forma aberta como e quando a IA é usada",
                 true,
-            ],
-        ],
-    },
-    {
-        statement:
-            "Um banco usa um modelo para recomendar aprovação de crédito e precisa mostrar, para cada decisão, quais variáveis mais pesaram no resultado. Qual recurso ajuda a produzir essa atribuição de importância por previsão?",
-        explanation:
-            "O SageMaker Clarify fornece explicações de atributos baseadas em valores SHAP, indicando quanto cada variável contribuiu para uma previsão, o que apoia a explicabilidade.",
-        topic: "IA responsável",
-        options: [
-            [
-                "Amazon SageMaker Clarify, que calcula a contribuição de cada atributo para as previsões do modelo",
-                true,
-            ],
-            [
-                "Amazon SageMaker Model Monitor, voltado a detectar desvio de dados no ambiente de produção ao longo do tempo",
-                false,
-            ],
-            [
-                "Amazon Macie, que descobre e classifica dados sensíveis armazenados em buckets do Amazon S3",
-                false,
-            ],
-            [
-                "AWS CloudTrail, que registra as chamadas de API feitas na conta para fins de auditoria",
-                false,
             ],
         ],
     },
@@ -3027,31 +2884,6 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma empresa processa documentos com um modelo, mas quer que os casos em que o modelo tem baixa confiança sejam revisados por uma pessoa antes da decisão final. Qual serviço facilita esse fluxo de revisão humana?",
-        explanation:
-            "O Amazon A2I (Augmented AI) permite encaminhar previsões, por exemplo as de baixa confiança, para revisão humana antes da decisão final, implementando human-in-the-loop.",
-        topic: "IA responsável",
-        options: [
-            [
-                "Amazon Augmented AI (A2I), que integra revisão humana às previsões de modelos de machine learning",
-                true,
-            ],
-            [
-                "Amazon SageMaker Model Monitor, que acompanha a qualidade das previsões e detecta desvios ao longo do tempo",
-                false,
-            ],
-            [
-                "AWS Artifact, que fornece sob demanda relatórios de conformidade e certificações de segurança da AWS",
-                false,
-            ],
-            [
-                "Amazon Macie, que identifica e classifica automaticamente dados sensíveis armazenados no Amazon S3",
-                false,
-            ],
-        ],
-    },
-    {
-        statement:
             "Uma equipe precisa de um modelo cujas decisões possam ser entendidas diretamente pela sua própria estrutura, sem depender de ferramentas externas de explicação. Qual opção descreve um modelo intrinsecamente interpretável?",
         explanation:
             "Modelos como árvores de decisão simples e regressões lineares são intrinsecamente interpretáveis, pois sua estrutura revela como as entradas levam à saída, sem métodos de explicação posteriores.",
@@ -3102,9 +2934,9 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "O SageMaker Clarify revelou que um modelo de concessão de crédito favorece um grupo específico por causa de desequilíbrios no conjunto de treino. Qual é uma ação de mitigação apropriada?",
+            "Uma análise de viés revelou que um modelo de concessão de crédito favorece um grupo específico por causa de desequilíbrios no conjunto de treino. Qual é uma ação de mitigação apropriada?",
         explanation:
-            "Quando o viés vem de desequilíbrios nos dados, uma mitigação apropriada é rebalancear ou aumentar o conjunto de treino e reavaliar as métricas de viés, em vez de ignorar o achado.",
+            "Quando o viés vem de desequilíbrios nos dados, uma mitigação apropriada é rebalancear ou aumentar o conjunto de treino e reavaliar as métricas de viés. Esconder o relatório ou publicar sem mudanças ignora o problema, e aumentar os tokens não altera o que o modelo aprendeu.",
         topic: "IA responsável",
         options: [
             [
@@ -3154,7 +2986,7 @@ const AUTORAIS: Questao[] = [
         statement:
             "Uma empresa precisa garantir que os dados de treino no Amazon S3 e os artefatos de modelo fiquem criptografados em repouso, com controle sobre as chaves. Qual serviço atende a esse requisito?",
         explanation:
-            "O AWS KMS gerencia as chaves de criptografia usadas para proteger dados em repouso, como os conjuntos de treino no S3 e os artefatos de modelo.",
+            "O AWS KMS gerencia as chaves de criptografia usadas para proteger dados em repouso, como os conjuntos de treino no S3 e os artefatos de modelo. CloudWatch monitora métricas, Artifact fornece relatórios de conformidade e o Model Registry cataloga versões de modelos; nenhum deles gerencia chaves.",
         topic: "Segurança e governança",
         options: [
             [
@@ -3170,7 +3002,7 @@ const AUTORAIS: Questao[] = [
                 true,
             ],
             [
-                "Amazon Augmented AI, para incluir uma etapa de revisão humana nas previsões geradas pelos modelos já treinados",
+                "Amazon SageMaker Model Registry, para catalogar e versionar os artefatos de modelo gerados no treinamento",
                 false,
             ],
         ],
@@ -3272,31 +3104,6 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Meses após implantar um modelo, uma equipe percebe queda de desempenho porque a distribuição dos dados de entrada mudou em relação ao treino. Qual recurso ajuda a detectar automaticamente esse desvio (drift)?",
-        explanation:
-            "O SageMaker Model Monitor compara continuamente os dados e as previsões em produção com uma linha de base e emite alertas quando detecta desvio, indicando necessidade de retreino.",
-        topic: "Segurança e governança",
-        options: [
-            [
-                "AWS CloudTrail, que registra chamadas de API na conta, mas não avalia a distribuição estatística dos dados de entrada",
-                false,
-            ],
-            [
-                "AWS KMS, que gerencia chaves de criptografia, mas não acompanha mudanças na qualidade das previsões do modelo",
-                false,
-            ],
-            [
-                "AWS PrivateLink, que mantém o tráfego na rede privada, mas não mede o desempenho preditivo do modelo em produção",
-                false,
-            ],
-            [
-                "Amazon SageMaker Model Monitor, que compara os dados de produção com uma linha de base e alerta sobre desvios",
-                true,
-            ],
-        ],
-    },
-    {
-        statement:
             "Uma empresa usa um serviço gerenciado de IA da AWS. Segundo o modelo de responsabilidade compartilhada, qual tarefa é responsabilidade do cliente, e não da AWS?",
         explanation:
             "No modelo de responsabilidade compartilhada, a AWS cuida da segurança da nuvem (a infraestrutura física), enquanto o cliente é responsável pela segurança na nuvem, como IAM e a classificação e proteção dos seus dados.",
@@ -3370,7 +3177,7 @@ const AUTORAIS: Questao[] = [
         statement:
             "Depois de publicar um endpoint de inferência, a equipe de operações quer acompanhar quase em tempo real o número de invocações, a latência e a taxa de erros, com alarmes automáticos. Qual serviço é o mais indicado?",
         explanation:
-            "O Amazon CloudWatch coleta métricas operacionais como invocações, latência e erros de um endpoint e permite configurar alarmes automáticos sobre esses indicadores.",
+            "O Amazon CloudWatch coleta métricas operacionais como invocações, latência e erros de um endpoint e permite configurar alarmes automáticos sobre esses indicadores. Artifact fornece relatórios de conformidade, KMS gerencia chaves e CloudTrail registra chamadas de API para auditoria.",
         topic: "Segurança e governança",
         options: [
             [
@@ -3386,7 +3193,7 @@ const AUTORAIS: Questao[] = [
                 true,
             ],
             [
-                "Amazon A2I, que adiciona revisão humana às previsões, mas não monitora indicadores operacionais da infraestrutura",
+                "AWS CloudTrail, que registra as chamadas de API para auditoria, mas não calcula métricas de desempenho do endpoint",
                 false,
             ],
         ],

--- a/backend/scripts/data/aif-c01-questoes.ts
+++ b/backend/scripts/data/aif-c01-questoes.ts
@@ -6,6 +6,10 @@
 // múltipla escolha terminam com "(Selecione DUAS opções.)" e têm cinco opções
 // com duas corretas.
 
+// As questões autorais vêm primeiro; os lotes importados do cloudcertprep entram
+// depois, pelo índice aif-c01-questoes-cloudcertprep.ts.
+import { QUESTOES_CLOUDCERTPREP } from "./aif-c01-questoes-cloudcertprep.ts";
+
 export type Questao = {
     statement: string;
     explanation: string;
@@ -13,7 +17,7 @@ export type Questao = {
     options: [string, boolean][];
 };
 
-export const QUESTOES: Questao[] = [
+const AUTORAIS: Questao[] = [
     {
         statement:
             "Uma equipe apresenta machine learning para a liderança. Qual afirmação define corretamente a relação entre inteligência artificial (IA), machine learning (ML) e deep learning?",
@@ -3458,3 +3462,5 @@ export const QUESTOES: Questao[] = [
         ],
     },
 ];
+
+export const QUESTOES: Questao[] = [...AUTORAIS, ...QUESTOES_CLOUDCERTPREP];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d1.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d1.ts
@@ -1,0 +1,1401 @@
+// Questões do simulado AWS Certified Cloud Practitioner (CLF-C02), domínio 1 da prova
+// (Cloud Concepts), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aws-ccp-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D1: Questao[] = [
+    {
+        statement:
+            "Quais das opções a seguir estão relacionadas à confiabilidade na Nuvem AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Confiabilidade é a capacidade de a carga de trabalho funcionar corretamente, obter recursos conforme a demanda e se recuperar rapidamente de falhas. Menor privilégio é prática de Segurança, a maioria dos serviços da AWS é regional e não global, e compensar clientes é crédito de SLA, não princípio de design.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Aplicar o princípio do menor privilégio a todos os recursos da AWS", false],
+            ["Provisionar automaticamente novos recursos para atender à demanda", true],
+            [
+                "Todos os serviços da AWS são globais, o que ajuda a atender usuários internacionais",
+                false,
+            ],
+            ["Compensar financeiramente os clientes quando ocorrerem problemas", false],
+            ["Recuperar-se rapidamente de falhas na infraestrutura ou nos serviços", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa japonesa hospeda suas aplicações em instâncias do Amazon EC2 na Região de Tóquio. Depois de abrir filiais nos Estados Unidos, os usuários americanos passaram a reclamar de alta latência. O que a empresa pode fazer para reduzir a latência desses usuários com o menor custo?",
+        explanation:
+            "Implantar instâncias em uma Região nos EUA aproxima a aplicação dos usuários e reduz a latência sem grande custo. O roteamento por latência do Route 53 não resolve se tudo continua em Tóquio, um domínio novo não muda a distância física e construir um data center exige alto investimento de capital.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Aplicar a política de roteamento baseada em latência do Amazon Route 53", false],
+            ["Registrar um novo nome de domínio americano para atender os usuários dos EUA", false],
+            ["Construir um data center nos EUA e adotar um modelo de nuvem híbrida", false],
+            ["Implantar novas instâncias do Amazon EC2 em uma Região localizada nos EUA", true],
+        ],
+    },
+    {
+        statement:
+            "Quais são benefícios de hospedar a infraestrutura na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Na AWS, recursos são provisionados em minutos, o que aumenta a agilidade, e a AWS cuida da segurança da nuvem: instalações, hardware e rede subjacente. O armazenamento é cobrado pelo uso, o cliente não controla o hardware físico e operar as aplicações continua sendo responsabilidade do cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Mais velocidade e agilidade para provisionar recursos e lançar produtos", true],
+            ["Armazenamento gratuito e ilimitado para todos os dados da empresa", false],
+            [
+                "Controle total sobre o hardware físico e as instalações dos data centers da AWS",
+                false,
+            ],
+            ["A AWS assume a operação das aplicações desenvolvidas pelos clientes", false],
+            ["A AWS cuida da segurança física e da infraestrutura de rede subjacente", true],
+        ],
+    },
+    {
+        statement: "Qual é a vantagem da prática recomendada pela AWS de desacoplar as aplicações?",
+        explanation:
+            "Desacoplar é fazer os componentes funcionarem de forma independente, para que a falha de um não se propague aos demais. Tratar a aplicação como unidade única descreve o monólito, atualizar um monólito exige implantar tudo junto e rastrear chamadas de API é função do AWS CloudTrail.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Permite tratar a aplicação como uma unidade única e coesa", false],
+            ["Reduz interdependências para que falhas não afetem outros componentes", true],
+            ["Permite atualizar qualquer aplicação monolítica de forma rápida e fácil", false],
+            ["Permite rastrear qualquer chamada de API feita a qualquer serviço da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "A elasticidade é um dos princípios de arquitetura na nuvem mais importantes recomendados pela AWS. Como esse princípio melhora o design da sua arquitetura?",
+        explanation:
+            "Elasticidade é provisionar e liberar recursos automaticamente conforme a demanda muda, pagando só pelo necessário. O Elastic Load Balancer distribui tráfego, mas quem adiciona ou remove instâncias é o Auto Scaling; reduzir interdependências é acoplamento fraco; e o conceito vale para recursos na nuvem, não on-premises.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "Escalando automaticamente os recursos on-premises conforme a variação da demanda",
+                false,
+            ],
+            ["Escalando automaticamente os recursos da AWS com um Elastic Load Balancer", false],
+            ["Reduzindo ao máximo as interdependências entre os componentes da aplicação", false],
+            [
+                "Provisionando automaticamente os recursos da AWS necessários conforme a demanda",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual das opções a seguir NÃO faz parte dos modelos de computação em nuvem descritos pela AWS?",
+        explanation:
+            "Os modelos de serviço de computação em nuvem descritos pela AWS são IaaS, PaaS e SaaS; redes como serviço (NaaS) não é um deles. IaaS entrega infraestrutura virtualizada, PaaS entrega uma plataforma gerenciada para implantar aplicações e SaaS entrega o software pronto ao usuário final.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Plataforma como serviço (PaaS)", false],
+            ["Infraestrutura como serviço (IaaS)", false],
+            ["Software como serviço (SaaS)", false],
+            ["Redes como serviço (NaaS)", true],
+        ],
+    },
+    {
+        statement:
+            "De acordo com as boas práticas, como uma aplicação deve ser projetada para ser executada na Nuvem AWS?",
+        explanation:
+            "Componentes fracamente acoplados podem escalar, falhar e ser atualizados de forma independente, sem efeito em cascata. Componentes fortemente acoplados propagam falhas, o design monolítico dificulta escalar partes isoladas e componentes que guardam estado localmente atrapalham a escalabilidade horizontal.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Com componentes fortemente acoplados", false],
+            ["Com componentes fracamente acoplados", true],
+            ["Com componentes monolíticos", false],
+            ["Com componentes com estado (stateful)", false],
+        ],
+    },
+    {
+        statement: "Como a AWS reduz o tempo necessário para provisionar recursos de TI?",
+        explanation:
+            "Na AWS, recursos são criados sob demanda por APIs, SDKs, CLI ou templates, em minutos e sem compra de hardware. A AWS não usa sistema de chamados nem fluxo com fornecedores para liberar recursos, e validação de código é qualidade de software, sem relação com o tempo de provisionamento.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Oferece uma plataforma on-line de chamados para solicitar recursos de TI", false],
+            ["Oferece serviços de validação automática do código das aplicações", false],
+            ["Permite provisionar recursos de forma programática, por meio de APIs", true],
+            [
+                "Automatiza o processo de solicitação de recursos aos fornecedores de TI da empresa",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Servidores web executados no Amazon EC2 acessam uma aplicação legada que roda no data center da empresa. Qual termo descreve esse modelo?",
+        explanation:
+            "Quando recursos na AWS se comunicam com sistemas que continuam no data center da empresa, a arquitetura é híbrida. Nativo da nuvem descreve aplicações feitas só para a nuvem, rede de parceiros é o programa AWS Partner Network e IaaS é um modelo de serviço, não a combinação de nuvem com on-premises.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Nativo da nuvem (cloud-native)", false],
+            ["Rede de parceiros", false],
+            ["Arquitetura de nuvem híbrida", true],
+            ["Infraestrutura como serviço", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é um princípio de design de arquitetura da Nuvem AWS?",
+        explanation:
+            "Acoplamento fraco faz os componentes interagirem por interfaces bem definidas, para que cada um escale, mude ou falhe sem afetar os outros. Pontos únicos de falha são um antipadrão, o design monolítico dificulta escalar partes isoladas e a escalabilidade vertical fica limitada ao tamanho de um único recurso.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implementar pontos únicos de falha", false],
+            ["Implementar o acoplamento fraco", true],
+            ["Implementar um design monolítico", false],
+            ["Implementar escalabilidade vertical", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é uma vantagem de transferir a infraestrutura de um data center on-premises para a Nuvem AWS?",
+        explanation:
+            "Ao delegar à AWS a gestão da infraestrutura física, a empresa direciona equipe e orçamento para o que diferencia o negócio. Os gastos com TI continuam, pois paga-se pelo uso; instalar servidores nos clientes é o oposto de migrar para a nuvem; e aplicar patches no sistema operacional das instâncias segue sendo tarefa do cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Permite que a empresa elimine totalmente os gastos com TI", false],
+            ["Permite que a empresa instale um servidor no data center de cada cliente", false],
+            ["Permite que a empresa se concentre nas atividades do negócio", true],
+            ["Permite que a empresa deixe os servidores sem aplicar patches", false],
+        ],
+    },
+    {
+        statement:
+            "Como um usuário pode se proteger de interrupções nos serviços da AWS caso um desastre natural atinja toda uma área geográfica?",
+        explanation:
+            "Um desastre que atinge toda uma área geográfica pode derrubar uma Região inteira, então implantar em várias Regiões mantém a aplicação no ar. Zonas de Disponibilidade ficam na mesma Região, a nuvem híbrida na mesma área sofre o mesmo impacto e o AWS Artifact é um portal de relatórios de conformidade, não de armazenamento.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantando as aplicações em várias Zonas de Disponibilidade de uma Região", false],
+            ["Usando nuvem híbrida dentro da mesma área geográfica", false],
+            ["Implantando as aplicações em várias Regiões da AWS", true],
+            ["Guardando artefatos no AWS Artifact e replicando-os entre Regiões", false],
+        ],
+    },
+    {
+        statement:
+            "Qual estratégia de recuperação de desastres oferece a menor probabilidade de tempo de inatividade?",
+        explanation:
+            "No multissite ativo-ativo, cópias completas da carga de trabalho rodam ao mesmo tempo em mais de um local, e se um falhar o outro já atende todo o tráfego. Backup e restauração tem a recuperação mais lenta, a luz piloto mantém só o núcleo ativo e o warm standby roda uma versão reduzida que precisa escalar antes de assumir a carga.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Backup e restauração", false],
+            ["Luz piloto (pilot light)", false],
+            ["Warm standby", false],
+            ["Multissite ativo-ativo", true],
+        ],
+    },
+    {
+        statement:
+            "Quais opções podem ajudar a avaliar uma aplicação antes de migrá-la para a nuvem? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Professional Services oferece consultores da própria AWS para avaliar e planejar migrações, e a AWS Partner Network reúne parceiros com experiência comprovada em migração. O Trusted Advisor verifica ambientes que já estão na AWS, o Systems Manager gerencia a operação dos recursos e o Secrets Manager guarda credenciais.",
+        topic: "Migração",
+        options: [
+            ["Verificações do AWS Trusted Advisor", false],
+            ["AWS Professional Services", true],
+            ["AWS Systems Manager", false],
+            ["AWS Partner Network (APN)", true],
+            ["AWS Secrets Manager", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é uma proposta de valor da Nuvem AWS?",
+        explanation:
+            "No modelo de pagamento conforme o uso não há contrato de longo prazo: o cliente usa os serviços sob demanda e pode parar quando quiser. A segurança na nuvem é do cliente (a AWS cuida da segurança da nuvem), servidores são provisionados em minutos, e não em dias, e as aplicações continuam sob gestão do cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["A AWS é responsável pela segurança na Nuvem AWS", false],
+            ["Não é necessário firmar um contrato de longo prazo", true],
+            ["É possível provisionar novos servidores em alguns dias", false],
+            ["A AWS gerencia as aplicações dos usuários na Nuvem AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são os benefícios de desenvolver e executar uma nova aplicação na Nuvem AWS em comparação com um ambiente on-premises? (Selecione DUAS opções.)",
+        explanation:
+            "Na AWS é simples usar várias Zonas de Disponibilidade, balanceadores de carga e serviços gerenciados para ter alta disponibilidade, e a elasticidade ajusta a capacidade à demanda. A replicação global dos dados depende da configuração do cliente, e operar a aplicação e aplicar seus patches continua sendo responsabilidade do cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "A AWS distribui os dados automaticamente pelo mundo para aumentar a durabilidade",
+                false,
+            ],
+            ["A AWS se encarrega de operar a aplicação no dia a dia", false],
+            ["A AWS facilita projetar a arquitetura para alta disponibilidade", true],
+            ["A AWS acomoda com facilidade as variações de demanda da aplicação", true],
+            ["A AWS se encarrega de aplicar os patches de segurança da aplicação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma solução capaz de suportar o crescimento de usuários, de tráfego ou do volume de dados sem perda de desempenho está alinhada a qual princípio de arquitetura na nuvem?",
+        explanation:
+            "Suportar crescimento sem perda de desempenho é escalabilidade, obtida na nuvem com elasticidade: recursos entram e saem automaticamente conforme a carga. Pensar em paralelo busca executar tarefas simultâneas para ganhar velocidade, desacoplar evita falhas em cascata e projetar para falhas trata de resiliência.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Pensar em paralelo", false],
+            ["Implementar elasticidade", true],
+            ["Desacoplar os componentes", false],
+            ["Projetar para falhas", false],
+        ],
+    },
+    {
+        statement:
+            "Qual benefício da Nuvem AWS elimina a necessidade de os usuários tentarem estimar o uso futuro da infraestrutura?",
+        explanation:
+            "Com a elasticidade, os recursos aumentam ou diminuem conforme a demanda real, então não é preciso prever e comprar capacidade para o pico futuro. Implantar em várias Regiões dá alcance global, a segurança da nuvem não trata de capacidade e as economias de escala reduzem preços, mas não dispensam a estimativa de uso.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantação rápida e fácil de aplicações em várias Regiões do mundo", false],
+            ["Segurança da Nuvem AWS", false],
+            ["Elasticidade da Nuvem AWS", true],
+            ["Custos variáveis menores graças às enormes economias de escala", false],
+        ],
+    },
+    {
+        statement:
+            "Como a Nuvem AWS pode aumentar a produtividade das equipes depois da migração de um data center on-premises?",
+        explanation:
+            "Na AWS, as equipes provisionam a infraestrutura por conta própria em minutos, sem esperar a compra e a instalação de hardware. O ganho não vem de a infraestrutura ser mais rápida, a configuração das aplicações continua com o cliente e a segurança e a conformidade na nuvem seguem sendo responsabilidade do cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "As equipes não precisam esperar semanas pelo provisionamento da infraestrutura",
+                true,
+            ],
+            [
+                "A infraestrutura da Nuvem AWS é muito mais rápida que a de um data center on-premises",
+                false,
+            ],
+            [
+                "A AWS assume o gerenciamento da configuração das aplicações em nome das equipes",
+                false,
+            ],
+            ["As equipes deixam de precisar tratar de questões de segurança e conformidade", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é um exemplo de agilidade na Nuvem AWS?",
+        explanation:
+            "Agilidade na nuvem é obter recursos em minutos, e não em semanas, o que permite experimentar e entregar mais rápido. Vários tipos de instância dão flexibilidade para escolher a capacidade, serviços gerenciados reduzem o trabalho operacional e o faturamento consolidado apenas une as cobranças de várias contas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Acesso a vários tipos e tamanhos de instância", false],
+            ["Acesso a serviços gerenciados pela própria AWS", false],
+            ["Uso do faturamento consolidado para gerar uma única fatura", false],
+            ["Redução do tempo para obter novos recursos de computação", true],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é uma boa prática ao projetar soluções na AWS?",
+        explanation:
+            "Automatizar a criação da infraestrutura permite testar arquiteturas diferentes com rapidez e menos erro humano. Na nuvem o design pode mudar com facilidade, reservas servem para cargas estáveis e previsíveis, não para testes, e superdimensionar a capacidade para picos é prática on-premises que a elasticidade substitui.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "Investir pesado no projeto inicial do ambiente, pois é difícil mudar o design depois",
+                false,
+            ],
+            ["Usar reservas da AWS para reduzir custos ao testar o ambiente de produção", false],
+            [
+                "Automatizar sempre que possível para facilitar a experimentação de arquiteturas",
+                true,
+            ],
+            [
+                "Provisionar uma grande capacidade de computação para absorver qualquer pico de carga",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            'O princípio "projete para falhas e nada falhará" é muito importante ao desenhar uma arquitetura na Nuvem AWS. Quais opções ajudam a seguir esse princípio? (Selecione DUAS opções.)',
+        explanation:
+            "Várias Zonas de Disponibilidade dão redundância física, e o Elastic Load Balancing detecta alvos com falha e envia tráfego só aos saudáveis, então a falha de um componente não derruba a aplicação. MFA e testes de penetração são controles de segurança, e a escalabilidade vertical concentra a carga em um único recurso.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Autenticação multifator (MFA)", false],
+            ["Zonas de Disponibilidade", true],
+            ["Elastic Load Balancing", true],
+            ["Testes de penetração", false],
+            ["Escalabilidade vertical", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são princípios de design importantes a adotar ao projetar sistemas na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Automatizar reduz erros manuais e acelera a recuperação, e eliminar pontos únicos de falha com redundância mantém o sistema operando quando um componente falha. Usar serviços globais ou regionais depende da carga, pagamento conforme o uso é modelo de cobrança e tratar servidores como fixos contraria a ideia de recursos descartáveis.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Usar sempre serviços globais em vez de serviços regionais", false],
+            ["Escolher sempre o pagamento conforme o uso", false],
+            ["Tratar os servidores como recursos fixos e permanentes", false],
+            ["Automatizar tudo o que for possível na infraestrutura", true],
+            ["Eliminar pontos únicos de falha na arquitetura", true],
+        ],
+    },
+    {
+        statement:
+            "Quais são vantagens da computação em nuvem em relação aos data centers tradicionais? (Selecione DUAS opções.)",
+        explanation:
+            "A nuvem oferece infraestrutura distribuída em várias Regiões e Zonas de Disponibilidade e capacidade provisionada sob demanda, sem compra antecipada de hardware, algo caro em um data center próprio. Virtualização, capacidade reservada e servidores dedicados também existem em data centers tradicionais, então não diferenciam a nuvem.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Infraestrutura distribuída em várias Regiões", true],
+            ["Capacidade sob demanda, sem compra de hardware", true],
+            ["Recursos de computação virtualizados em hipervisor", false],
+            ["Capacidade de computação reservada com antecedência", false],
+            ["Hospedagem em servidores dedicados a um só cliente", false],
+        ],
+    },
+    {
+        statement:
+            "Qual afirmação descreve melhor o pilar Excelência operacional do AWS Well-Architected Framework?",
+        explanation:
+            "Excelência operacional trata de executar e monitorar cargas de trabalho e melhorar continuamente processos e procedimentos. Recuperar-se de falhas descreve Confiabilidade, usar recursos com eficiência descreve Eficiência de desempenho e gerenciar data centers não é pilar, pois essa operação física fica com a AWS.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["A capacidade de um sistema se recuperar de falhas de forma controlada", false],
+            [
+                "O uso eficiente de recursos de computação para atender aos requisitos da carga",
+                false,
+            ],
+            ["A capacidade de monitorar sistemas e aprimorar processos e procedimentos", true],
+            ["A capacidade de gerenciar as operações do data center com mais eficiência", false],
+        ],
+    },
+    {
+        statement:
+            "Uma engenheira de nuvem gerencia uma aplicação web de e-commerce na AWS, hospedada em seis instâncias do Amazon EC2. Certo dia, três das instâncias falharam, mas nenhum cliente foi afetado. O que ela fez corretamente nesse cenário?",
+        explanation:
+            "Um sistema tolerante a falhas continua funcionando mesmo quando parte dos componentes falha, como na perda de três das seis instâncias sem impacto aos clientes. Elasticidade e escalabilidade tratam de ajustar ou ampliar a capacidade conforme a demanda, e a criptografia protege dados, sem garantir continuidade diante de falhas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Construiu um sistema elástico", false],
+            ["Construiu um sistema tolerante a falhas", true],
+            ["Construiu um sistema com dados criptografados", false],
+            ["Construiu um sistema escalável", false],
+        ],
+    },
+    {
+        statement: "O uso do Amazon EC2 se enquadra em qual modelo de computação em nuvem?",
+        explanation:
+            "O Amazon EC2 é IaaS: a AWS fornece a infraestrutura virtualizada e o cliente gerencia sistema operacional, middleware e aplicações. No PaaS o cliente só implanta o código em uma plataforma gerenciada, no SaaS recebe o software pronto, e um mesmo serviço não é classificado como IaaS e SaaS ao mesmo tempo.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["IaaS e SaaS", false],
+            ["IaaS", true],
+            ["SaaS", false],
+            ["PaaS", false],
+        ],
+    },
+    {
+        statement: "Ao construir aplicações na AWS, qual prática é recomendada?",
+        explanation:
+            "Desacoplar os componentes, com comunicação por APIs ou filas, permite que cada parte escale, falhe e seja atualizada sem derrubar o restante. Menor privilégio é controle de acesso, não de segurança física; o hardware é escolhido e gerenciado pela AWS; e políticas do IAM definem permissões, sem efeito no desempenho.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Reforçar a segurança física aplicando o princípio do menor privilégio", false],
+            ["Garantir que a aplicação rode em hardware de fornecedores confiáveis", false],
+            ["Usar políticas do IAM para manter o desempenho da aplicação", false],
+            ["Desacoplar os componentes para que funcionem de forma independente", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa cargas de trabalho críticas para o negócio na AWS e não aceita nenhum tempo de inatividade, mesmo que um desastre natural atinja uma Região inteira. Qual é a prática recomendada para proteger essas cargas?",
+        explanation:
+            "Com os recursos em outra Região e estratégia ativo-ativo, as duas Regiões atendem tráfego ao mesmo tempo e uma assume se a outra cair. O CloudFront entrega conteúdo em cache e não faz failover da aplicação, várias Zonas de Disponibilidade não bastam se o desastre atingir a Região inteira e restaurar backups gera inatividade.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "Replicar dados em locais de borda e usar o Amazon CloudFront para failover automático",
+                false,
+            ],
+            ["Implantar os recursos em várias Zonas de Disponibilidade da mesma Região", false],
+            ["Criar backups pontuais em outra sub-rede e restaurá-los após o desastre", false],
+            ["Implantar os recursos em outra Região e adotar uma estratégia ativo-ativo", true],
+        ],
+    },
+    {
+        statement:
+            "Qual item deve ser considerado em uma análise de custo total de propriedade (TCO) que compara o custo de executar uma aplicação na AWS com o de executá-la on-premises?",
+        explanation:
+            "Na comparação de TCO entram os custos que mudam entre on-premises e nuvem, como a compra e a manutenção de hardware físico, que na AWS ficam com o provedor. Desenvolvimento da aplicação, pesquisa de mercado e análise de negócio custam praticamente o mesmo em qualquer forma de hospedagem.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Desenvolvimento da aplicação", false],
+            ["Pesquisa de mercado", false],
+            ["Análise de negócio", false],
+            ["Hardware físico", true],
+        ],
+    },
+    {
+        statement: "Qual afirmação descreve a agilidade da Nuvem AWS?",
+        explanation:
+            "Agilidade é a rapidez para disponibilizar recursos: na AWS eles são provisionados em minutos pelo console, CLI ou API, e não em semanas. Hospedar em várias Regiões descreve alcance global, o cliente não personaliza o hardware da AWS e pagar adiantado para ter desconto é característica de Instâncias Reservadas e Savings Plans.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["A AWS permite hospedar aplicações em várias Regiões ao redor do mundo", false],
+            ["A AWS oferece hardware personalizável pelo menor custo possível", false],
+            ["A AWS permite provisionar recursos em questão de minutos", true],
+            ["A AWS permite pagar antecipadamente para reduzir custos", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são os benefícios de usar um serviço gerenciado da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Em serviços gerenciados a AWS cuida de provisionamento, patches e manutenção da infraestrutura, o que reduz a complexidade operacional e deixa a equipe livre para entregar soluções mais rápido. Controle total da infraestrutura é característica de IaaS, criptografar os dados continua sendo do cliente e os patches passam a ser feitos pela AWS.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Oferece controle total sobre a infraestrutura virtual", false],
+            ["Permite que os clientes entreguem novas soluções mais rápido", true],
+            ["Reduz a complexidade operacional para a equipe do cliente", true],
+            ["Elimina a necessidade de criptografar os dados", false],
+            ["Permite que os desenvolvedores controlem toda a aplicação de patches", false],
+        ],
+    },
+    {
+        statement: "Qual é o benefício de usar uma API para acessar os serviços da AWS?",
+        explanation:
+            "Com APIs, é possível criar, configurar e monitorar recursos da AWS por código, automatizando o que seria feito manualmente no console. A API é só uma interface de gerenciamento: não melhora o desempenho dos recursos, não altera as cotas da conta e não reduz por si só o número de desenvolvedores.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Melhora o desempenho dos recursos da AWS em execução", false],
+            ["Aumenta os limites de serviço (cotas) da conta AWS", false],
+            ["Reduz a quantidade de desenvolvedores necessária na equipe", false],
+            ["Permite gerenciar recursos da AWS de forma programática", true],
+        ],
+    },
+    {
+        statement:
+            "Quais princípios de design estão relacionados à eficiência de desempenho na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Os princípios de Eficiência de desempenho incluem tornar-se global em minutos, implantando em várias Regiões para reduzir a latência, e usar arquiteturas serverless, que escalam sem gerenciar servidores. Segurança em todas as camadas, identidade forte e rastreabilidade com logs de auditoria são princípios do pilar Segurança.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantar em várias Regiões para atender clientes globais", true],
+            ["Aplicar segurança em todas as camadas da arquitetura", false],
+            ["Implementar controles fortes de identidade e acesso aos recursos", false],
+            ["Adotar arquiteturas sem servidor (serverless)", true],
+            ["Habilitar logs de auditoria em todas as contas", false],
+        ],
+    },
+    {
+        statement:
+            "Por que uma organização decidiria usar a AWS em vez de um data center on-premises? (Selecione DUAS opções.)",
+        explanation:
+            "Na AWS os recursos são elásticos, acompanhando a demanda sem superdimensionar, e o pagamento pelo uso evita grandes investimentos iniciais. Licenças de software comercial são cobradas à parte, suporte técnico exige plano pago (o Basic cobre só conta e faturamento) e a conformidade é comprovada por relatórios no AWS Artifact, não por visitas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Licenças gratuitas de softwares comerciais", false],
+            ["Suporte técnico gratuito em todos os planos", false],
+            ["Recursos elásticos que acompanham a demanda", true],
+            ["Visitas presenciais aos data centers para auditoria", false],
+            ["Economia de custos com pagamento pelo uso", true],
+        ],
+    },
+    {
+        statement:
+            "Qual framework, criado pelo AWS Professional Services, ajuda as organizações a traçar um roteiro para uma adoção bem-sucedida da nuvem?",
+        explanation:
+            "O AWS Cloud Adoption Framework (AWS CAF), criado pelo AWS Professional Services, orienta a jornada de adoção da nuvem em seis perspectivas: Negócios, Pessoas, Governança, Plataforma, Segurança e Operações. O Secrets Manager guarda segredos, o AWS WAF é um firewall de aplicações web e o Amazon EFS é um sistema de arquivos.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["AWS Secrets Manager", false],
+            ["AWS CAF", true],
+            ["AWS WAF", false],
+            ["Amazon EFS", false],
+        ],
+    },
+    {
+        statement:
+            "Por que muitas startups preferem a AWS a soluções on-premises tradicionais? (Selecione DUAS opções.)",
+        explanation:
+            "Startups trocam o investimento inicial em hardware por custos variáveis e lançam produtos mais rápido porque não precisam construir nem operar data centers. A AWS cobra pelo uso desde o início, construir data centers mais rápido não é proposta de valor da AWS e as despesas operacionais continuam existindo, agora variáveis.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Podem pagar pelos serviços só depois que o negócio der certo", false],
+            [
+                "Contam com data centers construídos mais rápido que em qualquer outro provedor",
+                false,
+            ],
+            ["Reduzem o tempo de lançamento ao focar no negócio, e não em data centers", true],
+            ["Deixam de ter qualquer despesa operacional com a infraestrutura", false],
+            ["Trocam grandes despesas de capital por custos variáveis baixos", true],
+        ],
+    },
+    {
+        statement:
+            "Como parte do AWS Migration Acceleration Program (MAP), o que a AWS oferece para acelerar a adoção da nuvem por grandes empresas? (Selecione DUAS opções.)",
+        explanation:
+            "No MAP, a AWS oferece o AWS Professional Services e parceiros da AWS com experiência em migração, além de metodologia, ferramentas e incentivos. O AWS Artifact dá acesso a relatórios de conformidade, o Amazon Athena consulta dados no Amazon S3 com SQL e o Amazon Pinpoint envia mensagens de marketing aos clientes.",
+        topic: "Migração",
+        options: [
+            ["Parceiros da AWS", true],
+            ["Relatórios do AWS Artifact", false],
+            ["AWS Professional Services", true],
+            ["Amazon Athena", false],
+            ["Amazon Pinpoint", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa instâncias do Amazon EC2 para executar sua loja virtual na AWS. Se o site ficar indisponível, a empresa perderá muito dinheiro a cada minuto fora do ar. Qual princípio de design a empresa deve usar para minimizar o risco de interrupção?",
+        explanation:
+            "Tolerância a falhas mantém o sistema funcionando mesmo quando componentes falham, com redundância entre Zonas de Disponibilidade e failover automático, o que reduz o risco de a loja sair do ar. Menor privilégio é princípio de segurança, luz piloto é estratégia de recuperação após o desastre e multithreading é técnica de programação.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Menor privilégio", false],
+            ["Luz piloto (pilot light)", false],
+            ["Tolerância a falhas", true],
+            ["Multithreading", false],
+        ],
+    },
+    {
+        statement:
+            "Qual das opções a seguir é uma boa prática básica para tornar uma aplicação altamente disponível na AWS?",
+        explanation:
+            "Implantar em pelo menos duas Zonas de Disponibilidade mantém a aplicação no ar se uma AZ falhar, e é a prática básica de alta disponibilidade. Várias Regiões atendem requisitos de recuperação de desastres com mais custo e complexidade, dois servidores na mesma AZ não resistem à falha dela e reescrever o código não resolve falhas de infraestrutura.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantar a aplicação em pelo menos duas Zonas de Disponibilidade", true],
+            ["Implantar a aplicação em várias Regiões da AWS", false],
+            ["Implantar a aplicação em dois servidores na mesma Zona de Disponibilidade", false],
+            ["Reescrever o código da aplicação para tratar todas as requisições recebidas", false],
+        ],
+    },
+    {
+        statement:
+            "Quais itens devem ser levados em conta em uma análise de TCO que compara os custos de executar uma aplicação na AWS e on-premises? (Selecione DUAS opções.)",
+        explanation:
+            "O TCO compara o que a empresa gasta on-premises, como equipe de TI, mão de obra, energia e refrigeração do data center, com o custo na AWS, onde esses gastos físicos ficam com o provedor. O Amazon EBS é armazenamento em bloco, sem poder de computação, e arquitetura e compatibilidade do software são temas técnicos, não custos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Custos de mão de obra e de TI", true],
+            ["Refrigeração e consumo de energia", true],
+            ["Poder de computação dos volumes do Amazon EBS", false],
+            ["Arquitetura do software", false],
+            ["Compatibilidade do software", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa avalia a AWS como provedora de computação em nuvem. Quais vantagens ela terá? (Selecione DUAS opções.)",
+        explanation:
+            "Com a AWS, a capacidade acompanha a demanda, sem precisar adivinhar quanto provisionar, e investimentos iniciais em hardware viram despesas operacionais conforme o uso. O cliente continua monitorando seus servidores e aplicações, a conformidade é compartilhada e as instâncias seguem tipos padronizados, sem hardware sob medida.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Elimina a necessidade de monitorar servidores e aplicações", false],
+            ["Gerencia todas as tarefas de conformidade e auditoria", false],
+            ["Fornece hardware personalizado para atender a qualquer especificação", false],
+            ["Elimina a necessidade de adivinhar a capacidade de infraestrutura", true],
+            ["Permite trocar despesas de capital por despesas operacionais", true],
+        ],
+    },
+    {
+        statement:
+            "Qual modelo de implantação de computação em nuvem conecta a infraestrutura e as aplicações entre recursos na nuvem e recursos existentes que não estão na nuvem?",
+        explanation:
+            "O modelo híbrido conecta recursos na nuvem à infraestrutura que continua fora dela, como um data center on-premises. No modelo on-premises tudo fica nas instalações da empresa, no modelo em nuvem tudo roda no provedor e implantação mista não é um dos modelos de implantação descritos pela AWS.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantação on-premises", false],
+            ["Implantação mista", false],
+            ["Implantação híbrida", true],
+            ["Implantação na nuvem", false],
+        ],
+    },
+    {
+        statement: "O que significa o termo economia de escala no contexto da AWS?",
+        explanation:
+            "Economia de escala significa que, com o uso agregado de milhares de clientes, a AWS obtém custos unitários menores e repassa isso em reduções de preço ao longo do tempo. Economizar ao consumir mais descreve descontos por volume, pagar conforme o uso é o modelo de cobrança e os preços da AWS tendem a cair, não a subir.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Quanto mais você consome, mais você economiza", false],
+            ["Quanto mais tempo você usa a AWS, mais você paga pelos serviços", false],
+            ["A AWS reduz os preços continuamente à medida que cresce", true],
+            ["Você tem a possibilidade de pagar conforme o uso", false],
+        ],
+    },
+    {
+        statement:
+            "Por que arquiteturas sem servidor (serverless) são mais econômicas que arquiteturas baseadas em servidores?",
+        explanation:
+            "Em arquiteturas baseadas em servidores as instâncias ficam ligadas e geram custo mesmo ociosas; no serverless paga-se por requisição e tempo de execução. Custos de transferência de dados continuam existindo, a cobrança serverless não depende de reservar capacidade e escalar automaticamente também é possível com servidores e Auto Scaling.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Arquiteturas serverless eliminam todos os custos de rede das aplicações", false],
+            ["No serverless, a computação só é usada enquanto o código está em execução", true],
+            [
+                "Reservar capacidade serverless gera descontos maiores que reservar servidores",
+                false,
+            ],
+            ["No serverless, é possível escalar automaticamente conforme a demanda muda", false],
+        ],
+    },
+    {
+        statement:
+            "O responsável por uma aplicação de e-commerce percebe que a necessidade de capacidade de computação varia muito ao longo do tempo. O que torna a AWS mais econômica que um data center tradicional para esse tipo de aplicação?",
+        explanation:
+            "Iniciar e encerrar instâncias conforme a demanda faz a empresa pagar só pela capacidade usada, sem hardware ocioso nos períodos calmos. Instâncias maiores para picos continuam ociosas no resto do tempo, pagar adiantado reduz o preço unitário mas mantém capacidade paga sem uso, e instâncias mais baratas não eliminam a ociosidade.",
+        topic: "Preços e faturamento",
+        options: [
+            ["A AWS permite lançar instâncias EC2 potentes para absorver picos de carga", false],
+            ["A AWS permite pagar antecipadamente para obter descontos maiores", false],
+            ["A AWS permite iniciar e encerrar instâncias EC2 conforme a demanda", true],
+            [
+                "A AWS permite escolher tipos de instância EC2 mais baratos que atendam à necessidade",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir representam princípios de design para arquiteturas na Nuvem AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Acoplamento fraco evita que falhas se propaguem entre componentes, e recursos descartáveis são substituídos em vez de consertados, o que acelera a recuperação. Preferir capacidade reservada ou servidores a serviços gerenciados contraria a nuvem, e escolher entre várias AZs e várias Regiões depende do caso, não é princípio.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Capacidade reservada em vez de sob demanda", false],
+            ["Acoplamento fraco em vez de acoplamento forte", true],
+            ["Servidores em vez de serviços gerenciados", false],
+            ["Recursos descartáveis em vez de servidores fixos", true],
+            ["Várias Zonas de Disponibilidade em vez de várias Regiões", false],
+        ],
+    },
+    {
+        statement:
+            "Você desenvolveu uma aplicação web voltada a um público global. Qual opção oferece o maior nível de redundância e tolerância a falhas do ponto de vista da infraestrutura?",
+        explanation:
+            "Várias Zonas de Disponibilidade em várias Regiões protegem tanto contra a falha de uma AZ quanto contra a indisponibilidade de uma Região inteira. A redundância das cargas precisa ser projetada pelo cliente, uma única AZ não tem redundância e várias AZs em uma só Região não resistem a um problema regional.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Não é preciso projetar esses recursos, pois a AWS já é redundante por padrão", false],
+            ["Implantar a aplicação em uma única Zona de Disponibilidade", false],
+            ["Implantar a aplicação em várias Zonas de Disponibilidade de uma única Região", false],
+            ["Implantar a aplicação em várias Zonas de Disponibilidade de várias Regiões", true],
+        ],
+    },
+    {
+        statement:
+            "Como você pode aumentar a tolerância a falhas de uma aplicação hospedada na AWS?",
+        explanation:
+            "Com a aplicação em várias Zonas de Disponibilidade, a falha de uma AZ não a derruba, pois as demais continuam atendendo. Várias instâncias na mesma AZ caem juntas se ela falhar, uma única instância potente é ponto único de falha e sub-redes só ajudam se estiverem em AZs diferentes, já que cada sub-rede fica em uma AZ.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "Implantando a aplicação em várias instâncias EC2 na mesma Zona de Disponibilidade",
+                false,
+            ],
+            ["Implantando a aplicação em várias Zonas de Disponibilidade", true],
+            [
+                "Hospedando a aplicação em uma única instância EC2 potente em vez de várias menores",
+                false,
+            ],
+            ["Distribuindo os recursos da aplicação em várias sub-redes", false],
+        ],
+    },
+    {
+        statement: "Qual é um benefício do princípio de arquitetura de acoplamento fraco?",
+        explanation:
+            "Com acoplamento fraco, cada componente se comunica por interfaces bem definidas e pode ser alterado ou substituído sem afetar os outros. O gerenciamento de mudanças continua necessário, a replicação entre Regiões é recurso de redundância de dados e reduzir acesso privilegiado é aplicação do menor privilégio.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Elimina a necessidade de gerenciamento de mudanças", false],
+            ["Permite a replicação de dados entre Regiões da AWS", false],
+            ["Ajuda os clientes a reduzir o acesso privilegiado aos recursos da AWS", false],
+            ["Permite alterar componentes individuais sem afetar os demais", true],
+        ],
+    },
+    {
+        statement:
+            "Qual modelo de implantação de computação em nuvem elimina a necessidade de operar e manter data centers físicos?",
+        explanation:
+            "No modelo de implantação em nuvem toda a infraestrutura fica nas instalações do provedor, que opera e mantém os data centers. On-premises é o oposto, com tudo nas instalações da empresa, e IaaS e PaaS são modelos de serviço, que definem o que o cliente gerencia, e não modelos de implantação.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["On-premises", false],
+            ["IaaS", false],
+            ["PaaS", false],
+            ["Nuvem", true],
+        ],
+    },
+    {
+        statement:
+            "A AWS oferece capacidade de recuperação de desastres ao permitir que os clientes distribuam sua infraestrutura entre diferentes [...]. Qual opção completa a frase?",
+        explanation:
+            "Regiões são áreas geográficas separadas, então distribuir a infraestrutura entre elas mantém a aplicação operando mesmo se uma Região inteira ficar indisponível. Locais de borda servem para cache e entrega de conteúdo, planos de suporte dão acesso a atendimento técnico e dispositivos Snowball transferem dados fisicamente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Regiões geográficas da AWS", true],
+            ["Locais de borda da AWS", false],
+            ["Planos do AWS Support", false],
+            ["Dispositivos AWS Snowball Edge", false],
+        ],
+    },
+    {
+        statement:
+            "Um arquiteto precisa explicar à equipe o que é uma Zona de Disponibilidade da AWS. Qual descrição está correta?",
+        explanation:
+            "Uma Zona de Disponibilidade é formada por um ou mais data centers com energia, refrigeração e rede redundantes. Localização geográfica isolada descreve uma Região, locais de borda servem ao cache de conteúdo e fonte única de energia é o oposto do que uma Zona de Disponibilidade oferece.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Um ou mais data centers físicos dentro de uma Região", true],
+            ["Uma localização geográfica totalmente isolada das demais", false],
+            ["Um conjunto de locais de borda distribuídos pelo mundo", false],
+            ["Um data center com uma única fonte de energia e de rede", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa distribui sua carga de trabalho entre a Nuvem AWS e alguns servidores on-premises. Que tipo de arquitetura é essa?",
+        explanation:
+            "Nuvem híbrida combina infraestrutura on-premises com recursos na nuvem, normalmente conectados por VPN ou AWS Direct Connect. VPN é uma tecnologia de conexão, VPC é uma rede isolada dentro da AWS e nuvem privada não tem componente de nuvem pública.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Rede privada virtual (VPN)", false],
+            ["Nuvem privada virtual (VPC)", false],
+            ["Nuvem híbrida", true],
+            ["Nuvem privada", false],
+        ],
+    },
+    {
+        statement: "O que significa tolerância a falhas em uma aplicação?",
+        explanation:
+            "Tolerância a falhas é a redundância embutida nos componentes, que mantém a aplicação operando mesmo quando um deles falha. Crescer sem mudar o design é escalabilidade, restaurar dados perdidos é recuperação e proteção contra acessos indevidos é segurança.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["A capacidade de crescer sem mudar o design da aplicação", false],
+            ["A rapidez para restaurar dados perdidos no ambiente", false],
+            ["O nível de proteção contra acessos não autorizados", false],
+            ["A redundância embutida nos componentes da aplicação", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer uma carga de trabalho altamente disponível na AWS, com um plano de recuperação de desastres que permita se recuperar de uma interrupção de serviço em toda uma Região. Qual configuração atende a esses requisitos sem custo ou complexidade desnecessários?",
+        explanation:
+            "Duas Zonas de Disponibilidade dão alta disponibilidade dentro da Região, e outra Região como site de recuperação protege contra uma falha regional. Zonas da mesma Região e Local Zones dependem da mesma Região, e operar em duas Regiões mais uma terceira soma custo sem necessidade.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "Duas Zonas de Disponibilidade em uma Região, com outras Zonas de Disponibilidade da mesma Região como site de recuperação",
+                false,
+            ],
+            [
+                "Duas Zonas de Disponibilidade em uma Região, com outra Região da AWS como site de recuperação",
+                true,
+            ],
+            [
+                "Duas Zonas de Disponibilidade em uma Região, com uma AWS Local Zone como site de recuperação",
+                false,
+            ],
+            [
+                "Duas Regiões da AWS em operação, com uma terceira Região como site de recuperação",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Fazer mudanças frequentes, pequenas e reversíveis é um princípio de design de qual pilar do AWS Well-Architected Framework?",
+        explanation:
+            "Fazer mudanças frequentes, pequenas e reversíveis é princípio do pilar Excelência operacional: mudanças menores reduzem o impacto de erros e são mais fáceis de desfazer. Eficiência de desempenho trata do uso eficiente de recursos, Confiabilidade da recuperação de falhas e Segurança da proteção de dados e sistemas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Eficiência de desempenho", false],
+            ["Excelência operacional", true],
+            ["Confiabilidade", false],
+            ["Segurança", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem recursos on-premises subutilizados. Qual conceito da Nuvem AWS resolve MELHOR esse problema?",
+        explanation:
+            "Elasticidade ajusta a capacidade para cima ou para baixo conforme a demanda real, eliminando recursos ociosos e o pagamento por eles. Alta disponibilidade trata de redundância, agilidade da velocidade de provisionamento e acoplamento fraco da dependência entre componentes.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Alta disponibilidade", false],
+            ["Elasticidade", true],
+            ["Agilidade", false],
+            ["Acoplamento fraco", false],
+        ],
+    },
+    {
+        statement:
+            "Quais princípios de design da Nuvem AWS ajudam a aumentar a confiabilidade de uma carga de trabalho? (Selecione DUAS opções.)",
+        explanation:
+            "Testar os procedimentos de recuperação e recuperar-se automaticamente de falhas são princípios do pilar Confiabilidade. Medir a eficiência geral e adotar um modelo de consumo pertencem a Otimização de custos, e a arquitetura monolítica acopla componentes e amplia o impacto das falhas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Usar uma arquitetura monolítica", false],
+            ["Medir a eficiência geral da carga de trabalho", false],
+            ["Testar os procedimentos de recuperação", true],
+            ["Adotar um modelo de consumo sob demanda", false],
+            ["Recuperar-se automaticamente das falhas", true],
+        ],
+    },
+    {
+        statement:
+            "Qual benefício da computação em nuvem a AWS demonstra ao oferecer custos variáveis mais baixos graças ao seu alto volume de compras?",
+        explanation:
+            "Economia de escala: por agregar o uso de milhões de clientes, a AWS compra em volume e repassa custos variáveis menores. Pagamento conforme o uso é o modelo de cobrança, alta disponibilidade é característica de arquitetura e alcance global trata de implantar em várias localidades.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Pagamento conforme o uso", false],
+            ["Alta disponibilidade", false],
+            ["Alcance global", false],
+            ["Economia de escala", true],
+        ],
+    },
+    {
+        statement:
+            "Qual pilar do AWS Well-Architected Framework se concentra na capacidade de uma carga de trabalho executar a função pretendida de forma correta e consistente?",
+        explanation:
+            "Confiabilidade trata da carga de trabalho executar sua função de forma correta e consistente, incluindo se recuperar de falhas. Segurança protege dados e sistemas, Eficiência de desempenho usa recursos de forma eficiente e Excelência operacional cuida da operação e da melhoria contínua.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Segurança", false],
+            ["Confiabilidade", true],
+            ["Eficiência de desempenho", false],
+            ["Excelência operacional", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe revisa uma carga de trabalho para escolher tipos e tamanhos de recursos adequados aos requisitos e manter essa eficiência conforme a demanda muda. Qual pilar do AWS Well-Architected Framework orienta esse trabalho?",
+        explanation:
+            "Selecionar tipos e tamanhos de recursos otimizados para os requisitos e manter a eficiência conforme a demanda muda é foco de Eficiência de desempenho. Otimização de custos mira evitar gastos desnecessários, Confiabilidade trata da recuperação de falhas e escalabilidade automática não é um pilar.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Confiabilidade", false],
+            ["Otimização de custos", false],
+            ["Eficiência de desempenho", true],
+            ["Escalabilidade automática", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consultoria vai conduzir workshops organizados pelas perspectivas do AWS Cloud Adoption Framework (AWS CAF). Quais das opções a seguir são perspectivas desse framework? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CAF tem seis perspectivas: Negócios, Pessoas, Governança, Plataforma, Segurança e Operações. Não existe perspectiva Financeira (a gestão financeira da nuvem é capacidade de Governança), infraestrutura é tratada em Plataforma e agilidade é um benefício da nuvem.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Governança", true],
+            ["Financeira", false],
+            ["Pessoas", true],
+            ["Infraestrutura", false],
+            ["Agilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Segundo o AWS Cloud Adoption Framework (AWS CAF), quais são benefícios que uma organização pode obter com uma adoção de nuvem bem-sucedida? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CAF aponta quatro benefícios: redução do risco de negócio, melhor desempenho ESG, aumento de receita e maior eficiência operacional. A nuvem transforma as despesas, mas não as elimina, e conformidade e segurança das aplicações seguem com o cliente pelo modelo de responsabilidade compartilhada.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Redução do risco de negócio da organização", true],
+            ["Eliminação das despesas operacionais com TI", false],
+            ["Melhor desempenho em ESG (ambiental, social e governança)", true],
+            ["Conformidade regulatória automática das cargas de trabalho", false],
+            ["Transferência da segurança das aplicações para a AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa de uma estratégia de recuperação de desastres em que uma versão reduzida, porém totalmente funcional, do ambiente fique sempre em execução em uma Região secundária, permitindo failover rápido ao escalar para a capacidade total. Qual estratégia é essa?",
+        explanation:
+            "No warm standby, uma cópia reduzida e funcional roda sempre na Região secundária e é escalada no failover. Backup e restauração recria tudo a partir de backups, pilot light mantém só o núcleo (como o banco replicado) e multi-site ativo-ativo roda capacidade total em todos os locais.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Backup e restauração", false],
+            ["Pilot light", false],
+            ["Warm standby", true],
+            ["Multi-site ativo-ativo", false],
+        ],
+    },
+    {
+        statement:
+            "Qual estratégia de recuperação de desastres tem o maior tempo de recuperação e o menor custo, por não manter nenhuma infraestrutura em espera no local secundário?",
+        explanation:
+            "Backup e restauração não mantém recursos rodando no local secundário: após a falha, a infraestrutura é provisionada e os dados são restaurados, o que custa menos e demora mais. Pilot light e warm standby mantêm parte do ambiente ativa, e multi-site ativo-ativo roda capacidade total.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Multi-site ativo-ativo", false],
+            ["Warm standby", false],
+            ["Pilot light", false],
+            ["Backup e restauração", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer levar uma aplicação on-premises para a AWS o mais rápido possível, sem alterar o código nem a arquitetura. Qual estratégia de migração ela deve usar?",
+        explanation:
+            "Rehost (lift and shift) move a aplicação sem mudar código nem arquitetura, por isso é o caminho mais rápido. Replatform faz otimizações pontuais, como trocar para um banco gerenciado, Refactor redesenha a aplicação para recursos nativos da nuvem e Repurchase troca por outro produto, geralmente SaaS.",
+        topic: "Migração",
+        options: [
+            ["Replatform", false],
+            ["Refactor", false],
+            ["Rehost", true],
+            ["Repurchase", false],
+        ],
+    },
+    {
+        statement:
+            "Durante a migração para a AWS, uma empresa decide mover o banco MySQL autogerenciado, que roda em uma máquina virtual, para o Amazon RDS, sem mudar a lógica central da aplicação nem reescrever código. Qual estratégia de migração isso representa?",
+        explanation:
+            "Replatform (lift, tinker and shift) faz otimizações pontuais na migração, como trocar um banco autogerenciado pelo Amazon RDS para ganhar backups e patches gerenciados. Rehost moveria o banco como está, Repurchase trocaria por outro produto e Refactor redesenharia a aplicação.",
+        topic: "Migração",
+        options: [
+            ["Rehost", false],
+            ["Repurchase", false],
+            ["Replatform", true],
+            ["Refactor", false],
+        ],
+    },
+    {
+        statement:
+            "No planejamento da migração, uma empresa descobre que 30% das aplicações on-premises não são usadas há mais de dois anos e não geram valor para o negócio. Qual estratégia de migração deve ser aplicada a essas aplicações?",
+        explanation:
+            "Retire desativa aplicações sem uso nem valor para o negócio, o que reduz o escopo e o custo da migração. Retain as manteria on-premises com custo de manutenção, e Rehost ou Replatform gastariam esforço e recursos de nuvem com aplicações que ninguém usa.",
+        topic: "Migração",
+        options: [
+            ["Retain", false],
+            ["Rehost", false],
+            ["Retire", true],
+            ["Replatform", false],
+        ],
+    },
+    {
+        statement:
+            "Qual framework da AWS organiza suas orientações em perspectivas para ajudar as organizações a identificar e priorizar oportunidades de transformação na nuvem?",
+        explanation:
+            "O AWS CAF organiza suas orientações em seis perspectivas (Negócios, Pessoas, Governança, Plataforma, Segurança e Operações). O Well-Architected usa pilares para avaliar cargas de trabalho, o MAP é um programa de apoio à migração e a responsabilidade compartilhada divide a segurança.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["AWS Well-Architected Framework", false],
+            ["AWS Cloud Adoption Framework (AWS CAF)", true],
+            ["AWS Migration Acceleration Program", false],
+            ["Modelo de responsabilidade compartilhada da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está planejando a migração para a nuvem e precisa avaliar a prontidão da equipe e identificar lacunas de habilidades. Qual perspectiva do AWS Cloud Adoption Framework (AWS CAF) trata dessa necessidade?",
+        explanation:
+            "A perspectiva de Pessoas cuida de cultura, estrutura organizacional, liderança e fluência em nuvem, incluindo avaliar habilidades e treinar a equipe. Negócios alinha a nuvem aos resultados de negócio, Operações cuida da operação diária e Plataforma da arquitetura do ambiente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Negócios", false],
+            ["Pessoas", true],
+            ["Operações", false],
+            ["Plataforma", false],
+        ],
+    },
+    {
+        statement:
+            "Quais perspectivas do AWS Cloud Adoption Framework (AWS CAF) pertencem ao grupo de capacidades técnicas? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CAF divide as seis perspectivas em dois grupos: capacidades de negócio (Negócios, Pessoas e Governança) e capacidades técnicas (Plataforma, Segurança e Operações). Por isso Plataforma e Operações são as técnicas entre as opções.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Negócios", false],
+            ["Plataforma", true],
+            ["Pessoas", false],
+            ["Operações", true],
+            ["Governança", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer que a adoção da nuvem maximize os benefícios e minimize os riscos da transformação. Qual perspectiva do AWS Cloud Adoption Framework (AWS CAF) é a MAIS relevante?",
+        explanation:
+            "A perspectiva de Governança orquestra as iniciativas de nuvem para maximizar os benefícios e minimizar os riscos da transformação. Segurança trata de confidencialidade, integridade e disponibilidade de dados e cargas, Negócios do valor gerado e Plataforma da arquitetura da nuvem.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Segurança", false],
+            ["Negócios", false],
+            ["Governança", true],
+            ["Plataforma", false],
+        ],
+    },
+    {
+        statement:
+            "Qual perspectiva do AWS Cloud Adoption Framework (AWS CAF) ajuda a garantir a confidencialidade, a integridade e a disponibilidade dos dados e das cargas de trabalho na nuvem?",
+        explanation:
+            "A perspectiva de Segurança busca confidencialidade, integridade e disponibilidade de dados e cargas de trabalho, com gestão de identidades, detecção de ameaças e resposta a incidentes. Governança gerencia riscos e benefícios, Operações a entrega diária dos serviços e Plataforma o ambiente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Governança", false],
+            ["Operações", false],
+            ["Plataforma", false],
+            ["Segurança", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer usar o AWS Cloud Adoption Framework (AWS CAF) para montar o caso de negócio da migração para a nuvem. Em qual perspectiva ela deve se concentrar?",
+        explanation:
+            "A perspectiva de Negócios garante que os investimentos em nuvem acelerem resultados de negócio e ajuda a construir o caso de negócio. Pessoas cuida de habilidades e mudança organizacional, Plataforma da arquitetura técnica e Governança de riscos e benefícios, sem ser a dona do caso de negócio.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Pessoas", false],
+            ["Negócios", true],
+            ["Plataforma", false],
+            ["Governança", false],
+        ],
+    },
+    {
+        statement:
+            "Qual perspectiva do AWS Cloud Adoption Framework (AWS CAF) se concentra em projetar e implementar ambientes de nuvem novos com escalabilidade de nível corporativo?",
+        explanation:
+            "A perspectiva de Plataforma trata de construir um ambiente de nuvem corporativo e escalável, com arquitetura de rede, computação, armazenamento e provisionamento. Operações cuida da entrega diária dos serviços, Segurança da proteção de dados e cargas e Governança de riscos e benefícios.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Operações", false],
+            ["Segurança", false],
+            ["Plataforma", true],
+            ["Governança", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa definir como vai gerenciar e monitorar as cargas de trabalho na nuvem no dia a dia, depois da migração. Qual perspectiva do AWS Cloud Adoption Framework (AWS CAF) trata disso?",
+        explanation:
+            "A perspectiva de Operações garante que os serviços de nuvem sejam entregues no nível que o negócio precisa, com monitoramento, gestão de incidentes e melhoria contínua. Plataforma projeta o ambiente, Governança cuida de riscos e conformidade e Negócios do retorno do investimento.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Plataforma", false],
+            ["Governança", false],
+            ["Operações", true],
+            ["Negócios", false],
+        ],
+    },
+    {
+        statement: "Quantas perspectivas o AWS Cloud Adoption Framework (AWS CAF) define?",
+        explanation:
+            "O AWS CAF define seis perspectivas: Negócios, Pessoas e Governança (capacidades de negócio) e Plataforma, Segurança e Operações (capacidades técnicas). Não confunda com os quatro domínios de transformação: Tecnologia, Processo, Organização e Produto.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Quatro", false],
+            ["Cinco", false],
+            ["Seis", true],
+            ["Sete", false],
+        ],
+    },
+    {
+        statement:
+            "Na divisão do AWS Cloud Adoption Framework (AWS CAF), quais perspectivas são classificadas como capacidades de negócio? (Selecione DUAS opções.)",
+        explanation:
+            "No AWS CAF, Negócios, Pessoas e Governança formam as capacidades de negócio, voltadas a estratégia, prontidão organizacional e gestão de riscos. Plataforma, Operações e Segurança são as capacidades técnicas, que cuidam do ambiente, da operação e da proteção.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Negócios", true],
+            ["Plataforma", false],
+            ["Operações", false],
+            ["Segurança", false],
+            ["Governança", true],
+        ],
+    },
+    {
+        statement:
+            "Ao avaliar a prontidão para a nuvem, uma empresa descobre que a equipe de TI não tem experiência com os serviços da AWS. De acordo com o AWS Cloud Adoption Framework (AWS CAF), qual ação a empresa deve tomar?",
+        explanation:
+            "A perspectiva de Pessoas do AWS CAF recomenda desenvolver a fluência em nuvem com capacitação e gestão da mudança, criando capacidade interna. Adiar a migração até todos se certificarem atrasa sem necessidade, e terceirizar tudo ou trocar a equipe não constrói essa capacidade.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Adiar a migração até que toda a equipe conclua certificações da AWS", false],
+            ["Investir em programas de capacitação e requalificação da equipe atual", true],
+            ["Terceirizar em definitivo a operação da nuvem para um parceiro externo", false],
+            ["Contratar uma nova equipe de nuvem e substituir os profissionais atuais", false],
+        ],
+    },
+    {
+        statement:
+            "Qual das opções a seguir é um foco central da perspectiva de Governança do AWS Cloud Adoption Framework (AWS CAF)?",
+        explanation:
+            "Governança orquestra as iniciativas de nuvem para maximizar benefícios e minimizar riscos, com gestão de portfólio, de programas e financeira da nuvem. Projetar a arquitetura é foco de Plataforma, monitorar aplicações é de Operações e controles de identidade e acesso são de Segurança.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Projetar a arquitetura de destino do ambiente de nuvem", false],
+            ["Gerenciar os benefícios e os riscos da transformação", true],
+            ["Monitorar o desempenho das aplicações após a implantação", false],
+            ["Configurar controles de gerenciamento de identidade e acesso", false],
+        ],
+    },
+    {
+        statement:
+            "O AWS Cloud Adoption Framework (AWS CAF) descreve quatro domínios de transformação. Qual das opções a seguir é um desses domínios?",
+        explanation:
+            "Os quatro domínios de transformação do AWS CAF são Tecnologia, Processo, Organização e Produto. Redes, bancos de dados e computação são componentes técnicos que entram no domínio Tecnologia, mas não são domínios por si só.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Tecnologia", true],
+            ["Redes", false],
+            ["Banco de dados", false],
+            ["Computação", false],
+        ],
+    },
+    {
+        statement:
+            "Um executivo quer entender como o AWS Cloud Adoption Framework (AWS CAF) agrupa a transformação na nuvem. Quais das opções a seguir são domínios de transformação desse framework? (Selecione DUAS opções.)",
+        explanation:
+            "Os domínios de transformação do AWS CAF são Tecnologia, Processo, Organização e Produto. Segurança é uma das seis perspectivas, infraestrutura faz parte do domínio Tecnologia e conformidade é tratada na perspectiva de Governança.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Produto", true],
+            ["Segurança", false],
+            ["Processo", true],
+            ["Infraestrutura", false],
+            ["Conformidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa que usa o AWS Cloud Adoption Framework (AWS CAF) está identificando lacunas de capacidade e dependências entre áreas para melhorar a prontidão da organização para a nuvem. Em qual fase da jornada ela está?",
+        explanation:
+            "Na fase Align, a organização identifica lacunas de capacidade nas seis perspectivas, dependências entre áreas e preocupações dos envolvidos para melhorar a prontidão. Envision define a visão e as oportunidades, Launch entrega pilotos em produção e Scale expande a adoção.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Envision", false],
+            ["Align", true],
+            ["Launch", false],
+            ["Scale", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é a ordem correta das fases de transformação na nuvem do AWS Cloud Adoption Framework (AWS CAF)?",
+        explanation:
+            "A jornada do AWS CAF segue Envision (visão e oportunidades), Align (lacunas e plano de ação), Launch (pilotos em produção) e Scale (expansão). As outras ordens executam antes de planejar ou avaliam a prontidão depois de já ter implantado.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Align, Envision, Launch, Scale", false],
+            ["Envision, Align, Launch, Scale", true],
+            ["Launch, Envision, Scale, Align", false],
+            ["Envision, Launch, Align, Scale", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa que segue o AWS Cloud Adoption Framework (AWS CAF) vai colocar em produção seus primeiros projetos-piloto para demonstrar valor ao negócio. Em qual fase da jornada ela está?",
+        explanation:
+            "Na fase Launch, a organização entrega iniciativas piloto em produção e demonstra valor incremental ao negócio. Envision define a visão e as oportunidades, Align avalia lacunas de capacidade e monta o plano, e Scale expande os pilotos para toda a organização.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Envision", false],
+            ["Align", false],
+            ["Launch", true],
+            ["Scale", false],
+        ],
+    },
+    {
+        statement:
+            "Durante a migração, uma empresa decide substituir seu sistema de e-mail on-premises por um serviço de e-mail em nuvem no modelo SaaS. Qual estratégia de migração isso representa?",
+        explanation:
+            "Repurchase troca a aplicação existente por outro produto, normalmente SaaS, como sair de um e-mail on-premises para um serviço de e-mail em nuvem. Replatform otimiza a aplicação atual, Refactor a redesenha e Rehost a levaria como está para servidores na nuvem.",
+        topic: "Migração",
+        options: [
+            ["Replatform", false],
+            ["Repurchase", true],
+            ["Refactor", false],
+            ["Rehost", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem aplicações que ainda não podem ir para a nuvem por causa de dependências de conformidade não resolvidas. Qual estratégia de migração deve ser aplicada a essas aplicações?",
+        explanation:
+            "Retain mantém as aplicações no ambiente atual enquanto restrições de conformidade ou dependências técnicas impedem a migração. Retire desativaria aplicações ainda em uso, e Relocate ou Repurchase não resolvem a restrição de conformidade que bloqueia a mudança.",
+        topic: "Migração",
+        options: [
+            ["Retire", false],
+            ["Retain", true],
+            ["Relocate", false],
+            ["Repurchase", false],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir são estratégias de migração reconhecidas pela AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Rehost e Repurchase estão entre as sete estratégias de migração da AWS: Rehost, Replatform, Refactor, Repurchase, Relocate, Retain e Retire. Revalidate, Reuse e Reconfigure não fazem parte dessa lista; a mais próxima de uma reconfiguração seria Replatform.",
+        topic: "Migração",
+        options: [
+            ["Rehost", true],
+            ["Revalidate", false],
+            ["Repurchase", true],
+            ["Reuse", false],
+            ["Reconfigure", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa roda máquinas virtuais VMware on-premises e quer levá-las para a AWS com o mínimo de mudanças no ambiente VMware existente. Qual estratégia de migração isso descreve?",
+        explanation:
+            "Relocate move a infraestrutura para uma versão em nuvem da mesma plataforma, sem comprar hardware, reescrever aplicações ou mudar a operação, como levar o ambiente VMware inteiro para a AWS. Rehost converte servidores em instâncias EC2, Replatform faz otimizações e Refactor redesenha.",
+        topic: "Migração",
+        options: [
+            ["Rehost", false],
+            ["Replatform", false],
+            ["Relocate", true],
+            ["Refactor", false],
+        ],
+    },
+    {
+        statement:
+            "Quantas estratégias de migração (os chamados Rs da migração) a AWS define atualmente?",
+        explanation:
+            "A AWS define sete estratégias, os 7 Rs: Rehost, Replatform, Refactor, Repurchase, Relocate, Retain e Retire. O modelo anterior da AWS tinha seis e ganhou Relocate; os cinco Rs são a lista antiga do Gartner, com outros nomes.",
+        topic: "Migração",
+        options: [
+            ["Cinco", false],
+            ["Seis", false],
+            ["Sete", true],
+            ["Oito", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer migrar um grande banco de dados Oracle on-premises para o Amazon DynamoDB, a fim de melhorar a escalabilidade e reduzir custos de licença. Qual estratégia de migração isso descreve?",
+        explanation:
+            "Sair de um banco relacional Oracle para um NoSQL como o DynamoDB exige redesenhar o modelo de dados e a aplicação, o que é Refactor. Replatform levaria o Oracle para o Amazon RDS for Oracle, Rehost o rodaria em EC2 como está e Repurchase trocaria por um produto comercial.",
+        topic: "Migração",
+        options: [
+            ["Replatform", false],
+            ["Rehost", false],
+            ["Refactor", true],
+            ["Repurchase", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS automatiza a migração lift and shift de servidores on-premises ou de outras nuvens para a AWS?",
+        explanation:
+            "O AWS Application Migration Service replica continuamente os servidores de origem e os converte e inicia como instâncias na AWS, automatizando o rehost. O AWS DMS migra bancos de dados, o Migration Hub acompanha o andamento das migrações e o AWS SCT converte esquemas de banco.",
+        topic: "Migração",
+        options: [
+            ["AWS Database Migration Service (AWS DMS)", false],
+            ["AWS Application Migration Service", true],
+            ["AWS Migration Hub", false],
+            ["AWS Schema Conversion Tool (AWS SCT)", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS oferece um local central para acompanhar o andamento de migrações de aplicações feitas com várias ferramentas de migração da AWS?",
+        explanation:
+            "O AWS Migration Hub reúne em um painel o status das migrações feitas com ferramentas como o Application Migration Service e o AWS DMS. O Application Migration Service executa a migração dos servidores, o CloudTrail registra chamadas de API e o AWS Config avalia configurações de recursos.",
+        topic: "Migração",
+        options: [
+            ["AWS Application Migration Service", false],
+            ["AWS CloudTrail", false],
+            ["AWS Migration Hub", true],
+            ["AWS Config", false],
+        ],
+    },
+    {
+        statement:
+            "Qual estratégia de migração traz o MAIOR benefício de longo prazo com recursos nativos da nuvem, mas exige o MAIOR esforço de desenvolvimento?",
+        explanation:
+            "Refactor rearquiteta a aplicação com serviços nativos da nuvem, como serverless e arquiteturas orientadas a eventos, trazendo mais escalabilidade e eficiência de custo, mas com o maior investimento. Rehost e Relocate quase não mudam a aplicação, e Replatform faz só otimizações pontuais.",
+        topic: "Migração",
+        options: [
+            ["Rehost", false],
+            ["Replatform", false],
+            ["Refactor", true],
+            ["Relocate", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está migrando para a AWS e quer avaliar sua infraestrutura on-premises para entender as dependências e a utilização dos servidores. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O AWS Application Discovery Service coleta configuração, utilização e dependências de rede dos servidores on-premises para planejar a migração. O Migration Hub acompanha o andamento, o Application Migration Service executa a migração e o Trusted Advisor avalia ambientes que já estão na AWS.",
+        topic: "Migração",
+        options: [
+            ["AWS Migration Hub", false],
+            ["AWS Application Discovery Service", true],
+            ["AWS Application Migration Service", false],
+            ["AWS Trusted Advisor", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS foi criado especificamente para migrar bancos de dados on-premises para a AWS, tanto entre mecanismos iguais quanto entre mecanismos diferentes?",
+        explanation:
+            "O AWS DMS replica dados de bancos on-premises para a AWS com pouca indisponibilidade, em migrações homogêneas e heterogêneas. O Application Migration Service migra servidores inteiros, o AWS SCT só converte esquemas e código de banco e o DataSync transfere arquivos entre sistemas de armazenamento.",
+        topic: "Migração",
+        options: [
+            ["AWS Application Migration Service (AWS MGN)", false],
+            ["AWS Schema Conversion Tool (AWS SCT)", false],
+            ["AWS Database Migration Service (AWS DMS)", true],
+            ["AWS DataSync", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está migrando uma aplicação monolítica para a AWS e decide dividi-la em microsserviços com AWS Lambda e Amazon API Gateway. Qual estratégia de migração isso representa?",
+        explanation:
+            "Quebrar um monólito em microsserviços com AWS Lambda e Amazon API Gateway muda o desenho da aplicação para usar recursos nativos da nuvem, o que é Refactor. Rehost manteria o monólito em EC2, Replatform faria só ajustes pontuais e Repurchase trocaria a aplicação por um produto SaaS.",
+        topic: "Migração",
+        options: [
+            ["Rehost", false],
+            ["Replatform", false],
+            ["Repurchase", false],
+            ["Refactor", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem 500 servidores on-premises para migrar. Após a avaliação, 200 serão movidos como estão (lift and shift), 100 terão a aplicação redesenhada e o mecanismo de banco de dados trocado, 50 serão substituídos por soluções SaaS e 150 não são mais necessários. Quais combinações de estratégia estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Os 200 servidores movidos sem mudanças são Rehost e os 150 sem uso são Retire. Redesenhar a aplicação trocando o mecanismo de banco é Refactor, não Replatform; trocar por SaaS é Repurchase, não Retain; e Relocate leva uma plataforma inteira, como VMware, para a nuvem.",
+        topic: "Migração",
+        options: [
+            ["Rehost para os 200 servidores", true],
+            ["Replatform para os 100 servidores de banco de dados", false],
+            ["Retire para os 150 servidores sem uso", true],
+            ["Retain para as 50 aplicações substituídas por SaaS", false],
+            ["Relocate para os 200 servidores", false],
+        ],
+    },
+    {
+        statement:
+            "Qual opção descreve MELHOR a diferença entre Rehost e Replatform como estratégias de migração?",
+        explanation:
+            "Rehost (lift and shift) leva a aplicação sem mudar código nem arquitetura; Replatform (lift, tinker and shift) faz ajustes pontuais, como usar um banco gerenciado. Trocar por SaaS é Repurchase, e o Rehost costuma ser mais rápido, não mais lento, por exigir menos mudanças.",
+        topic: "Migração",
+        options: [
+            [
+                "Rehost altera o código da aplicação, enquanto Replatform mantém o código intacto",
+                false,
+            ],
+            [
+                "Rehost move a aplicação como está, enquanto Replatform faz otimizações pontuais",
+                true,
+            ],
+            [
+                "Rehost troca a aplicação por SaaS, enquanto Replatform mantém a aplicação original",
+                false,
+            ],
+            ["Rehost é mais lento que Replatform, porque exige mais testes antes da virada", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d1.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d1.ts
@@ -726,13 +726,13 @@ export const QUESTOES_CLOUDCERTPREP_D1: Questao[] = [
         statement:
             "A AWS oferece capacidade de recuperação de desastres ao permitir que os clientes distribuam sua infraestrutura entre diferentes [...]. Qual opção completa a frase?",
         explanation:
-            "Regiões são áreas geográficas separadas, então distribuir a infraestrutura entre elas mantém a aplicação operando mesmo se uma Região inteira ficar indisponível. Locais de borda servem para cache e entrega de conteúdo, planos de suporte dão acesso a atendimento técnico e dispositivos Snowball transferem dados fisicamente.",
+            "Regiões são áreas geográficas separadas, então distribuir a infraestrutura entre elas mantém a aplicação operando mesmo se uma Região inteira ficar indisponível. Locais de borda servem para cache e entrega de conteúdo, planos de suporte dão acesso a atendimento técnico e grupos de segurança controlam o tráfego das instâncias.",
         topic: "Conceitos e arquitetura",
         options: [
             ["Regiões geográficas da AWS", true],
             ["Locais de borda da AWS", false],
             ["Planos do AWS Support", false],
-            ["Dispositivos AWS Snowball Edge", false],
+            ["Grupos de segurança da VPC", false],
         ],
     },
     {
@@ -1905,26 +1905,13 @@ export const QUESTOES_CLOUDCERTPREP_D1: Questao[] = [
         statement:
             "Qual serviço da AWS automatiza a migração lift and shift de servidores on-premises ou de outras nuvens para a AWS?",
         explanation:
-            "O AWS Application Migration Service replica continuamente os servidores de origem e os converte e inicia como instâncias na AWS, automatizando o rehost. O AWS DMS migra bancos de dados, o Migration Hub acompanha o andamento das migrações e o AWS SCT converte esquemas de banco.",
+            "O AWS Application Migration Service replica continuamente os servidores de origem e os converte e inicia como instâncias na AWS, automatizando o rehost. O AWS DMS migra bancos de dados, o AWS DataSync transfere arquivos e objetos e o AWS SCT converte esquemas de banco.",
         topic: "Migração",
         options: [
             ["AWS Database Migration Service (AWS DMS)", false],
             ["AWS Application Migration Service", true],
-            ["AWS Migration Hub", false],
+            ["AWS DataSync", false],
             ["AWS Schema Conversion Tool (AWS SCT)", false],
-        ],
-    },
-    {
-        statement:
-            "Qual serviço da AWS oferece um local central para acompanhar o andamento de migrações de aplicações feitas com várias ferramentas de migração da AWS?",
-        explanation:
-            "O AWS Migration Hub reúne em um painel o status das migrações feitas com ferramentas como o Application Migration Service e o AWS DMS. O Application Migration Service executa a migração dos servidores, o CloudTrail registra chamadas de API e o AWS Config avalia configurações de recursos.",
-        topic: "Migração",
-        options: [
-            ["AWS Application Migration Service", false],
-            ["AWS CloudTrail", false],
-            ["AWS Migration Hub", true],
-            ["AWS Config", false],
         ],
     },
     {
@@ -1938,19 +1925,6 @@ export const QUESTOES_CLOUDCERTPREP_D1: Questao[] = [
             ["Replatform", false],
             ["Refactor", true],
             ["Relocate", false],
-        ],
-    },
-    {
-        statement:
-            "Uma empresa está migrando para a AWS e quer avaliar sua infraestrutura on-premises para entender as dependências e a utilização dos servidores. Qual serviço da AWS ela deve usar?",
-        explanation:
-            "O AWS Application Discovery Service coleta configuração, utilização e dependências de rede dos servidores on-premises para planejar a migração. O Migration Hub acompanha o andamento, o Application Migration Service executa a migração e o Trusted Advisor avalia ambientes que já estão na AWS.",
-        topic: "Migração",
-        options: [
-            ["AWS Migration Hub", false],
-            ["AWS Application Discovery Service", true],
-            ["AWS Application Migration Service", false],
-            ["AWS Trusted Advisor", false],
         ],
     },
     {

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d1.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d1.ts
@@ -144,18 +144,6 @@ export const QUESTOES_CLOUDCERTPREP_D1: Questao[] = [
         ],
     },
     {
-        statement: "Qual das opções a seguir é um princípio de design de arquitetura da Nuvem AWS?",
-        explanation:
-            "Acoplamento fraco faz os componentes interagirem por interfaces bem definidas, para que cada um escale, mude ou falhe sem afetar os outros. Pontos únicos de falha são um antipadrão, o design monolítico dificulta escalar partes isoladas e a escalabilidade vertical fica limitada ao tamanho de um único recurso.",
-        topic: "Conceitos e arquitetura",
-        options: [
-            ["Implementar pontos únicos de falha", false],
-            ["Implementar o acoplamento fraco", true],
-            ["Implementar um design monolítico", false],
-            ["Implementar escalabilidade vertical", false],
-        ],
-    },
-    {
         statement:
             "Qual é uma vantagem de transferir a infraestrutura de um data center on-premises para a Nuvem AWS?",
         explanation:
@@ -745,6 +733,635 @@ export const QUESTOES_CLOUDCERTPREP_D1: Questao[] = [
             ["Locais de borda da AWS", false],
             ["Planos do AWS Support", false],
             ["Dispositivos AWS Snowball Edge", false],
+        ],
+    },
+    {
+        statement:
+            "Quais características da AWS tornam a nuvem econômica para uma carga de trabalho com demanda de usuários variável? (Selecione DUAS opções.)",
+        explanation:
+            "A elasticidade ajusta a capacidade à demanda e o pagamento conforme o uso cobra só pelo que foi consumido, então os vales de acesso não geram custo ocioso. Alta disponibilidade e confiabilidade tratam de resistir a falhas, e o modelo de responsabilidade compartilhada divide deveres de segurança; nenhum deles reduz custo.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Alta disponibilidade", false],
+            ["Modelo de responsabilidade compartilhada", false],
+            ["Elasticidade", true],
+            ["Pagamento conforme o uso", true],
+            ["Confiabilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Ao arquitetar aplicações para a nuvem, qual das opções a seguir é um princípio de design fundamental?",
+        explanation:
+            "Elasticidade é um princípio central do design na nuvem: a capacidade cresce e diminui conforme a demanda, sem pagar por recursos ociosos. Usar a maior instância e provisionar para o pico são hábitos on-premises que geram desperdício, e o Scrum é um processo de desenvolvimento, não um princípio de arquitetura.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Usar sempre o maior tamanho de instância disponível", false],
+            ["Provisionar capacidade fixa para o pico de carga", false],
+            ["Adotar o Scrum como processo de desenvolvimento", false],
+            ["Implementar elasticidade para acompanhar a demanda", true],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é um benefício de usar a Nuvem AWS?",
+        explanation:
+            "A AWS assume a operação da infraestrutura física, o que libera a empresa para investir tempo e dinheiro no que gera receita. A AWS não adota segurança permissiva (o padrão é o menor privilégio), e o cliente não controla o hardware de rede nem escolhe os fornecedores de hardware da nuvem.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Segurança permissiva que reduz o trabalho administrativo", false],
+            ["Poder se concentrar em atividades que geram receita", true],
+            ["Controle sobre o hardware de rede da nuvem", false],
+            ["Escolha de fornecedores específicos de hardware da nuvem", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso da AWS um cliente deve aproveitar para obter alta disponibilidade em uma aplicação?",
+        explanation:
+            "Distribuir a aplicação em várias Zonas de Disponibilidade, que têm energia e rede independentes, mantém o serviço no ar se uma delas falhar. O Direct Connect é um link dedicado com o ambiente on-premises, a VPC é uma rede isolada e os data centers não são escolhidos diretamente pelo cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["AWS Direct Connect", false],
+            ["Zonas de Disponibilidade", true],
+            ["Data centers da AWS", false],
+            ["Amazon Virtual Private Cloud (Amazon VPC)", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é um princípio de design de arquitetura na nuvem?",
+        explanation:
+            "Acoplamento fraco faz os componentes conversarem por interfaces bem definidas, como filas e APIs, para que a falha ou a mudança de um não derrube os outros. Escalar só verticalmente e montar sistemas monolíticos vão contra as boas práticas, e escolher software comercial é decisão de compra, não princípio de arquitetura.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Escalar verticalmente em vez de horizontalmente", false],
+            ["Manter os componentes com acoplamento fraco", true],
+            ["Construir aplicações como sistemas monolíticos", false],
+            ["Usar software de banco de dados comercial", false],
+        ],
+    },
+    {
+        statement: "Quais são benefícios financeiros de usar a AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Sem data center próprio, some o investimento em hardware e caem os gastos com energia, manutenção e operação da infraestrutura, o que reduz o TCO e as despesas operacionais. A nuvem diminui o CapEx em vez de aumentá-lo, e a AWS não oferece pagamento adiado nem linha de crédito (o AWS Activate dá créditos promocionais).",
+        topic: "Preços e faturamento",
+        options: [
+            ["Redução do custo total de propriedade (TCO)", true],
+            ["Aumento das despesas de capital (CapEx)", false],
+            ["Redução das despesas operacionais (OpEx)", true],
+            ["Planos de pagamento adiado para startups", false],
+            ["Linhas de crédito empresarial para startups", false],
+        ],
+    },
+    {
+        statement:
+            "Ao comparar o custo total de propriedade (TCO) da AWS com o de um ambiente on-premises, qual custo deve ser incluído?",
+        explanation:
+            "No on-premises, a empresa paga pela segurança física do data center (vigilância, controle de acesso, câmeras); na AWS esse custo fica com a AWS, por isso ele diferencia os dois cenários. Gestão de projetos, antivírus e desenvolvimento de software existem nos dois ambientes e não mudam a comparação.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Gestão dos projetos de TI", false],
+            ["Licenciamento de software antivírus", false],
+            ["Segurança física do data center", true],
+            ["Desenvolvimento de software", false],
+        ],
+    },
+    {
+        statement:
+            "Ao projetar aplicações na nuvem, qual prática é um princípio importante de arquitetura?",
+        explanation:
+            "Usar várias Zonas de Disponibilidade distribui a aplicação por locais isolados, e a falha de uma zona não derruba o sistema. Componentes fortemente acoplados propagam falhas, usar código aberto é escolha de licenciamento e provisionar capacidade extra contraria a elasticidade, que ajusta recursos conforme a demanda.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Usar várias Zonas de Disponibilidade", true],
+            ["Usar componentes fortemente acoplados", false],
+            ["Usar software de código aberto", false],
+            ["Provisionar capacidade extra", false],
+        ],
+    },
+    {
+        statement:
+            "Qual característica da AWS reduz o custo total de propriedade (TCO) do cliente?",
+        explanation:
+            "Com computação elástica, a capacidade acompanha a demanda e o cliente deixa de pagar por infraestrutura ociosa, o que reduz o TCO. Suportar vários sistemas operacionais não muda o custo, hardware dedicado costuma custar mais que o compartilhado e a criptografia protege dados sem reduzir custos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Suporte a vários sistemas operacionais", false],
+            ["Hardware dedicado a um único cliente", false],
+            ["Computação elástica", true],
+            ["Criptografia dos dados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai rearquitetar uma grande aplicação monolítica para a nuvem. Quais princípios de design são recomendados? (Selecione DUAS opções.)",
+        explanation:
+            "Ao quebrar um monólito, o acoplamento fraco evita que a falha de uma parte se propague e o design para escalabilidade deixa cada componente crescer de forma independente. Monitoramento manual e servidores fixos são antipadrões na nuvem, e depender de um componente central é justamente o problema do monólito.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Usar monitoramento manual", false],
+            ["Manter servidores fixos e permanentes", false],
+            ["Implementar acoplamento fraco", true],
+            ["Depender de um único componente central", false],
+            ["Projetar para escalabilidade", true],
+        ],
+    },
+    {
+        statement: "Como os clientes se beneficiam da enorme economia de escala da AWS?",
+        explanation:
+            "Com milhões de clientes, a AWS compra e opera em escala muito maior, reduz o custo por unidade e repassa parte da economia em reduções periódicas de preço. Aumentar e reduzir recursos é elasticidade, e novos tipos de instância ou hardware mais confiável são evolução do produto, não efeito direto da economia de escala.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Reduções periódicas de preço graças à eficiência operacional da AWS", true],
+            ["Novos tipos de instância do Amazon EC2 com o hardware mais recente", false],
+            ["A capacidade de aumentar e reduzir recursos quando necessário", false],
+            ["Maior confiabilidade no hardware subjacente das instâncias do Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Quais opções são benefícios da Nuvem AWS em comparação com a infraestrutura tradicional? (Selecione DUAS opções.)",
+        explanation:
+            "Elasticidade ajusta recursos à demanda e agilidade permite provisionar e experimentar em minutos, sem longos ciclos de compra. A AWS oferece SLAs, não tempo de atividade ilimitado; colocation é hospedar servidores próprios em data center de terceiros; e despesas de capital são o que a nuvem substitui por custos variáveis.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Tempo de atividade ilimitado", false],
+            ["Elasticidade", true],
+            ["Agilidade", true],
+            ["Colocation", false],
+            ["Despesas de capital (CapEx)", false],
+        ],
+    },
+    {
+        statement:
+            "Ao comparar o custo total de propriedade (TCO) da Nuvem AWS com o de um ambiente on-premises, quais despesas devem ser consideradas? (Selecione DUAS opções.)",
+        explanation:
+            "Servidores físicos e hardware de armazenamento precisam ser comprados, mantidos e trocados no on-premises e deixam de existir na AWS, por isso pesam no TCO. Desenvolvimento de software, gestão de projetos e licenças de antivírus continuam iguais nos dois ambientes e não diferenciam a comparação.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Desenvolvimento de software", false],
+            ["Gestão de projetos", false],
+            ["Hardware de armazenamento", true],
+            ["Servidores físicos", true],
+            ["Licença de software antivírus", false],
+        ],
+    },
+    {
+        statement:
+            "Quais cenários representam o conceito de elasticidade na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Ajustar a quantidade de instâncias EC2 conforme o tráfego (escala horizontal) e redimensionar instâncias RDS conforme a necessidade (escala vertical) adaptam a capacidade à demanda. Direcionar tráfego para instâncias ociosas é balanceamento de carga, documentos de conformidade vêm do AWS Artifact e ambientes via código são infraestrutura como código.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Ajustar o número de instâncias do Amazon EC2 conforme o tráfego", true],
+            ["Redimensionar instâncias do Amazon RDS quando a demanda do negócio muda", true],
+            [
+                "Direcionar automaticamente o tráfego para as instâncias do Amazon EC2 menos utilizadas",
+                false,
+            ],
+            ["Usar documentos de conformidade da AWS para acelerar auditorias", false],
+            ["Criar e governar ambientes inteiros por meio de código", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa avalia migrar seu data center on-premises para a AWS. Quais fatores devem entrar na análise de custo total de propriedade (TCO)? (Selecione DUAS opções.)",
+        explanation:
+            "Energia elétrica e mão de obra para trocar servidores são custos do data center próprio que desaparecem na AWS, então entram no TCO. Disponibilidade de instâncias EC2 é um dado do lado da AWS, horas dos desenvolvedores não mudam com a hospedagem e capacidade do banco é questão de dimensionamento, não custo on-premises.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Disponibilidade de tipos de instância do Amazon EC2", false],
+            ["Consumo de energia elétrica do data center", true],
+            ["Mão de obra para substituir servidores antigos", true],
+            ["Horas de trabalho dos desenvolvedores de aplicações", false],
+            ["Capacidade do mecanismo de banco de dados", false],
+        ],
+    },
+    {
+        statement:
+            "Qual modelo de implantação permite ao cliente trocar totalmente as despesas de capital (CapEx) de TI por despesas operacionais (OpEx)?",
+        explanation:
+            "Na implantação em nuvem, toda a infraestrutura roda no provedor e o investimento inicial em hardware vira custo variável pelo uso. No on-premises o CapEx continua integral, no modelo híbrido parte dele permanece, e PaaS é um modelo de serviço (como IaaS e SaaS), não um modelo de implantação.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Implantação on-premises", false],
+            ["Implantação híbrida", false],
+            ["Implantação em nuvem", true],
+            ["Plataforma como serviço (PaaS)", false],
+        ],
+    },
+    {
+        statement:
+            "A aplicação web de uma empresa tem dependências rígidas entre seus componentes, e a falha de um deles derruba a aplicação inteira. Qual princípio de design da Nuvem AWS resolve esse problema?",
+        explanation:
+            "Desacoplar isola os componentes, que passam a se comunicar por interfaces como filas, e a falha de um não derruba os demais. Elasticidade ajusta capacidade à demanda, instâncias em paralelo melhoram desempenho e dobrar recursos só aumenta capacidade; nenhuma dessas opções remove a dependência rígida entre os componentes.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implementar elasticidade, para a aplicação escalar conforme a demanda muda", false],
+            ["Executar várias instâncias EC2 em paralelo para obter melhor desempenho", false],
+            ["Desacoplar os componentes, para que cada um funcione mesmo se outro falhar", true],
+            ["Dobrar os recursos de computação do EC2 para aumentar a tolerância a falhas", false],
+        ],
+    },
+    {
+        statement:
+            "Qual das opções a seguir é um princípio de design do AWS Well-Architected Framework relacionado ao pilar Confiabilidade?",
+        explanation:
+            "Recuperar-se automaticamente de falhas é um dos princípios do pilar Confiabilidade, ao lado de testar procedimentos de recuperação e escalar horizontalmente. Adotar um modelo de consumo é princípio de Otimização de custos, base sólida de identidade é de Segurança, e implantar em uma única zona cria ponto único de falha.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantar em uma única Zona de Disponibilidade", false],
+            ["Recuperar-se automaticamente de falhas", true],
+            ["Adotar um modelo de consumo", false],
+            ["Implementar uma base sólida de identidade", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é uma vantagem de usar a Nuvem AWS em vez de uma solução on-premises tradicional?",
+        explanation:
+            "Na AWS a capacidade é provisionada sob demanda e ajustada em minutos, então não é preciso comprar hardware com base em previsões. Contratos de hardware são coisa do modelo on-premises, os custos da nuvem variam com o uso e os relatórios do AWS Artifact apoiam auditorias, mas não livram o cliente delas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Os usuários não precisam adivinhar a capacidade futura", true],
+            ["Os usuários aproveitam contratos de hardware já existentes", false],
+            ["Os usuários mantêm custos fixos, seja qual for o tráfego", false],
+            ["Os usuários evitam auditorias usando relatórios da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Por que uma empresa deveria escolher a AWS em vez de um data center tradicional?",
+        explanation:
+            "A AWS cobra pelo uso, sem contratos de longo prazo na maioria dos serviços, o que evita grandes investimentos iniciais. O cliente não controla o hardware subjacente, os locais de borda não existem em todos os países e há cotas de serviço por conta e Região, que podem ser aumentadas sob pedido.",
+        topic: "Preços e faturamento",
+        options: [
+            ["A AWS dá aos usuários controle total sobre os recursos subjacentes", false],
+            ["A AWS dispensa contratos de longo prazo e cobra pelo uso", true],
+            ["A AWS tem locais de borda em todos os países do mundo", false],
+            ["A AWS não impõe limite à quantidade de recursos criados", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é a forma MAIS eficaz de a AWS reduzir os custos de computação de uma startup em crescimento?",
+        explanation:
+            "Com recursos sob demanda, a startup provisiona capacidade só nos picos e a libera depois, pagando apenas pelo que usa em vez de comprar hardware para a carga máxima. Automatizar ambientes de desenvolvimento ajuda na produtividade, CRM não tem relação com infraestrutura e um orçamento fixo limita gastos sem reduzir o custo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Oferecer recursos sob demanda para os picos de uso", true],
+            ["Automatizar o provisionamento de ambientes de cada desenvolvedor", false],
+            ["Automatizar a gestão do relacionamento com clientes", false],
+            ["Aplicar um orçamento mensal fixo de computação", false],
+        ],
+    },
+    {
+        statement:
+            "Quais princípios são usados para arquitetar aplicações confiáveis na Nuvem AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Recuperação automática de falhas é princípio do pilar Confiabilidade, e distribuir a carga em várias Zonas de Disponibilidade elimina pontos únicos de falha. O pilar pede mudanças por automação, e não manuais, e testes de recuperação e de pico em vez de carga moderada; restaurar backups on-premises cria dependência de infraestrutura local.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Projetar a recuperação automática em caso de falhas", true],
+            ["Distribuir a carga em várias Zonas de Disponibilidade", true],
+            ["Gerenciar mudanças manualmente, seguindo processos documentados", false],
+            ["Testar com demanda moderada para garantir a confiabilidade", false],
+            ["Restaurar os backups em um ambiente on-premises", false],
+        ],
+    },
+    {
+        statement: "Qual opção é um exemplo de alta disponibilidade na Nuvem AWS?",
+        explanation:
+            "Alta disponibilidade é manter a aplicação acessível mesmo quando um recurso falha, com redundância entre Zonas de Disponibilidade e failover automático. Suporte 24 horas é uma oferta dos planos de suporte, pagar sob demanda é modelo de preço e implantar em várias Regiões é alcance global, que sozinho não garante disponibilidade.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Consultar o suporte técnico da AWS a qualquer hora do dia ou da noite", false],
+            ["Manter a aplicação acessível mesmo se um recurso falhar", true],
+            ["Usar qualquer serviço da AWS pagando sob demanda", false],
+            ["Implantar em qualquer parte do mundo usando Regiões da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está avaliando levar seus servidores para a Nuvem AWS. Quais vantagens ela terá ao hospedar a infraestrutura na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Na AWS não há compromisso nem investimento inicial, e os recursos são provisionados sob demanda em minutos. Pelo modelo de responsabilidade compartilhada, a segurança na nuvem é do cliente; o armazenamento é cobrado pelo uso, com cota gratuita só no nível gratuito; e o cliente não controla a infraestrutura física.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Não há compromissos nem investimentos iniciais", true],
+            ["A AWS gerencia toda a segurança na nuvem", false],
+            ["É possível provisionar recursos sob demanda", true],
+            ["Há armazenamento gratuito e ilimitado", false],
+            ["Os usuários têm controle sobre a infraestrutura física", false],
+        ],
+    },
+    {
+        statement:
+            "Quais benefícios a Nuvem AWS oferece a empresas com clientes em muitos países do mundo? (Selecione DUAS opções.)",
+        explanation:
+            "Implantar em várias Regiões aproxima a aplicação dos usuários, e os locais de borda do CloudFront entregam conteúdo perto deles; os dois reduzem a latência. O Translate traduz textos, mas não interfaces de terceiros por conta própria; o Comprehend analisa texto; e o Elastic Load Balancing distribui tráfego dentro de uma Região.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantar as aplicações em várias Regiões da AWS para reduzir a latência", true],
+            ["O Amazon Translate traduz automaticamente a interface de sites de terceiros", false],
+            ["O Amazon CloudFront tem locais de borda pelo mundo que reduzem a latência", true],
+            [
+                "O Amazon Comprehend cria aplicações que respondem a usuários em vários idiomas",
+                false,
+            ],
+            [
+                "O Elastic Load Balancing distribui o tráfego entre Regiões e reduz a latência",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quando uma empresa provisiona servidores web em várias Regiões da AWS, o que está sendo aumentado?",
+        explanation:
+            "Com servidores web em mais de uma Região, a aplicação continua atendendo mesmo se uma Região inteira ficar indisponível, o que aumenta a disponibilidade. O acoplamento trata da dependência entre componentes, a segurança depende de configuração e controles, e a durabilidade se refere à preservação de dados armazenados.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["O acoplamento entre os componentes", false],
+            ["A disponibilidade da aplicação", true],
+            ["A segurança da aplicação", false],
+            ["A durabilidade dos dados", false],
+        ],
+    },
+    {
+        statement:
+            "Durante uma revisão de arquitetura, um arquiteto avalia uma carga de trabalho com base no AWS Well-Architected Framework. Quais opções correspondem a pilares desse framework? (Selecione DUAS opções.)",
+        explanation:
+            "O Well-Architected tem seis pilares: Excelência operacional, Segurança, Confiabilidade, Eficiência de desempenho, Otimização de custos e Sustentabilidade. Várias Zonas de Disponibilidade são estratégia de implantação, criptografia é prática dentro do pilar Segurança e alta disponibilidade é objetivo ligado ao pilar Confiabilidade.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Várias Zonas de Disponibilidade", false],
+            ["Eficiência de desempenho", true],
+            ["Segurança", true],
+            ["Criptografia", false],
+            ["Alta disponibilidade", false],
+        ],
+    },
+    {
+        statement: "O que a prática de infraestrutura como código permite fazer na Nuvem AWS?",
+        explanation:
+            "Com infraestrutura como código, os recursos são descritos em templates (como no AWS CloudFormation) e provisionados de forma automática, repetível e versionada. Hardware físico não migra por código, auditoria feita por terceiros é outra atividade e o código da aplicação continua sob responsabilidade do cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Automatizar a migração de hardware on-premises para data centers da AWS", false],
+            ["Permitir que terceiros automatizem a auditoria da infraestrutura da AWS", false],
+            ["Entregar o código da aplicação para a AWS executar por conta própria", false],
+            ["Automatizar o provisionamento da infraestrutura a partir de templates", true],
+        ],
+    },
+    {
+        statement:
+            "Um sistema na Nuvem AWS foi projetado para suportar a falha de um ou mais componentes e continuar atendendo os usuários. Isso é um exemplo de quê?",
+        explanation:
+            "Seguir atendendo quando componentes falham, com redundância e failover automático, é alta disponibilidade (a ideia se aproxima de tolerância a falhas, que não está entre as opções). Elasticidade e escalabilidade ajustam ou ampliam a capacidade conforme a carga, e agilidade nos negócios é a rapidez para provisionar e lançar novidades.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Elasticidade", false],
+            ["Alta disponibilidade", true],
+            ["Escalabilidade", false],
+            ["Agilidade nos negócios", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer construir as cargas de trabalho de suas novas aplicações na Nuvem AWS em vez de usar recursos on-premises. Qual despesa pode ser reduzida com a Nuvem AWS?",
+        explanation:
+            "Na AWS a empresa não precisa comprar, instalar e cabear servidores e equipamentos de rede para as novas aplicações; paga só pelo consumo. Escrever código em Java ou Node.js, fazer testes de penetração e criar casos de teste para software de terceiros são custos de pessoas e processos que continuam iguais na nuvem.",
+        topic: "Preços e faturamento",
+        options: [
+            ["O custo de escrever código próprio em Java ou Node.js", false],
+            ["Testes de penetração (pentest) de segurança", false],
+            ["O hardware necessário para rodar as novas aplicações", true],
+            ["A escrita de casos de teste para aplicações de terceiros", false],
+        ],
+    },
+    {
+        statement: "O que significa um usuário implantar uma arquitetura de nuvem híbrida na AWS?",
+        explanation:
+            "Na nuvem híbrida, parte dos recursos continua no data center on-premises e parte roda na Nuvem AWS, conectadas por serviços como AWS Site-to-Site VPN ou AWS Direct Connect. Tudo on-premises ou tudo na AWS não é híbrido, e dividir entre on-premises e colocation não envolve nenhum provedor de nuvem.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Todos os recursos rodam em infraestrutura on-premises", false],
+            ["Parte dos recursos roda on-premises e parte em um centro de colocation", false],
+            ["Todos os recursos rodam na Nuvem AWS", false],
+            ["Parte dos recursos roda on-premises e parte na Nuvem AWS", true],
+        ],
+    },
+    {
+        statement:
+            "Uma startup compara a Nuvem AWS com a compra de servidores próprios. Quais vantagens a nuvem oferece nesse caso? (Selecione DUAS opções.)",
+        explanation:
+            "Com capacidade sob demanda, não é preciso prever a infraestrutura necessária, e provisionar em minutos acelera a chegada ao mercado. A cobrança da AWS varia com o uso, a nuvem reduz o investimento de capital antecipado em vez de aumentá-lo, e clientes não têm acesso físico aos data centers.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Custo mensal fixo, independente do uso", false],
+            ["Não precisar adivinhar a capacidade necessária", true],
+            ["Maior velocidade para chegar ao mercado", true],
+            ["Aumento da despesa de capital antecipada", false],
+            ["Acesso físico aos data centers onde a nuvem roda", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai comparar o custo de manter sua infraestrutura on-premises com o de uma arquitetura na nuvem. Quais custos devem entrar nesse cálculo de TCO? (Selecione DUAS opções.)",
+        explanation:
+            "No TCO entram os custos de infraestrutura que mudam entre os modelos: comprar e instalar servidores e administrar o ambiente (patches, backups, recuperação de falhas). Taxas de cartão, testes de penetração e campanhas de publicidade existem em qualquer hospedagem e não diferenciam on-premises de nuvem.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Taxas de processamento de cartão de crédito nas transações da aplicação", false],
+            ["Compra e instalação de servidores no data center on-premises", true],
+            ["Administração da infraestrutura, como patches, backups e recuperação", true],
+            ["Testes de penetração contratados de terceiros", false],
+            ["Custos de publicidade de uma campanha contínua em toda a empresa", false],
+        ],
+    },
+    {
+        statement: "Qual das opções é uma boa prática de design na Nuvem AWS?",
+        explanation:
+            "Projetar para alta disponibilidade, com redundância entre Zonas de Disponibilidade e failover automático, é boa prática na Nuvem AWS. Acoplamento forte faz falhas se propagarem, ponto único de falha é justamente o que o design deve eliminar e superprovisionar é hábito on-premises que a elasticidade substitui.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Acoplamento forte entre componentes", false],
+            ["Ponto único de falha", false],
+            ["Alta disponibilidade", true],
+            ["Superprovisionamento de recursos", false],
+        ],
+    },
+    {
+        statement:
+            "Por que a AWS é mais econômica que um data center tradicional para aplicações com carga de computação variável?",
+        explanation:
+            "Instâncias EC2 são iniciadas quando a carga sobe e encerradas quando cai, então paga-se só pelo tempo de uso em vez de manter hardware dimensionado para o pico. O EC2 não cobra valor mensal fixo, ter acesso administrativo não reduz custo e manter capacidade de pico o tempo todo é justamente o modelo caro do data center.",
+        topic: "Preços e faturamento",
+        options: [
+            ["O Amazon EC2 cobra um valor mensal fixo por instância", false],
+            ["Os clientes mantêm acesso administrativo total às instâncias EC2", false],
+            ["As instâncias do Amazon EC2 podem ser iniciadas sob demanda", true],
+            ["Os clientes podem manter sempre instâncias suficientes para o pico", false],
+        ],
+    },
+    {
+        statement: "Qual princípio de design está alinhado às boas práticas da Nuvem AWS?",
+        explanation:
+            "Distribuir a carga de computação entre vários recursos (escala horizontal) melhora desempenho e tolerância a falhas, sem ponto único de falha. Dependências fixas contrariam o acoplamento fraco, e concentrar tudo em uma instância ou em uma única Zona de Disponibilidade deixa a aplicação exposta a uma falha localizada.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Criar dependências fixas entre os componentes da aplicação", false],
+            ["Concentrar os serviços em uma única instância", false],
+            ["Implantar as aplicações em uma única Zona de Disponibilidade", false],
+            ["Distribuir a carga de computação entre vários recursos", true],
+        ],
+    },
+    {
+        statement:
+            "Um novo serviço na AWS precisa ter alta disponibilidade, mas uma exigência regulatória obriga todas as instâncias do Amazon EC2 a ficarem em uma única área geográfica. Segundo as boas práticas, qual distribuição mínima das instâncias atende aos dois requisitos?",
+        explanation:
+            "Zonas de Disponibilidade são locais isolados dentro de uma mesma Região, então usar duas delas protege contra a falha de uma zona sem sair da área geográfica. Duas Regiões violam a exigência regulatória, e sub-redes ou grupos de posicionamento dentro de uma única zona não resistem à falha dessa zona.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Duas Regiões da AWS, em áreas geográficas diferentes", false],
+            ["Duas Zonas de Disponibilidade dentro da mesma Região", true],
+            ["Duas sub-redes dentro da mesma Zona de Disponibilidade", false],
+            ["Dois grupos de posicionamento na mesma Zona de Disponibilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Um usuário implanta uma instância de banco de dados do Amazon RDS em várias Zonas de Disponibilidade. Essa estratégia está ligada a qual pilar do AWS Well-Architected Framework?",
+        explanation:
+            "Com o RDS em várias Zonas de Disponibilidade, uma réplica em espera assume automaticamente se a zona principal falhar, o que atende ao foco do pilar Confiabilidade em recuperação e disponibilidade. Eficiência de desempenho trata do uso eficiente de recursos, Otimização de custos evita gastos desnecessários e Segurança protege dados e sistemas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Eficiência de desempenho", false],
+            ["Confiabilidade", true],
+            ["Otimização de custos", false],
+            ["Segurança", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa que vende pela internet precisa entregar novas funcionalidades rapidamente e de forma iterativa, reduzindo o tempo até chegar ao mercado. Qual característica da Nuvem AWS oferece isso?",
+        explanation:
+            "Agilidade é poder provisionar recursos em minutos, experimentar e publicar mudanças com frequência, o que encurta o tempo até o mercado. Elasticidade ajusta capacidade à demanda, e alta disponibilidade e confiabilidade tratam de manter a aplicação funcionando diante de falhas; nenhuma delas acelera a entrega de funcionalidades.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Elasticidade", false],
+            ["Alta disponibilidade", false],
+            ["Agilidade", true],
+            ["Confiabilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Quais medidas ajudam a rastrear mudanças nos recursos da AWS e a investigar a causa de falhas? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Config mantém o inventário e o histórico de configuração dos recursos, e o AWS CloudTrail registra as chamadas de API; juntos permitem rastrear mudanças e investigar a causa de falhas. Cotas não servem para bloquear mudanças, o Certificate Manager emite certificados SSL/TLS e o GuardDuty detecta ameaças, sem validar configurações.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Usar o AWS Config para manter um inventário atualizado dos recursos da AWS", true],
+            ["Usar cotas de serviço para impedir que usuários criem ou alterem recursos", false],
+            ["Usar o AWS CloudTrail para registrar chamadas de API em logs auditáveis", true],
+            [
+                "Usar o AWS Certificate Manager para criar uma lista de permissões de serviços",
+                false,
+            ],
+            ["Usar o Amazon GuardDuty para validar mudanças de configuração nos recursos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma carga de trabalho em lote leva 5 horas para terminar em uma instância do Amazon EC2. O volume de dados dobra todo mês, e o tempo de processamento cresce na mesma proporção. Qual é a melhor arquitetura na nuvem para atender a essa demanda sempre crescente?",
+        explanation:
+            "Com o volume dobrando todo mês, só a escala horizontal acompanha o crescimento: dividir o trabalho entre várias instâncias em paralelo mantém o tempo sob controle. Instância maior, outra família ou bare metal são escala vertical ou ajuste de perfil, que esbarram no limite de uma única máquina.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Executar a aplicação em uma instância EC2 de tamanho maior", false],
+            ["Trocar para uma família de instância EC2 própria para lotes", false],
+            ["Dividir o trabalho entre várias instâncias EC2 em paralelo", true],
+            ["Executar a aplicação em uma instância EC2 bare metal", false],
+        ],
+    },
+    {
+        statement: "Qual é o benefício da elasticidade na Nuvem AWS?",
+        explanation:
+            "A elasticidade adiciona capacidade nos picos e a remove nos períodos calmos, mantendo o desempenho estável sem intervenção manual. Distribuir tráfego entre Regiões é roteamento global, arquivar logs é gestão do ciclo de vida dos dados e a escolha dos serviços mais baratos continua sendo decisão do cliente.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "Garantir que o tráfego web seja distribuído automaticamente entre várias Regiões",
+                false,
+            ],
+            ["Reduzir custos de armazenamento arquivando logs automaticamente", false],
+            ["Permitir que a AWS escolha automaticamente os serviços mais baratos", false],
+            ["Ajustar automaticamente a capacidade de computação para manter o desempenho", true],
+        ],
+    },
+    {
+        statement:
+            "Qual boa prática da Nuvem AWS aproveita diretamente a elasticidade e a agilidade da computação em nuvem?",
+        explanation:
+            "Escalar de forma dinâmica e preditiva usa a elasticidade (ajustar recursos à demanda) e a agilidade (reagir rápido a mudanças). Provisionar por picos teóricos gera ociosidade, data center com acesso físico é modelo on-premises, e acoplamento fraco é boa prática de resiliência, não de uso da elasticidade.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Provisionar capacidade com base no uso passado e em picos teóricos", false],
+            ["Escalar de forma dinâmica e preditiva para atender à demanda de uso", true],
+            ["Construir a aplicação e a infraestrutura em um data center com acesso físico", false],
+            ["Dividir a aplicação em componentes com acoplamento fraco", false],
+        ],
+    },
+    {
+        statement: "Qual método ajuda a otimizar os custos de quem está migrando para a Nuvem AWS?",
+        explanation:
+            "No modelo de pagamento conforme o uso, o cliente paga só pelos recursos consumidos, sem desperdício com capacidade ociosa. Comprar hardware antecipadamente e dimensionar para a carga máxima geram recursos parados, e o provisionamento manual reage devagar à demanda, ao contrário da escala automática.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Pagar apenas pelos recursos usados", true],
+            ["Comprar hardware antes de precisar dele", false],
+            ["Provisionar recursos na nuvem manualmente", false],
+            ["Comprar para a carga máxima possível", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é um dos princípios centrais ao projetar uma aplicação altamente disponível na Nuvem AWS?",
+        explanation:
+            "Presumir que qualquer componente pode falhar leva a projetar redundância, verificações de integridade e failover em todas as camadas. Serverless é uma opção válida, mas não obrigatória para alta disponibilidade, o Auto Scaling ajuda na escala sem ser exigido em toda aplicação, e código aberto é escolha de licenciamento.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Projetar com arquitetura sem servidor (serverless)", false],
+            ["Presumir que todos os componentes podem falhar", true],
+            ["Incluir o AWS Auto Scaling em todas as aplicações", false],
+            ["Desenvolver todos os componentes com código aberto", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de nuvem está elaborando um plano de recuperação de desastres e pretende replicar dados entre diferentes áreas geográficas. Qual opção atende a esse requisito?",
+        explanation:
+            "Regiões são áreas geográficas separadas no mundo, então replicar dados entre elas protege contra desastres que atinjam uma localidade inteira. Contas são limites lógicos de gestão e faturamento, Zonas de Disponibilidade ficam dentro de uma mesma Região e locais de borda servem para entrega de conteúdo e cache.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Contas da AWS", false],
+            ["Regiões da AWS", true],
+            ["Zonas de Disponibilidade", false],
+            ["Locais de borda", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai usar o Amazon EC2 para implantar uma aplicação comercial global, com o maior nível possível de redundância e tolerância a falhas. Como as instâncias do EC2 devem ser implantadas?",
+        explanation:
+            "Várias Zonas de Disponibilidade em duas Regiões protegem tanto contra a falha de uma zona quanto contra a indisponibilidade de uma Região inteira, o maior nível de redundância entre as opções. Uma única zona é ponto único de falha, várias interfaces de rede não trazem redundância de computação e uma só Região fica exposta a falhas regionais.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Em uma única Zona de Disponibilidade de uma Região da AWS", false],
+            ["Com várias interfaces de rede elásticas em sub-redes diferentes", false],
+            ["Em várias Zonas de Disponibilidade de uma Região da AWS", false],
+            ["Em várias Zonas de Disponibilidade de duas Regiões da AWS", true],
         ],
     },
     {

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d2.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d2.ts
@@ -1,0 +1,2221 @@
+// Questões do simulado AWS Certified Cloud Practitioner (CLF-C02), domínio 2 da prova
+// (Security and Compliance), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aws-ccp-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D2: Questao[] = [
+    {
+        statement:
+            "Uma equipe percebeu que várias instâncias críticas do Amazon EC2 foram encerradas. Qual serviço da AWS ajuda a descobrir quem executou essa ação?",
+        explanation:
+            "O AWS CloudTrail registra as chamadas de API da conta com a identidade de quem as fez, o horário e o IP de origem, então mostra quem encerrou as instâncias. O Inspector procura vulnerabilidades, o Trusted Advisor faz recomendações e o relatório de uso traz apenas dados de consumo.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon Inspector", false],
+            ["AWS CloudTrail", true],
+            ["AWS Trusted Advisor", false],
+            ["Relatório de uso de instâncias do Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Qual afirmação sobre o modelo de responsabilidade compartilhada da AWS está correta?",
+        explanation:
+            "A divisão muda conforme o tipo de serviço: no Amazon EC2 (IaaS) o cliente cuida do sistema operacional convidado, enquanto em serviços gerenciados como o Amazon RDS a AWS assume mais camadas. Por isso não dá para dizer que IaaS, patches do sistema convidado ou serviços gerenciados ficam sempre com um único lado.",
+        topic: "Segurança e identidade",
+        options: [
+            ["A divisão de responsabilidades varia de acordo com os serviços utilizados", true],
+            ["A segurança dos serviços de IaaS é responsabilidade exclusiva da AWS", false],
+            ["A aplicação de patches no sistema operacional convidado é sempre da AWS", false],
+            ["A segurança dos serviços gerenciados é responsabilidade exclusiva do cliente", false],
+        ],
+    },
+    {
+        statement:
+            "Centenas de milhares de ataques DDoS são registrados todos os meses no mundo. Quais serviços da AWS ajudam a proteger os clientes contra esses ataques? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Shield oferece proteção gerenciada contra DDoS nas camadas de rede e de transporte, e o AWS WAF ajuda contra ataques na camada de aplicação, como inundações HTTP, com regras baseadas em taxa. O Config registra configurações, o Cognito autentica usuários de aplicativos e o KMS gerencia chaves.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Shield", true],
+            ["AWS Config", false],
+            ["Amazon Cognito", false],
+            ["AWS WAF", true],
+            ["AWS Key Management Service (AWS KMS)", false],
+        ],
+    },
+    {
+        statement: "Qual serviço permite que os clientes gerenciem os acordos firmados com a AWS?",
+        explanation:
+            "O AWS Artifact é o portal de autoatendimento em que o cliente consulta, aceita e gerencia acordos com a AWS, como o BAA, além de baixar relatórios de conformidade. O ACM gerencia certificados SSL/TLS, o Config avalia a configuração dos recursos e o Organizations administra várias contas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Artifact", true],
+            ["AWS Certificate Manager (ACM)", false],
+            ["AWS Config", false],
+            ["AWS Organizations", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são exemplos de serviços gerenciados, em que a AWS opera e mantém o sistema operacional e a plataforma que executam o serviço? (Selecione DUAS opções.)",
+        explanation:
+            "No Amazon DynamoDB e no Amazon EMR, a AWS provisiona, corrige e mantém a plataforma do serviço. Amazon EC2, Amazon EBS e Amazon VPC são serviços de infraestrutura: a AWS mantém o hardware, mas o cliente configura e opera as instâncias, os volumes e as redes.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon VPC", false],
+            ["Amazon DynamoDB", true],
+            ["Amazon EMR", true],
+            ["Amazon EBS", false],
+            ["Amazon Elastic Compute Cloud (Amazon EC2)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa com o plano AWS Basic Support percebeu que recursos da AWS de outra conta estão sendo usados em atividades maliciosas contra os sistemas dela. O que ela deve fazer?",
+        explanation:
+            "A equipe AWS Trust & Safety (antiga AWS Abuse team) recebe denúncias de uso malicioso de recursos da AWS, e esse canal está disponível em qualquer plano de suporte. O atendimento ao cliente e o Concierge cuidam de conta e faturamento, e a equipe de segurança da AWS trata vulnerabilidades da própria AWS.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Entrar em contato com a equipe de atendimento ao cliente da AWS", false],
+            ["Entrar em contato com a equipe AWS Trust & Safety", true],
+            ["Entrar em contato com a equipe de Concierge da AWS", false],
+            ["Entrar em contato com a equipe de segurança da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "A AWS classifica alguns controles de segurança como compartilhados, pois se aplicam tanto à infraestrutura dela quanto ao ambiente do cliente. Quais são exemplos desses controles? (Selecione DUAS opções.)",
+        explanation:
+            "Gerenciamento de patches e de configuração são controles compartilhados: a AWS cuida da própria infraestrutura e o cliente, dos seus sistemas operacionais, aplicações e recursos. IAM e VPC são configurados só pelo cliente, e a operação dos data centers é só da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Gerenciamento de patches", true],
+            ["Gerenciamento do IAM", false],
+            ["Gerenciamento da VPC", false],
+            ["Gerenciamento de configuração", true],
+            ["Operação dos data centers físicos", false],
+        ],
+    },
+    {
+        statement: "Pelo modelo de responsabilidade compartilhada, qual destas tarefas cabe à AWS?",
+        explanation:
+            "Configurar os dispositivos físicos de infraestrutura (servidores, rede e armazenamento) faz parte da segurança da nuvem, a cargo da AWS. Criptografar do lado do cliente, gerenciar as chaves de criptografia dos dados e definir regras de grupos de segurança são tarefas do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criptografar os dados do lado do cliente", false],
+            ["Configurar os dispositivos de infraestrutura", true],
+            ["Gerenciar as chaves de criptografia dos dados", false],
+            ["Filtrar o tráfego das instâncias com grupos de segurança", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está desenvolvendo uma aplicação web crítica na AWS e trata a segurança como prioridade máxima. Qual serviço da AWS fornece recomendações de otimização da segurança da infraestrutura?",
+        explanation:
+            "O AWS Trusted Advisor analisa o ambiente e aponta recomendações de boas práticas, inclusive de segurança, como grupos de segurança abertos e usuário raiz sem MFA. O Shield protege contra DDoS, o console é só a interface web de gerenciamento e o Secrets Manager guarda e rotaciona segredos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Shield", false],
+            ["Console de Gerenciamento da AWS", false],
+            ["AWS Secrets Manager", false],
+            ["AWS Trusted Advisor", true],
+        ],
+    },
+    {
+        statement:
+            "Ao revisar o modelo de responsabilidade compartilhada, uma equipe precisa listar o que é tarefa dela. Quais atividades cabem ao cliente? (Selecione DUAS opções.)",
+        explanation:
+            "O cliente define as regras de senha dos usuários do IAM e as regras de acesso à rede, como grupos de segurança e Network ACLs (segurança na nuvem). Descartar discos, controlar o acesso físico e aplicar patches na infraestrutura de rede são tarefas da AWS (segurança da nuvem).",
+        topic: "Segurança e identidade",
+        options: [
+            ["Descarte seguro de discos de armazenamento", false],
+            ["Controle do acesso físico aos recursos de computação", false],
+            ["Aplicação de patches na infraestrutura de rede", false],
+            ["Definição de regras de complexidade de senhas", true],
+            ["Configuração de regras de acesso à rede", true],
+        ],
+    },
+    {
+        statement:
+            "Segundo o modelo de responsabilidade compartilhada da AWS, quem é responsável pelo gerenciamento de configuração?",
+        explanation:
+            "Gerenciamento de configuração é um controle compartilhado: a AWS configura e mantém os dispositivos da sua infraestrutura, e o cliente configura os próprios sistemas operacionais convidados, bancos de dados e aplicações. Por isso não é exclusivo de nenhum dos lados e faz parte do modelo.",
+        topic: "Segurança e identidade",
+        options: [
+            ["É responsabilidade exclusiva do cliente", false],
+            ["É responsabilidade exclusiva da AWS", false],
+            ["É compartilhado entre a AWS e o cliente", true],
+            ["Não faz parte do modelo de responsabilidade compartilhada", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer saber quais tarefas de segurança continuam com ela depois de migrar para a AWS. Quais são de responsabilidade do cliente? (Selecione DUAS opções.)",
+        explanation:
+            "Proteger os dados, inclusive com criptografia em repouso, e treinar os próprios usuários em segurança são tarefas do cliente (segurança na nuvem). Servidores NTP, acesso físico aos data centers e descarte de hardware fazem parte da infraestrutura mantida pela AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Garantir que os dados da aplicação sejam criptografados em repouso", true],
+            ["Garantir que os servidores NTP da AWS estejam com o horário correto", false],
+            ["Garantir o treinamento de segurança dos próprios usuários", true],
+            ["Garantir que o acesso físico aos data centers seja restrito", false],
+            ["Garantir que o hardware antigo seja descartado corretamente", false],
+        ],
+    },
+    {
+        statement:
+            "Para que servem as chaves de acesso do AWS Identity and Access Management (IAM)?",
+        explanation:
+            "As chaves de acesso (ID da chave de acesso e chave de acesso secreta) autenticam chamadas programáticas feitas pela AWS CLI, pelos SDKs ou direto pela API. O console usa nome de usuário e senha, o login em instâncias EC2 usa pares de chaves e a criptografia no S3 usa chaves do KMS ou gerenciadas pelo S3.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Fazer login no Console de Gerenciamento da AWS", false],
+            ["Fazer chamadas programáticas às APIs da AWS", true],
+            ["Fazer login em instâncias do Amazon EC2", false],
+            ["Criptografar dados armazenados no Amazon S3", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem ser usados para reunir informações sobre a atividade de uma conta AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CloudTrail registra as chamadas de API e as ações feitas na conta, e o Amazon CloudWatch coleta métricas, logs e eventos dos recursos, permitindo acompanhar essa atividade e criar alertas. O CloudFront é uma CDN, o Cloud9 é um IDE na nuvem e o CloudHSM oferece módulos de segurança de hardware.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon CloudFront", false],
+            ["AWS Cloud9", false],
+            ["AWS CloudTrail", true],
+            ["AWS CloudHSM", false],
+            ["Amazon CloudWatch", true],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso do IAM permite que desenvolvedores acessem os serviços da AWS pela AWS Command Line Interface (AWS CLI)?",
+        explanation:
+            "A AWS CLI se autentica com chaves de acesso do IAM, formadas pelo ID da chave de acesso e pela chave de acesso secreta (hoje a AWS recomenda preferir credenciais temporárias). Nome de usuário e senha servem para o Console de Gerenciamento, chaves SSH dão acesso a instâncias Linux e chave de API não é credencial do IAM.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Chaves de API", false],
+            ["Chaves de acesso", true],
+            ["Nome de usuário e senha", false],
+            ["Chaves SSH", false],
+        ],
+    },
+    {
+        statement:
+            "Ao executar cargas de trabalho na AWS, por qual ação o cliente é o único responsável?",
+        explanation:
+            "Controles específicos da aplicação, como rotear ou segmentar o tráfego dela entre ambientes de segurança, são exclusivos do cliente. Aplicar patches e manter a infraestrutura subjacente, assim como os controles físicos e ambientais dos data centers, são responsabilidades da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Aplicar patches nos componentes da infraestrutura", false],
+            ["Manter os componentes da infraestrutura subjacente", false],
+            ["Manter os controles físicos e ambientais dos data centers", false],
+            ["Implementar controles para rotear o tráfego da aplicação", true],
+        ],
+    },
+    {
+        statement: "Em qual área a auditoria é responsabilidade exclusiva da AWS?",
+        explanation:
+            "Os controles de segurança física dos data centers (acesso às instalações, vigilância e descarte de hardware) são auditados só pela AWS, já que o cliente não tem acesso a eles. Políticas do IAM, políticas de bucket do S3 e a análise dos logs do CloudTrail são configuradas e auditadas pelo cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Políticas do IAM", false],
+            ["Segurança física", true],
+            ["Políticas de bucket do Amazon S3", false],
+            ["Logs do AWS CloudTrail", false],
+        ],
+    },
+    {
+        statement:
+            "Quais tarefas comuns de TI a AWS pode assumir, por meio de serviços gerenciados como o Amazon RDS, para liberar a equipe de TI da empresa? (Selecione DUAS opções.)",
+        explanation:
+            "Em serviços gerenciados como o Amazon RDS, a AWS aplica os patches do mecanismo do banco e faz backups automáticos, liberando a equipe do cliente. Testar versões da aplicação, criar o esquema do banco e realizar testes de penetração dependem do conhecimento do negócio e continuam com o cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Aplicar patches no banco de dados", true],
+            ["Testar novas versões da aplicação", false],
+            ["Fazer backup dos bancos de dados", true],
+            ["Criar o esquema do banco de dados", false],
+            ["Executar testes de penetração", false],
+        ],
+    },
+    {
+        statement:
+            "Um cliente precisa auditar o gerenciamento de mudanças dos seus recursos da AWS. Qual serviço da AWS ele deve usar?",
+        explanation:
+            "O AWS Config registra continuamente a configuração dos recursos e mantém o histórico de alterações, mostrando o que mudou e quando, o que permite auditar o gerenciamento de mudanças. O Trusted Advisor faz recomendações, o CloudWatch monitora métricas e logs e o Artifact entrega relatórios de conformidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Config", true],
+            ["AWS Trusted Advisor", false],
+            ["Amazon CloudWatch", false],
+            ["AWS Artifact", false],
+        ],
+    },
+    {
+        statement:
+            "Ao usar a AWS Command Line Interface (AWS CLI), qual entidade do IAM fica associada a um ID de chave de acesso e a uma chave de acesso secreta?",
+        explanation:
+            "O usuário do IAM pode ter chaves de acesso de longo prazo (ID da chave e chave secreta) configuradas na AWS CLI. O grupo apenas reúne usuários, a função do IAM fornece credenciais temporárias quando é assumida e a política é um documento JSON de permissões, não uma identidade.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Grupo do IAM", false],
+            ["Usuário do IAM", true],
+            ["Função do IAM (IAM role)", false],
+            ["Política do IAM", false],
+        ],
+    },
+    {
+        statement:
+            "Pelo modelo de responsabilidade compartilhada, qual destes itens fica a cargo do cliente?",
+        explanation:
+            "A AWS oferece os recursos de criptografia, mas cabe ao cliente decidir e garantir que seus dados sejam criptografados em repouso. Apagar discos usados, atualizar o firmware do hardware e manter o cabeamento de rede fazem parte da infraestrutura física, responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Garantir que os discos sejam apagados após o uso", false],
+            ["Garantir que o firmware dos dispositivos de hardware esteja atualizado", false],
+            ["Garantir que os dados sejam criptografados em repouso", true],
+            ["Garantir que os cabos de rede sejam de categoria 6 ou superior", false],
+        ],
+    },
+    {
+        statement:
+            "Quais componentes de credencial são necessários para obter acesso programático a uma conta AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O acesso programático usa o ID da chave de acesso, que identifica quem faz a chamada, e a chave de acesso secreta, que assina as requisições. Chave primária e chave secundária não são credenciais do IAM, e o ID de usuário é só um identificador interno, que não autentica chamadas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Um ID de chave de acesso", true],
+            ["Uma chave primária da conta", false],
+            ["Uma chave de acesso secreta", true],
+            ["Um ID de usuário do IAM", false],
+            ["Uma chave secundária da conta", false],
+        ],
+    },
+    {
+        statement: "Qual destes itens é um controle compartilhado entre o cliente e a AWS?",
+        explanation:
+            "Conscientização e treinamento é um controle compartilhado: a AWS treina os próprios funcionários e o cliente treina os dele. A chave da criptografia do lado do cliente e a configuração do sistema operacional da instância são só do cliente, e os controles ambientais dos data centers são só da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Fornecer a chave usada na criptografia do lado do cliente no Amazon S3", false],
+            ["Configurar o sistema operacional de uma instância do Amazon EC2", false],
+            ["Manter os controles ambientais dos data centers físicos da AWS", false],
+            ["Conscientizar e treinar as equipes sobre as práticas de segurança", true],
+        ],
+    },
+    {
+        statement:
+            "Quais medidas de segurança protegem o acesso a uma conta AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Conceder só as permissões necessárias limita o estrago de uma credencial comprometida, e o MFA exige um segundo fator além da senha. O CloudTrail registra a atividade, mas não impede acessos; compartilhar um usuário do IAM elimina a rastreabilidade individual; o CloudFront é uma CDN.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Ativar o AWS CloudTrail para registrar as chamadas de API", false],
+            ["Conceder acesso com privilégio mínimo aos usuários do IAM", true],
+            ["Criar um único usuário do IAM e compartilhá-lo entre vários desenvolvedores", false],
+            ["Ativar o Amazon CloudFront para distribuir o conteúdo", false],
+            ["Ativar a autenticação multifator (MFA) para usuários com privilégios", true],
+        ],
+    },
+    {
+        statement:
+            "Qual atividade é responsabilidade do cliente na Nuvem AWS, de acordo com o modelo de responsabilidade compartilhada?",
+        explanation:
+            "Fazer backup dos volumes do Amazon EBS, por exemplo com snapshots, é tarefa do cliente: a AWS mantém a infraestrutura, mas não cria cópias de segurança dos dados por conta própria. A conectividade com a internet, a correção de falhas na infraestrutura e a segurança física dos data centers ficam com a AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Garantir a conectividade de rede entre a AWS e a internet", false],
+            ["Aplicar patches e corrigir falhas na infraestrutura da Nuvem AWS", false],
+            ["Garantir a segurança física dos data centers da nuvem", false],
+            ["Garantir que os volumes do Amazon EBS tenham backup", true],
+        ],
+    },
+    {
+        statement:
+            "Como um cliente pode aumentar a segurança do login nas contas AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O MFA exige um segundo fator além da senha, e uma política de senhas fortes impõe tamanho mínimo, complexidade e troca periódica. O ACM gerencia certificados SSL/TLS, o Cognito autentica usuários de aplicativos, não o login na conta, e o Organizations administra várias contas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Configurar o AWS Certificate Manager (ACM)", false],
+            ["Ativar a autenticação multifator (MFA)", true],
+            ["Usar o Amazon Cognito para gerenciar o acesso", false],
+            ["Configurar uma política de senhas fortes", true],
+            ["Ativar o AWS Organizations para as contas", false],
+        ],
+    },
+    {
+        statement:
+            "Em qual destes serviços o cliente é responsável por manter a configuração do sistema operacional, a aplicação de patches de segurança e a configuração de rede?",
+        explanation:
+            "No Amazon EC2 o cliente controla o sistema operacional convidado, então cuida da configuração dele, dos patches e da rede das instâncias. No Amazon RDS e no Amazon ElastiCache a AWS gerencia o sistema operacional, e no AWS Fargate os servidores dos contêineres também ficam com a AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon RDS", false],
+            ["Amazon EC2", true],
+            ["Amazon ElastiCache", false],
+            ["AWS Fargate", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de nuvem precisa verificar se algum grupo de segurança de uma conta AWS permite acesso irrestrito a portas específicas. Qual é a maneira MAIS SIMPLES de fazer isso?",
+        explanation:
+            "O AWS Trusted Advisor já tem uma verificação que aponta grupos de segurança com portas específicas liberadas sem restrição, então basta executá-lo e ler o resultado. Revisar grupo por grupo é lento, o IAM não tem regras de entrada e uma regra personalizada do Config com Lambda exige muito mais esforço.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Revisar as regras de entrada de cada grupo de segurança no console do Amazon EC2",
+                false,
+            ],
+            ["Executar o AWS Trusted Advisor e analisar os resultados das verificações", true],
+            ["Abrir o console do IAM e verificar as regras de entrada com acesso aberto", false],
+            [
+                "Criar uma regra personalizada do AWS Config que invoque uma função do AWS Lambda",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais destes serviços têm recursos de mitigação de ataques distribuídos de negação de serviço (DDoS)? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS WAF bloqueia inundações na camada de aplicação com regras baseadas em taxa, e o Amazon CloudFront distribui o tráfego entre pontos de presença e já conta com o AWS Shield Standard. O Secrets Manager guarda segredos, o EC2 depende de outros serviços para essa proteção e o Inspector procura vulnerabilidades.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS WAF", true],
+            ["AWS Secrets Manager", false],
+            ["Amazon EC2", false],
+            ["Amazon CloudFront", true],
+            ["Amazon Inspector", false],
+        ],
+    },
+    {
+        statement: "O que os usuários podem acessar pelo AWS Artifact?",
+        explanation:
+            "O AWS Artifact dá acesso sob demanda a documentos de segurança e conformidade da AWS, como relatórios SOC e atestados PCI DSS. O histórico de configuração dos recursos vem do AWS Config, o treinamento vem do AWS Skill Builder e a avaliação de vulnerabilidades é feita pelo Amazon Inspector.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Relatórios e documentos de segurança e conformidade da AWS", true],
+            ["Um download dos detalhes de configuração de todos os recursos da AWS", false],
+            ["Materiais de treinamento sobre os serviços da AWS", false],
+            ["Uma avaliação de segurança das aplicações implantadas na Nuvem AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual destes recursos pode limitar o acesso a um bucket do Amazon S3 a usuários específicos?",
+        explanation:
+            "Políticas do IAM anexadas a usuários ou grupos definem quem pode acessar o bucket e quais ações cada um pode executar. Pares de chaves servem para login em instâncias EC2, o Inspector procura vulnerabilidades e grupos de segurança filtram tráfego de rede de instâncias, não o acesso a buckets.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Um par de chaves pública e privada", false],
+            ["Amazon Inspector", false],
+            ["Políticas do IAM", true],
+            ["Grupos de segurança", false],
+        ],
+    },
+    {
+        statement: "Qual destas tarefas é responsabilidade da AWS?",
+        explanation:
+            "Proteger o hipervisor que executa as instâncias do Amazon EC2 faz parte da infraestrutura de virtualização, dentro da segurança da nuvem mantida pela AWS. Criptografar dados do lado do cliente, configurar funções do IAM e definir políticas de senha são tarefas do cliente (segurança na nuvem).",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criptografar os dados do lado do cliente", false],
+            ["Configurar funções do IAM (IAM roles)", false],
+            ["Proteger o hipervisor do Amazon EC2", true],
+            ["Definir as políticas de senha dos usuários", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa aplicações em instâncias do Amazon EC2. Pelo modelo de responsabilidade compartilhada, quais áreas são de responsabilidade dela? (Selecione DUAS opções.)",
+        explanation:
+            "Em instâncias do Amazon EC2, o cliente aplica os patches do sistema operacional convidado e configura os grupos de segurança que filtram o tráfego. Firmware da infraestrutura de rede, patches do hipervisor e segurança física dos data centers são responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Atualização do firmware da infraestrutura de rede", false],
+            ["Aplicação de patches nos sistemas operacionais", true],
+            ["Aplicação de patches no hipervisor subjacente", false],
+            ["Segurança física dos data centers", false],
+            ["Configuração dos grupos de segurança", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa migrou para a AWS recentemente. Quais serviços da AWS ajudam a garantir que ela tenha as configurações de segurança adequadas? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Trusted Advisor verifica boas práticas de segurança, como portas abertas e MFA no usuário raiz, e o Amazon Inspector avalia instâncias e cargas de trabalho em busca de vulnerabilidades e exposição de rede. O SNS envia notificações, o CloudWatch monitora métricas e o Concierge ajuda com conta e faturamento.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Trusted Advisor", true],
+            ["Amazon Inspector", true],
+            ["Amazon SNS", false],
+            ["Amazon CloudWatch", false],
+            ["Equipe de Concierge do AWS Support", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso da AWS adiciona um nível extra de segurança além do mecanismo padrão de autenticação com nome de usuário e senha?",
+        explanation:
+            "A autenticação multifator (MFA) exige, além do nome de usuário e da senha, um código ou uma chave de um dispositivo físico ou virtual. Chaves criptografadas e o AWS KMS protegem dados, não o login, e a verificação por e-mail confirma o endereço, sem acrescentar um fator a cada acesso.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Chaves criptografadas", false],
+            ["Verificação por e-mail", false],
+            ["AWS Key Management Service (AWS KMS)", false],
+            ["Autenticação multifator (MFA)", true],
+        ],
+    },
+    {
+        statement:
+            "De acordo com a política da AWS para testes de penetração, qual afirmação sobre esses testes em instâncias do Amazon EC2 está correta?",
+        explanation:
+            "Pela política de testes de penetração da AWS, o cliente pode avaliar os próprios recursos em serviços permitidos, como o Amazon EC2, sem aprovação prévia, desde que não faça ataques DoS. Os testes não são proibidos, a AWS não os executa pelo cliente e a lista de permitidos não se limita a serviços gerenciados.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Testes de penetração não são permitidos em nenhum serviço da AWS", false],
+            ["A AWS executa testes de penetração automáticos na infraestrutura do cliente", false],
+            ["O cliente pode testar as próprias instâncias sem autorização prévia da AWS", true],
+            [
+                "Os clientes só podem fazer testes de penetração em serviços gerenciados pela AWS",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa guarda arquivos no Amazon S3 e roda aplicações no Amazon EC2. Quais tarefas de segurança cabem a ela nesse cenário? (Selecione DUAS opções.)",
+        explanation:
+            "O cliente protege os próprios dados, inclusive com criptografia (HTTPS/TLS) no tráfego com o S3, e aplica patches no sistema e nas aplicações das instâncias EC2. Eventos ambientais e acesso físico aos data centers e às Regiões, assim como a configuração do host físico do EC2, ficam com a AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Gerenciar eventos ambientais nos data centers da AWS", false],
+            ["Proteger a confidencialidade dos dados em trânsito no Amazon S3", true],
+            ["Controlar o acesso físico às Regiões da AWS", false],
+            ["Garantir que o host subjacente do Amazon EC2 esteja bem configurado", false],
+            ["Aplicar patches nas aplicações instaladas no Amazon EC2", true],
+        ],
+    },
+    {
+        statement:
+            "Quais atividades cabem somente à AWS, sem qualquer participação do cliente? (Selecione DUAS opções.)",
+        explanation:
+            "Construir e manter os hipervisores e fazer a manutenção do hardware físico cabem só à AWS, pois o cliente não tem acesso a essas camadas. Monitorar o desempenho da rede das próprias aplicações, instalar software nas instâncias EC2 e configurar Network ACLs são tarefas do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Monitorar o desempenho da rede das aplicações", false],
+            ["Instalar software nas instâncias EC2", false],
+            ["Criar e manter os hipervisores", true],
+            ["Configurar as Network ACLs da VPC", false],
+            ["Fazer a manutenção do hardware físico", true],
+        ],
+    },
+    {
+        statement:
+            "Quais são as credenciais de segurança padrão exigidas para que um usuário do IAM acesse o Console de Gerenciamento da AWS?",
+        explanation:
+            "Por padrão, um usuário do IAM entra no Console de Gerenciamento com nome de usuário e senha. O MFA é um fator adicional opcional, tokens de segurança temporários vêm de funções assumidas e chaves de acesso servem para chamadas programáticas pela AWS CLI, pelos SDKs ou pela API.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Autenticação multifator (MFA)", false],
+            ["Tokens de segurança temporários", false],
+            ["Nome de usuário e senha", true],
+            ["Chaves de acesso do IAM", false],
+        ],
+    },
+    {
+        statement: "Quais aspectos da segurança são gerenciados pela AWS? (Selecione DUAS opções.)",
+        explanation:
+            "A AWS aplica patches e mantém o hardware físico, além de proteger a infraestrutura global (data centers, energia e rede). A criptografia dos volumes do Amazon EBS, a configuração de segurança da VPC (grupos de segurança e Network ACLs) e as permissões de acesso do IAM ficam com o cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criptografia dos volumes do Amazon EBS", false],
+            ["Configuração da segurança da VPC", false],
+            ["Definição das permissões de acesso", false],
+            ["Atualização do firmware do hardware", true],
+            ["Proteção da infraestrutura física", true],
+        ],
+    },
+    {
+        statement:
+            "Quais ferramentas de gerenciamento de mudanças ajudam os clientes da AWS a auditar e monitorar todas as alterações de recursos no ambiente? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CloudTrail registra as chamadas de API que alteram os recursos (quem fez o quê e quando), e o AWS Config registra o histórico de configuração e avalia a conformidade. O Comprehend analisa texto com ML, o Transit Gateway conecta redes e o X-Ray rastreia requisições em aplicações distribuídas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS CloudTrail", true],
+            ["Amazon Comprehend", false],
+            ["AWS Transit Gateway", false],
+            ["AWS X-Ray", false],
+            ["AWS Config", true],
+        ],
+    },
+    {
+        statement: "Qual destes serviços ajuda as empresas a auditar a conformidade na AWS?",
+        explanation:
+            "O AWS CloudTrail mantém o histórico de chamadas de API e eventos da conta, uma trilha de auditoria usada para comprovar conformidade e investigar incidentes. O CloudFront distribui conteúdo, o Migration Hub acompanha migrações e o CloudWatch monitora métricas e logs de operação, sem essa trilha de auditoria.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon CloudFront", false],
+            ["AWS Migration Hub", false],
+            ["Amazon CloudWatch", false],
+            ["AWS CloudTrail", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa o Amazon RDS como banco de dados gerenciado. Quais tarefas continuam sob responsabilidade dela? (Selecione DUAS opções.)",
+        explanation:
+            "No Amazon RDS, o cliente modela o esquema do banco e ajusta as configurações dele, como grupos de parâmetros e usuários. A AWS instala o software do banco, aplica os patches e executa os backups automáticos, que o cliente apenas configura, como o período de retenção.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criar o esquema do banco de dados relacional", true],
+            ["Realizar os backups do banco de dados", false],
+            ["Gerenciar as configurações do banco de dados", true],
+            ["Aplicar patches no software do banco de dados", false],
+            ["Instalar o software do banco de dados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização mantém muitos sistemas e usa vários produtos da AWS. Qual serviço permite controlar como cada desenvolvedor interage com esses produtos?",
+        explanation:
+            "O AWS Identity and Access Management (IAM) define usuários, grupos, funções e políticas que controlam quais serviços e ações cada desenvolvedor pode usar. O Amazon RDS é um banco de dados relacional, as Network ACLs filtram tráfego nas sub-redes e o Amazon EMR processa big data.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Identity and Access Management (IAM)", true],
+            ["Amazon Relational Database Service (Amazon RDS)", false],
+            ["Network ACLs da Amazon VPC", false],
+            ["Amazon EMR", false],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada, alguns controles são herdados integralmente da AWS, sem nenhuma ação do cliente. Quais são eles? (Selecione DUAS opções.)",
+        explanation:
+            "Controles físicos e ambientais (acesso às instalações, energia, refrigeração e combate a incêndio) são herdados por completo da AWS. Gerenciamento de patches e conscientização e treinamento são controles compartilhados, e os controles de banco de dados dependem da configuração feita pelo cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Controles de gerenciamento de patches", false],
+            ["Controles de banco de dados", false],
+            ["Conscientização e treinamento", false],
+            ["Controles ambientais dos data centers", true],
+            ["Controles físicos das instalações", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos podem ajudar a proteger instâncias do Amazon EC2 contra um ataque de negação de serviço distribuído (DDoS)? (Selecione DUAS opções.)",
+        explanation:
+            "Grupos de segurança (firewall stateful no nível da instância) e Network ACLs (stateless, no nível da sub-rede) bloqueiam tráfego indesejado antes que ele chegue às instâncias. O CloudHSM guarda chaves criptográficas, o AWS Batch executa jobs em lote e o IAM controla permissões, não tráfego de rede.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS CloudHSM", false],
+            ["Grupos de segurança", true],
+            ["AWS Batch", false],
+            ["AWS Identity and Access Management (IAM)", false],
+            ["Network ACLs", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos são usados para controlar o tráfego de rede na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Network ACLs filtram o tráfego no nível da sub-rede (stateless) e grupos de segurança filtram no nível da instância (stateful). Pares de chaves autenticam o acesso SSH às instâncias, chaves de acesso autenticam chamadas de API e políticas do IAM definem permissões, sem filtrar tráfego de rede.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Network ACLs", true],
+            ["Pares de chaves", false],
+            ["Chaves de acesso do IAM", false],
+            ["Políticas do IAM", false],
+            ["Grupos de segurança", true],
+        ],
+    },
+    {
+        statement:
+            "A segurança dos dados é uma das prioridades da AWS. O que a AWS faz com os dispositivos de armazenamento que chegaram ao fim da vida útil?",
+        explanation:
+            "Quando um dispositivo de armazenamento chega ao fim da vida útil, a AWS o descomissiona com as técnicas da NIST 800-88, e a mídia não sai do controle da AWS antes disso. Vender, enviar para remanufatura ou apenas guardar dispositivos com dados de clientes criaria risco de exposição desses dados.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Vende os dispositivos antigos para outros provedores de hospedagem", false],
+            ["Descomissiona e destrói os dispositivos seguindo práticas padrão do setor", true],
+            ["Envia os dispositivos antigos para remanufatura pelo fabricante", false],
+            ["Armazena os dispositivos antigos em um local seguro por tempo indeterminado", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor precisa configurar um certificado SSL para que o site de comércio eletrônico de um cliente use o protocolo HTTPS. Quais serviços da AWS podem ser usados para implantar os certificados de servidor SSL necessários? (Selecione DUAS opções.)",
+        explanation:
+            "O ACM é a ferramenta recomendada para provisionar e implantar certificados SSL/TLS, e o IAM também armazena certificados de servidor, opção usada nas Regiões sem suporte ao ACM. O Route 53 cuida de DNS e domínios, o Directory Service oferece Active Directory gerenciado e o Config rastreia configurações de recursos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon Route 53", false],
+            ["AWS Certificate Manager (ACM)", true],
+            ["AWS Directory Service (Active Directory)", false],
+            ["AWS Identity and Access Management (IAM)", true],
+            ["AWS Config", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa planeja migrar uma aplicação do Amazon EC2 para o AWS Lambda, adotando uma arquitetura sem servidor. O que passará a ser responsabilidade da AWS após a migração? (Selecione DUAS opções.)",
+        explanation:
+            "No AWS Lambda, a AWS escala as funções automaticamente conforme a demanda e mantém o sistema operacional e a infraestrutura subjacentes. O código da aplicação, as permissões de quem pode invocar as funções e os dados processados continuam sendo responsabilidade do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Gerenciamento do código da aplicação", false],
+            ["Gerenciamento da capacidade", true],
+            ["Controle de acesso às funções", false],
+            ["Manutenção do sistema operacional", true],
+            ["Gerenciamento dos dados", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço ou recurso da AWS é usado para gerenciar as permissões dos usuários?",
+        explanation:
+            "O AWS IAM permite criar usuários, grupos e funções e anexar políticas que definem quem pode acessar quais serviços e recursos. Grupos de segurança filtram tráfego de rede, o Amazon ECS orquestra contêineres e o AWS Support oferece atendimento técnico, sem gerenciar permissões.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Grupos de segurança", false],
+            ["Amazon ECS", false],
+            ["AWS IAM", true],
+            ["AWS Support", false],
+        ],
+    },
+    {
+        statement: "Qual é a recomendação da AWS em relação às chaves de acesso?",
+        explanation:
+            "Fazer a rotação periódica das chaves de acesso limita o tempo de exposição caso alguma seja vazada. Senhas não substituem chaves no acesso programático, chaves não devem ser compartilhadas entre pessoas e, guardadas no código, podem vazar pelo repositório; para aplicações na AWS, prefira funções do IAM.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Excluir todas as chaves de acesso e usar apenas senhas", false],
+            ["Compartilhá-las somente com pessoas de confiança", false],
+            ["Fazer a rotação das chaves de acesso periodicamente", true],
+            ["Guardá-las diretamente no código da aplicação", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso do AWS IAM oferece uma camada adicional de segurança além da autenticação por nome de usuário e senha?",
+        explanation:
+            "A MFA exige, além do nome de usuário e da senha, um segundo fator, como o código de um aplicativo autenticador ou uma chave de segurança. Pares de chaves autenticam o acesso SSH a instâncias, chaves de acesso servem para chamadas de API e o SDK é uma biblioteca para programar com a AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Par de chaves do Amazon EC2", false],
+            ["Chaves de acesso programático", false],
+            ["Kit de desenvolvimento de software (SDK)", false],
+            ["Autenticação multifator (MFA)", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa descobriu que vários buckets do Amazon S3 foram excluídos, mas não sabe quem executou essas ações. Qual recurso da AWS pode ser usado para identificar quem excluiu os buckets?",
+        explanation:
+            "O AWS CloudTrail registra as chamadas de API da conta, como a exclusão de buckets, com quem as fez, o IP de origem e o horário. O SNS envia notificações, o SQS gerencia filas de mensagens e o CloudWatch Logs armazena logs de aplicações, recebendo eventos de API só se o CloudTrail os enviar para lá.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Logs do Amazon SNS", false],
+            ["Logs do Amazon SQS", false],
+            ["Amazon CloudWatch Logs", false],
+            ["Logs do AWS CloudTrail", true],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada da AWS, o que são os controles compartilhados?",
+        explanation:
+            "Pela definição da AWS, controles compartilhados valem para a camada de infraestrutura e para a do cliente, mas cada parte implementa o seu, como nos patches: a AWS corrige a infraestrutura e o cliente, o sistema operacional convidado. Os herdados vêm da AWS, os específicos são só do cliente e não há proteção conjunta da infraestrutura.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Controles de responsabilidade exclusiva do cliente, conforme a aplicação que ele implanta na AWS",
+                false,
+            ],
+            [
+                "Controles que o cliente herda integralmente da AWS, como os controles físicos e ambientais",
+                false,
+            ],
+            [
+                "Controles que se aplicam às camadas de infraestrutura e do cliente, em contextos separados",
+                true,
+            ],
+            [
+                "Controles em que o cliente e a AWS trabalham juntos para proteger a infraestrutura",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais itens são responsabilidade do cliente ao usar o Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "No Amazon EC2 o cliente cuida de tudo que roda na instância: proteger os dados e instalar, configurar e atualizar o software, inclusive o de terceiros. Patches da infraestrutura subjacente e manutenção do hardware são da AWS, e a operação de bancos de dados gerenciados, como o Amazon RDS, também fica com a AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Proteger os dados sensíveis armazenados", true],
+            ["Aplicar patches na infraestrutura subjacente", false],
+            ["Configurar e operar bancos de dados gerenciados", false],
+            ["Manter os componentes de hardware", false],
+            ["Instalar e configurar software de terceiros", true],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS ajudam a realizar análises de segurança e auditorias de conformidade regulatória? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Inspector avalia cargas de trabalho em busca de vulnerabilidades e o AWS Config registra as configurações dos recursos e as avalia contra regras de conformidade. O CloudFormation provisiona infraestrutura como código, o AWS Batch executa jobs em lote e o Amazon ECS orquestra contêineres.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon Inspector", true],
+            ["AWS CloudFormation", false],
+            ["AWS Batch", false],
+            ["Amazon ECS", false],
+            ["AWS Config", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos podem ser usados para proteger dados em repouso no Amazon S3? (Selecione DUAS opções.)",
+        explanation:
+            "O versionamento do S3 guarda versões anteriores dos objetos e permite recuperá-los após exclusão ou sobrescrita acidental, e as permissões (políticas do IAM e de bucket) controlam quem acessa os dados. Desduplicação economiza espaço, descriptografia reverte a criptografia e conversão muda formatos, sem proteger os dados.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Versionamento", true],
+            ["Desduplicação", false],
+            ["Permissões", true],
+            ["Descriptografia", false],
+            ["Conversão", false],
+        ],
+    },
+    {
+        statement:
+            "Ao executar uma carga de trabalho na AWS, quais atividades NÃO são responsabilidade do cliente? (Selecione DUAS opções.)",
+        explanation:
+            "Operar os data centers e proteger a infraestrutura física e de virtualização é segurança da nuvem, responsabilidade da AWS. Testes de penetração nos próprios recursos e a reserva de capacidade são decisões do cliente, e a conformidade é compartilhada: a AWS certifica a infraestrutura e o cliente, suas cargas de trabalho.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Executar testes de penetração", false],
+            ["Reservar capacidade", false],
+            ["Operações do data center", true],
+            ["Auditoria e conformidade regulatória", false],
+            ["Segurança da infraestrutura", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos a AWS oferece para ajudar a proteger os seus dados na nuvem? (Selecione DUAS opções.)",
+        explanation:
+            "O controle de acesso (políticas do IAM, políticas de bucket, grupos de segurança) limita quem chega aos dados, e a criptografia em repouso e em trânsito os protege mesmo se forem interceptados. Dispositivos de MFA protegem o login, não os dados em si; armazenamento ilimitado e balanceamento de carga tratam de capacidade e disponibilidade.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Controle de acesso", true],
+            ["Dispositivos físicos de MFA", false],
+            ["Criptografia de dados", true],
+            ["Armazenamento ilimitado", false],
+            ["Balanceamento de carga", false],
+        ],
+    },
+    {
+        statement:
+            "Quais meios os clientes podem usar para interagir com o AWS Identity and Access Management (IAM)? (Selecione DUAS opções.)",
+        explanation:
+            "Além do Console de Gerenciamento da AWS, o IAM pode ser usado pela AWS CLI, com comandos no terminal, e pelos SDKs da AWS, dentro do código das aplicações. Grupos de segurança e Network ACLs filtram tráfego de rede e o CodeCommit hospeda repositórios Git; nenhum deles é interface para gerenciar o IAM.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Command Line Interface (AWS CLI)", true],
+            ["Grupos de segurança", false],
+            ["SDKs da AWS", true],
+            ["Network Access Control Lists (Network ACLs)", false],
+            ["AWS CodeCommit", false],
+        ],
+    },
+    {
+        statement:
+            "Quais itens são tipos de identidade do AWS Identity and Access Management (IAM)? (Selecione DUAS opções.)",
+        explanation:
+            "Usuários e funções do IAM são identidades: o usuário representa uma pessoa ou aplicação com credenciais de longo prazo e a função é assumida para obter credenciais temporárias. Políticas são documentos de permissão anexados às identidades, o Resource Groups organiza recursos e o Organizations gerencia várias contas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Resource Groups", false],
+            ["Políticas do IAM", false],
+            ["Funções do IAM", true],
+            ["Usuários do IAM", true],
+            ["AWS Organizations", false],
+        ],
+    },
+    {
+        statement:
+            "Como a AWS informa os clientes sobre eventos de segurança e privacidade relacionados aos serviços da AWS?",
+        explanation:
+            "A AWS publica boletins de segurança (Security Bulletins) com as vulnerabilidades e os eventos de segurança e privacidade que afetam seus serviços, junto com as ações recomendadas. O ACM gerencia certificados SSL/TLS, o console é a interface de gerenciamento e os recursos de conformidade são guias e relatórios de auditoria.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Pelo AWS Certificate Manager (ACM)", false],
+            ["Pelos boletins de segurança da AWS", true],
+            ["Pelo Console de Gerenciamento da AWS", false],
+            ["Pelos recursos de conformidade da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual entidade do IAM é a mais indicada para conceder acesso temporário aos recursos da AWS?",
+        explanation:
+            "Funções do IAM fornecem credenciais temporárias que expiram automaticamente, sem que seja preciso compartilhar credenciais de longo prazo. Usuários do IAM têm credenciais permanentes, pares de chaves autenticam o acesso SSH a instâncias EC2 e grupos apenas reúnem usuários com as mesmas políticas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Usuários do IAM", false],
+            ["Par de chaves", false],
+            ["Funções do IAM", true],
+            ["Grupos do IAM", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer proteger melhor sua conta da AWS contra acessos não autorizados. Qual medida ela pode adotar para atingir esse objetivo?",
+        explanation:
+            "Exigir MFA de todos os usuários do IAM acrescenta um segundo fator ao login e dificulta o acesso mesmo com a senha vazada. Bloquear toda chamada de API inviabiliza automações, usuários compartilhados eliminam a rastreabilidade individual e a AWS não oferece duas senhas de login; o reforço vem da MFA.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Bloquear todas as chamadas de API feitas por SDKs ou pela AWS CLI", false],
+            ["Criar um usuário do IAM por departamento e compartilhá-lo com toda a equipe", false],
+            ["Exigir autenticação multifator (MFA) para todos os usuários do IAM", true],
+            ["Configurar duas senhas diferentes para o login no console", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são exemplos da responsabilidade do cliente pela segurança na nuvem? (Selecione DUAS opções.)",
+        explanation:
+            "Segurança na nuvem é o que o cliente configura e controla, como o esquema de dados das próprias aplicações e a criptografia do sistema de arquivos das instâncias. Substituir hardware físico, manter o hipervisor e aplicar patches na infraestrutura subjacente são segurança da nuvem, responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criar o esquema de dados de uma aplicação", true],
+            ["Substituir o hardware físico", false],
+            ["Criar um novo hipervisor", false],
+            ["Gerenciar patches da infraestrutura subjacente", false],
+            ["Criptografar o sistema de arquivos", true],
+        ],
+    },
+    {
+        statement:
+            "Você acabou de contratar um administrador de sistemas experiente e, como de costume, criou um novo usuário do IAM para ele. No primeiro dia, você pede que ele crie snapshots de todos os volumes do Amazon EBS e um novo bucket do Amazon S3, mas ele informa que não consegue fazer nenhuma das duas coisas. O que pode estar impedindo essa tarefa simples?",
+        explanation:
+            "Um usuário do IAM recém-criado não tem nenhuma permissão: toda ação é negada implicitamente até que uma política conceda acesso. EBS e S3 podem ser usados por qualquer identidade com permissão, usuários do IAM já nascem ativos sem passar pelo AWS Support e o S3 escala sem limite prático de espaço.",
+        topic: "Segurança e identidade",
+        options: [
+            ["O Amazon EBS e o Amazon S3 só podem ser acessados pelo usuário raiz da conta", false],
+            [
+                "O administrador precisa pedir ao AWS Support que ative seu novo usuário do IAM",
+                false,
+            ],
+            ["Não há espaço suficiente no Amazon S3 para armazenar os snapshots", false],
+            ["Todo usuário novo do IAM começa com uma negação implícita a todas as ações", true],
+        ],
+    },
+    {
+        statement:
+            "Um auditor externo solicitou um registro de todos os acessos aos recursos da AWS na conta da empresa. Qual serviço fornecerá ao auditor as informações solicitadas?",
+        explanation:
+            "O AWS CloudTrail registra as chamadas de API feitas na conta, com quem acessou cada recurso, de qual IP e quando, que é o que um auditor precisa. O CloudFront distribui conteúdo pela rede de borda, o CloudFormation provisiona recursos por modelos e o CloudWatch coleta métricas e logs operacionais.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS CloudTrail", true],
+            ["Amazon CloudFront", false],
+            ["AWS CloudFormation", false],
+            ["Amazon CloudWatch", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS permite conectar os recursos da AWS a um Microsoft Active Directory local, para que os usuários entrem com as credenciais corporativas que já têm?",
+        explanation:
+            "O AWS Directory Service, com o AD Connector ou o AWS Managed Microsoft AD, integra os recursos da AWS a um Active Directory local e permite usar as credenciais corporativas. O IAM Identity Center centraliza o login único e usa o Directory Service para chegar ao AD, o Cognito atende usuários de aplicativos e o Secrets Manager guarda segredos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS IAM Identity Center", false],
+            ["AWS Directory Service", true],
+            ["Amazon Cognito", false],
+            ["AWS Secrets Manager", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa, que ainda não usa federação de identidades, quer conceder a um novo funcionário acesso de longo prazo para gerenciar bancos de dados do Amazon DynamoDB. Qual é a prática recomendada ao conceder essas permissões?",
+        explanation:
+            "Sem federação, um funcionário com acesso de longo prazo precisa de um usuário do IAM, e a política restrita ao DynamoDB segue o princípio do privilégio mínimo. Funções do IAM são assumidas para obter credenciais temporárias, e permissões de administrador liberam todos os serviços, muito além do necessário.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Criar uma função do IAM e anexar uma política com permissões de acesso ao Amazon DynamoDB",
+                false,
+            ],
+            [
+                "Criar uma função do IAM e anexar uma política com permissões de administrador",
+                false,
+            ],
+            [
+                "Criar um usuário do IAM e anexar uma política com permissões de acesso ao Amazon DynamoDB",
+                true,
+            ],
+            [
+                "Criar um usuário do IAM e anexar uma política com permissões de administrador",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "O que pode ser usado para habilitar um dispositivo de MFA virtual? (Selecione DUAS opções.)",
+        explanation:
+            "Um dispositivo de MFA virtual pode ser atribuído pelo console do IAM ou pela AWS CLI, com comandos como create-virtual-mfa-device e enable-mfa-device. O Amazon Connect é uma central de atendimento, o SNS envia notificações e a VPC isola a rede, sem relação com a configuração de MFA.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon Connect", false],
+            ["AWS Command Line Interface (AWS CLI)", true],
+            ["AWS Identity and Access Management (IAM)", true],
+            ["Amazon SNS", false],
+            ["Amazon Virtual Private Cloud (Amazon VPC)", false],
+        ],
+    },
+    {
+        statement:
+            "O que você deve fazer se encontrar, no Console de Gerenciamento da AWS, recursos que não se lembra de ter criado? (Selecione DUAS opções.)",
+        explanation:
+            "Recursos desconhecidos indicam possível comprometimento: investigue, remova os usuários do IAM suspeitos e troque as senhas do usuário raiz e dos usuários do IAM para cortar o acesso do invasor. Parar tudo derruba cargas legítimas, a AWS nunca pede sua senha e excluir todos os usuários tira o acesso da equipe.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Interromper todos os serviços em execução e abrir uma investigação", false],
+            [
+                "Informar a senha do usuário raiz ao AWS Support para que ele ajude a proteger a conta",
+                false,
+            ],
+            [
+                "Consultar os logs do AWS CloudTrail e excluir todos os usuários do IAM com acesso aos recursos",
+                false,
+            ],
+            [
+                "Abrir uma investigação e excluir os usuários do IAM que possam ter sido comprometidos",
+                true,
+            ],
+            ["Trocar a senha do usuário raiz e as senhas de todos os usuários do IAM", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de DevOps precisa de acesso administrativo total a todos os recursos de uma conta da AWS. Quem pode conceder essas permissões?",
+        explanation:
+            "Quem controla a conta, pelo usuário raiz ou por uma identidade com permissões administrativas, é quem concede acesso pelo IAM. O TAM atende clientes do plano Enterprise Support, a equipe de segurança da AWS cuida da própria infraestrutura e os engenheiros de suporte ajudam em casos técnicos, sem mexer nas permissões da conta.",
+        topic: "Segurança e identidade",
+        options: [
+            ["O proprietário da conta da AWS", true],
+            ["O Technical Account Manager (TAM) da AWS", false],
+            ["A equipe de segurança da AWS", false],
+            ["Os engenheiros de suporte em nuvem da AWS", false],
+        ],
+    },
+    {
+        statement: "Qual estratégia ajuda a proteger o usuário raiz da sua conta da AWS?",
+        explanation:
+            "O usuário raiz tem acesso irrestrito, então chaves de acesso dele são um alvo valioso e devem ser excluídas se não forem usadas. A MFA no raiz é recomendada, mas ele deve ficar restrito às tarefas que exigem o raiz, não ao dia a dia; limitar o acesso a um celular não é controle de segurança e credenciais nunca devem ser compartilhadas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Excluir as chaves de acesso do usuário raiz se elas não forem necessárias", true],
+            ["Ativar a MFA no usuário raiz e usá-lo em todo o trabalho do dia a dia", false],
+            ["Acessar o usuário raiz somente pelo seu celular pessoal", false],
+            [
+                "Compartilhar a senha ou as chaves de acesso da conta só com pessoas de confiança",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Você acabou de configurar seu ambiente na AWS e criou seis usuários do IAM para a equipe de DevOps. Qual é a recomendação da AWS ao conceder permissões a esses usuários?",
+        explanation:
+            "O princípio do privilégio mínimo concede a cada usuário só as permissões de que ele precisa para trabalhar, reduzindo o estrago de erros ou de credenciais vazadas. Políticas separadas por usuário complicam a gestão (grupos são o caminho), negar tudo impede o trabalho da equipe e senhas diferentes não limitam o que cada um pode fazer.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Anexar uma política do IAM separada a cada usuário individual", false],
+            ["Aplicar o princípio do privilégio mínimo a cada usuário", true],
+            ["Não conceder nenhuma permissão à equipe de DevOps, por segurança", false],
+            ["Criar seis senhas diferentes do IAM", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços fazem verificações automatizadas que ajudam a auditar a conformidade e os riscos de segurança dos recursos da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Config avalia continuamente as configurações dos recursos contra regras de conformidade e o Trusted Advisor verifica a conta em busca de riscos, como portas liberadas em grupos de segurança e usuário raiz sem MFA. O Secrets Manager guarda e rotaciona segredos, o Amazon MQ é um broker de mensagens e o Cognito autentica usuários de aplicativos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Config", true],
+            ["AWS Secrets Manager", false],
+            ["Amazon MQ", false],
+            ["AWS Trusted Advisor", true],
+            ["Amazon Cognito", false],
+        ],
+    },
+    {
+        statement: "O que melhor descreve um teste de penetração?",
+        explanation:
+            "Um teste de penetração simula ataques contra os próprios sistemas para encontrar vulnerabilidades exploráveis antes de um invasor real. Medir o tempo de resposta de vários locais é teste de desempenho, identificar instâncias com problema é verificação de integridade e procurar bugs é teste funcional ou de qualidade.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Testar o tempo de resposta da aplicação a partir de diferentes regiões do mundo",
+                false,
+            ],
+            ["Testar a rede em busca de vulnerabilidades que um invasor poderia explorar", true],
+            [
+                "Testar as instâncias para identificar as que não estão íntegras ou disponíveis",
+                false,
+            ],
+            ["Testar o software em busca de bugs e erros de funcionamento no código", false],
+        ],
+    },
+    {
+        statement:
+            "Quais medidas podem ajudar a proteger dados sensíveis armazenados no Amazon S3? (Selecione DUAS opções.)",
+        explanation:
+            "A criptografia do lado do servidor (por exemplo, com chaves do AWS KMS) e a criptografia no cliente antes do envio protegem os dados sensíveis. O S3 já aplica SSE-S3 por padrão, mas escolher as chaves e controlar o acesso segue com o cliente; excluir as chaves torna os dados ilegíveis e apagar todos os usuários só bloqueia o acesso legítimo.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Excluir as chaves de criptografia depois que os dados forem criptografados", false],
+            ["Não se preocupar com criptografia, pois a AWS cuida de tudo", false],
+            ["Configurar a criptografia do lado do servidor com chaves do AWS KMS", true],
+            ["Criptografar os dados no cliente antes de enviá-los ao Amazon S3", true],
+            ["Excluir todos os usuários do IAM que têm acesso ao Amazon S3", false],
+        ],
+    },
+    {
+        statement: "O que você pode usar para atribuir permissões diretamente a um usuário do IAM?",
+        explanation:
+            "Uma política do IAM é um documento JSON que define ações permitidas ou negadas e pode ser anexada diretamente a um usuário. Identidade é o termo que abrange usuários, grupos e funções, o grupo repassa suas políticas a todos os membros e a função é assumida temporariamente, não anexada a um usuário.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Identidade do IAM", false],
+            ["Grupo do IAM", false],
+            ["Função do IAM", false],
+            ["Política do IAM", true],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços você usaria para gerenciar suas chaves de criptografia na Nuvem AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS KMS cria e gerencia chaves de criptografia integradas à maioria dos serviços da AWS, e o AWS CloudHSM oferece módulos de hardware dedicados para quem precisa de controle exclusivo das chaves. O ACM gerencia certificados SSL/TLS, o CodeDeploy automatiza implantações e o CodeCommit hospeda repositórios Git.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Key Management Service", true],
+            ["AWS Certificate Manager (ACM)", false],
+            ["AWS CodeDeploy", false],
+            ["AWS CodeCommit", false],
+            ["AWS CloudHSM", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa mantém sua infraestrutura em um data center local, onde uma equipe de operações cria usuários e define as permissões de acesso a cada recurso. Se a empresa migrar para a Nuvem AWS, qual serviço permite definir essas permissões de acesso aos recursos da AWS?",
+        explanation:
+            "O IAM centraliza a autenticação e a autorização na AWS, com usuários, grupos, funções e políticas, o mesmo papel da equipe de identidades no data center. O Directory Service oferece Active Directory gerenciado e pode complementar o IAM, o Outposts leva infraestrutura da AWS ao local do cliente e o Redshift é um data warehouse.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Identity and Access Management (IAM)", true],
+            ["AWS Outposts", false],
+            ["AWS Directory Service (Active Directory)", false],
+            ["Amazon Redshift", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso um cliente da AWS pode consultar para conhecer os usos proibidos dos serviços oferecidos pela AWS?",
+        explanation:
+            "A Política de Uso Aceitável da AWS lista as atividades proibidas nos serviços, como enviar spam, hospedar conteúdo ilegal ou lançar ataques contra outros sistemas. As SCPs limitam permissões de contas no AWS Organizations, o Artifact disponibiliza relatórios de conformidade e o Budgets acompanha gastos com alertas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Políticas de controle de serviço (SCPs)", false],
+            ["AWS Artifact", false],
+            ["AWS Budgets", false],
+            ["Política de Uso Aceitável da AWS", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos de segurança estão disponíveis gratuitamente para qualquer usuário? (Selecione DUAS opções.)",
+        explanation:
+            "Os boletins de segurança e o AWS Security Blog são públicos e gratuitos para qualquer pessoa. O Technical Account Manager vem com o plano Enterprise Support, a AWS Support API exige um plano de suporte pago e os treinamentos em sala de aula da AWS são cursos pagos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Boletins de segurança da AWS", true],
+            ["Technical Account Manager (TAM) da AWS", false],
+            ["AWS Support API", false],
+            ["AWS Security Blog", true],
+            ["Treinamentos em sala de aula da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada da AWS, quem é responsável por escalar uma tabela do Amazon DynamoDB no modo de capacidade sob demanda?",
+        explanation:
+            "O DynamoDB é um banco NoSQL totalmente gerenciado e sem servidor: a AWS cuida da infraestrutura e escala as tabelas automaticamente, como no modo de capacidade sob demanda. As equipes de segurança, desenvolvimento e DevOps definem configurações e acessos, mas não administram a infraestrutura que escala o serviço.",
+        topic: "Segurança e identidade",
+        options: [
+            ["A sua equipe de segurança", false],
+            ["A sua equipe de desenvolvimento", false],
+            ["A Amazon Web Services (AWS)", true],
+            ["A sua equipe interna de DevOps", false],
+        ],
+    },
+    {
+        statement:
+            "Segundo o modelo de responsabilidade compartilhada da AWS, quais controles o cliente herda integralmente da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Controles herdados são os que o cliente recebe prontos da AWS: os físicos, como a segurança dos data centers, e os ambientais, como energia, refrigeração e proteção contra incêndio. Conscientização e treinamento e gestão de configuração são controles compartilhados, e a proteção das comunicações é específica do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Conscientização e treinamento", false],
+            ["Controles de comunicação", false],
+            ["Controles de segurança do data center", true],
+            ["Controles ambientais das instalações", true],
+            ["Gerenciamento da configuração de recursos", false],
+        ],
+    },
+    {
+        statement:
+            "Quais itens fazem parte dos sete princípios de design do pilar de segurança do AWS Well-Architected Framework? (Selecione DUAS opções.)",
+        explanation:
+            "Dois dos sete princípios do pilar de segurança são ter uma base forte de identidade, sem depender de credenciais de longo prazo, e manter a rastreabilidade com monitoramento e auditoria em tempo real. O pilar pede automação, não monitoramento manual; escalar horizontalmente é princípio de confiabilidade e dados sensíveis podem ficar na nuvem com proteção.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Usar técnicas de monitoramento manual para proteger todos os recursos da AWS", false],
+            ["Implementar uma base sólida de identidade, sem credenciais estáticas", true],
+            ["Escalar horizontalmente os recursos para se proteger contra falhas", false],
+            ["Manter a rastreabilidade, monitorando e auditando ações em tempo real", true],
+            ["Nunca armazenar dados sensíveis na nuvem, apenas localmente", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é o principal benefício de associar grupos de segurança a uma instância do Amazon RDS?",
+        explanation:
+            "Grupos de segurança funcionam como firewall virtual e definem quais intervalos de IP ou outros grupos de segurança podem se conectar à instância do RDS. Usuários e chaves são geridos pelo IAM e pelo AWS KMS, certificados SSL/TLS não são implantados por grupos de segurança e distribuir tráfego é função do Elastic Load Balancing.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Gerencia o acesso dos usuários e as chaves de criptografia do banco", false],
+            ["Controla quais intervalos de IP podem se conectar ao banco de dados", true],
+            ["Implanta certificados SSL/TLS para uso com a instância de banco de dados", false],
+            ["Distribui o tráfego de entrada entre várias instâncias de destino", false],
+        ],
+    },
+    {
+        statement:
+            "Você foi encarregado de auditar a segurança da sua VPC e precisa começar analisando qual tráfego de entrada e de saída é permitido nas instâncias do Amazon EC2. Qual combinação de componentes da VPC você precisa verificar?",
+        explanation:
+            "Grupos de segurança controlam o tráfego no nível da instância (stateful) e Network ACLs no nível da sub-rede (stateless); juntos, mostram o que pode entrar e sair das instâncias. Tabelas de rotas só direcionam o tráfego, sub-redes são segmentos de rede e gateways de internet dão acesso à internet, sem regras de permissão.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Network ACLs e tabelas de rotas", false],
+            ["Network ACLs e sub-redes", false],
+            ["Grupos de segurança e gateways de internet", false],
+            ["Grupos de segurança e Network ACLs", true],
+        ],
+    },
+    {
+        statement: "Qual afirmação é verdadeira em relação à segurança na AWS?",
+        explanation:
+            "Pelo modelo de responsabilidade compartilhada, todo software que o cliente instala no EC2, inclusive bancos de dados, é dele para configurar e corrigir. O sistema operacional convidado também é do cliente, a criptografia do lado do servidor depende das escolhas do cliente (como as chaves) e a segurança das aplicações cabe ao cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "A AWS gerencia tudo o que diz respeito ao sistema operacional das instâncias EC2",
+                false,
+            ],
+            ["O cliente deve aplicar patches no software de banco de dados que roda no EC2", true],
+            ["A criptografia do lado do servidor é responsabilidade exclusiva da AWS", false],
+            ["A AWS é responsável pela segurança das aplicações que o cliente implanta", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são as principais diferenças entre um usuário do IAM e uma função do IAM? (Selecione DUAS opções.)",
+        explanation:
+            "Um usuário do IAM representa uma pessoa ou aplicação específica e tem credenciais de longo prazo, como senha e chaves de acesso. A função não pertence a ninguém: é assumida por quem precisa dela e gera credenciais temporárias. As opções invertidas trocam esses papéis, e o IAM não cobra por usuários nem por funções.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "O usuário do IAM é associado a uma única pessoa, enquanto a função pode ser assumida por quem precisar dela",
+                true,
+            ],
+            [
+                "O usuário do IAM tem credenciais permanentes, enquanto a função fornece credenciais temporárias",
+                true,
+            ],
+            [
+                "O usuário do IAM tem custo menor, enquanto a função é cobrada a cada sessão assumida",
+                false,
+            ],
+            [
+                "A função é associada a uma única pessoa, enquanto o usuário do IAM pode ser assumido por quem precisar dele",
+                false,
+            ],
+            [
+                "O usuário do IAM tem credenciais temporárias, enquanto a função fornece credenciais permanentes",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir usam um ID de chave de acesso e uma chave de acesso secreta para obter acesso programático de longo prazo aos recursos da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Usuários do IAM e o usuário raiz podem ter chaves de acesso de longo prazo, embora a AWS recomende não criá-las para o raiz. Grupos do IAM não se autenticam nem têm credenciais, funções do IAM fornecem credenciais temporárias e usuários do IAM Identity Center recebem credenciais de curto prazo pelo portal de acesso.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Grupo do IAM", false],
+            ["Usuário do IAM", true],
+            ["Função do IAM (IAM role)", false],
+            ["Usuário raiz da conta da AWS", true],
+            ["Usuário do AWS IAM Identity Center", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS se integra ao AWS Shield e ao AWS WAF para proteger aplicações contra ataques DDoS nas camadas de rede e de aplicação?",
+        explanation:
+            "O Amazon CloudFront entrega conteúdo a partir das edge locations e se integra ao AWS Shield, que mitiga DDoS nas camadas de rede e transporte, e ao AWS WAF, que filtra requisições na camada de aplicação. O Amazon EFS é armazenamento de arquivos, o Secrets Manager guarda segredos e o Systems Manager gerencia a operação de recursos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon EFS", false],
+            ["AWS Secrets Manager", false],
+            ["AWS Systems Manager", false],
+            ["Amazon CloudFront", true],
+        ],
+    },
+    {
+        statement:
+            "O administrador da conta AWS de uma empresa foi demitido. Com as permissões que tinha, ele criou vários usuários do IAM e chaves de acesso, e não se sabe se ele também tem acesso ao usuário raiz. O que deve ser feito imediatamente para proteger a infraestrutura na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Rotacionar as chaves de acesso invalida as que o ex-administrador possa ter guardado, e trocar o e-mail e a senha do usuário raiz, com MFA ativado, impede o acesso total à conta. Guardar as políticas não revoga nada, excluir todos os usuários paralisa a equipe e revisar chamadas de API é investigação posterior, feita com o AWS CloudTrail.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Baixar todas as políticas anexadas e guardá-las em local seguro", false],
+            ["Excluir todos os usuários do IAM e recriá-los em seguida", false],
+            [
+                "Usar o Amazon CloudWatch para verificar as chamadas de API feitas desde a demissão",
+                false,
+            ],
+            ["Rotacionar todas as chaves de acesso existentes na conta", true],
+            ["Alterar o e-mail e a senha do usuário raiz e ativar o MFA", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de serviços financeiros vai migrar para a AWS uma aplicação que lida com dados sensíveis, como números de cartão de crédito, e que precisa rodar em um ambiente em conformidade com o PCI DSS. Quais são responsabilidades da empresa ao montar esse ambiente na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O cliente precisa configurar corretamente os serviços que usa para atender ao PCI DSS e controlar o acesso aos dados de cartão, com uma política de segurança da informação para o seu pessoal. Nem todo serviço da AWS está no escopo do PCI DSS, e a infraestrutura subjacente e a segurança física dos data centers ficam com a AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Iniciar a migração imediatamente, pois todos os serviços da AWS já atendem ao PCI DSS",
+                false,
+            ],
+            [
+                "Garantir que os serviços da AWS usados estejam configurados para atender ao PCI DSS",
+                true,
+            ],
+            [
+                "Restringir o acesso aos dados de cartão e manter uma política de segurança da informação",
+                true,
+            ],
+            [
+                "Configurar a infraestrutura subjacente dos serviços da AWS para atender ao PCI DSS",
+                false,
+            ],
+            [
+                "Garantir que os requisitos de segurança física do PCI DSS sejam atendidos nos data centers",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um cliente quer realizar testes de invasão (pentest) nos seus próprios recursos na AWS. Qual procedimento ele deve seguir?",
+        explanation:
+            "Para os serviços permitidos, a AWS não exige aprovação prévia nem aviso para testes de invasão, então vale o processo interno de autorização do cliente (simulações de DDoS e alguns outros eventos ainda exigem pedido). Avisar ou pedir aprovação ao AWS Support deixou de ser necessário, e o Amazon Inspector avalia vulnerabilidades, mas não substitui um pentest.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Executar o teste com o Amazon Inspector e depois notificar o AWS Support", false],
+            ["Realizar o teste nos serviços permitidos, sem pedir aprovação prévia à AWS", true],
+            [
+                "Notificar o AWS Support e realizar o teste logo em seguida, sem aguardar resposta",
+                false,
+            ],
+            ["Solicitar e aguardar a aprovação do AWS Support antes de realizar o teste", false],
+        ],
+    },
+    {
+        statement:
+            "Segundo o modelo de responsabilidade compartilhada da AWS, o que é responsabilidade exclusiva da AWS?",
+        explanation:
+            "As edge locations fazem parte da infraestrutura global que a AWS opera e protege sozinha. A segurança da camada de aplicação e os dados do lado do cliente cabem ao cliente, e o gerenciamento de patches é compartilhado: a AWS corrige a infraestrutura e o cliente corrige o sistema operacional convidado e as aplicações.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Segurança da camada de aplicação", false],
+            ["Gerenciamento das edge locations", true],
+            ["Gerenciamento de patches", false],
+            ["Dados do lado do cliente", false],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada, qual destes é um controle compartilhado entre o cliente e a AWS?",
+        explanation:
+            "No gerenciamento de patches, a AWS corrige a infraestrutura e o cliente corrige o sistema operacional convidado e as aplicações. Controles físicos e a auditoria dos data centers são herdados da AWS, e a segurança de zonas (rotear ou separar dados em ambientes de segurança específicos) é controle exclusivo do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Controles físicos", false],
+            ["Gerenciamento de patches", true],
+            ["Segurança de zonas", false],
+            ["Auditoria de data centers", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços ou recursos da AWS podem reforçar a segurança de uma aplicação web bloqueando requisições vindas de uma rede específica? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS WAF bloqueia requisições web por endereço IP ou intervalo de rede, e as Network ACLs negam o tráfego de intervalos de IP no nível da sub-rede. O Trusted Advisor e o AWS Config apontam configurações inseguras, mas não bloqueiam tráfego, e o AWS Organizations governa várias contas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS WAF", true],
+            ["AWS Trusted Advisor", false],
+            ["AWS Config", false],
+            ["AWS Organizations", false],
+            ["Network ACLs", true],
+        ],
+    },
+    {
+        statement:
+            "Segundo o modelo de responsabilidade compartilhada da AWS, pelo que o cliente é responsável?",
+        explanation:
+            "Proteger os dados, o que inclui decidir e configurar a criptografia e gerenciar as chaves, é responsabilidade do cliente; a AWS fornece as ferramentas, como o AWS KMS. Controles de acesso físico, descarte seguro de mídias de armazenamento e gestão de riscos ambientais dos data centers são responsabilidades da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Controles de acesso físico", false],
+            ["Gerenciamento da criptografia dos dados", true],
+            ["Descarte seguro de mídias de armazenamento", false],
+            ["Gestão de riscos ambientais", false],
+        ],
+    },
+    {
+        statement:
+            "Qual componente do modelo de responsabilidade compartilhada é gerenciado inteiramente pela AWS?",
+        explanation:
+            "A AWS audita sozinha os ativos físicos dos data centers, como inventário de hardware e registros de acesso, pois o cliente não tem acesso às instalações. Aplicar patches no sistema operacional das instâncias, criptografar os dados e exigir MFA são tarefas do cliente, que usa ferramentas fornecidas pela AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Aplicação de patches no sistema operacional das instâncias", false],
+            ["Criptografia dos dados", false],
+            ["Exigência de autenticação multifator (MFA)", false],
+            ["Auditoria dos ativos físicos dos data centers", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço um cliente pode usar para habilitar o login único (SSO) no Console de Gerenciamento da AWS?",
+        explanation:
+            "O AWS Directory Service integra o Microsoft Active Directory à AWS e permite que os usuários do diretório entrem no console com as credenciais corporativas, sem um usuário do IAM para cada um (hoje o AWS IAM Identity Center é o caminho recomendado para SSO). O Amazon Connect é central de atendimento, o SES envia e-mails e o Rekognition analisa imagens.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon Connect", false],
+            ["AWS Directory Service", true],
+            ["Amazon Simple Email Service (Amazon SES)", false],
+            ["Amazon Rekognition", false],
+        ],
+    },
+    {
+        statement:
+            "Quais benefícios o programa de conformidade da AWS oferece aos clientes? (Selecione DUAS opções.)",
+        explanation:
+            "Com o programa de conformidade, o cliente herda os controles já auditados da infraestrutura da AWS, o que reduz o escopo das próprias auditorias, e tem a garantia de que a AWS mantém a segurança física e a proteção de dados do seu lado. A conformidade das cargas continua sendo do cliente, e a AWS não segue outros provedores nem promete adotar todo framework novo.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Permite herdar os controles certificados da AWS e reduz o escopo das auditorias do cliente",
+                true,
+            ],
+            [
+                "Torna a AWS responsável por manter a documentação de conformidade das cargas do cliente",
+                false,
+            ],
+            [
+                "Assegura que a AWS mantém a segurança física e a proteção de dados na infraestrutura",
+                true,
+            ],
+            [
+                "Garante o uso dos mesmos frameworks de conformidade adotados por outros provedores de nuvem",
+                false,
+            ],
+            [
+                "Compromete-se a adotar todo novo framework que se torne relevante para as cargas do cliente",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada da AWS, qual controle operacional o cliente herda integralmente da AWS?",
+        explanation:
+            "Controles herdados são executados por completo pela AWS, como a segurança física e ambiental dos data centers. Gerenciamento de patches e de configuração são controles compartilhados (a AWS cuida da infraestrutura e o cliente, do sistema operacional convidado e das aplicações), e o gerenciamento de usuários e acessos é do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Segurança física dos data centers", true],
+            ["Gerenciamento de patches", false],
+            ["Gerenciamento de configuração", false],
+            ["Gerenciamento de usuários e acessos", false],
+        ],
+    },
+    {
+        statement:
+            "Qual função os grupos de segurança exercem na segurança das instâncias do Amazon EC2?",
+        explanation:
+            "O grupo de segurança é um firewall virtual stateful no nível da instância: regras de protocolo, porta e origem controlam o tráfego de entrada e saída. Políticas do IAM definem o que usuários podem fazer, o AWS Shield protege contra DDoS e o Amazon CloudFront é uma rede de entrega de conteúdo; nenhuma dessas é a função do grupo de segurança.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Atuam como firewall virtual das instâncias do Amazon EC2", true],
+            ["Protegem as contas dos usuários com políticas do IAM", false],
+            ["Oferecem proteção contra DDoS com o AWS Shield", false],
+            ["Usam o Amazon CloudFront para proteger as instâncias do EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Por que o gerenciamento de ativos na AWS é mais fácil do que em um data center físico?",
+        explanation:
+            "Na AWS, todo recurso é criado e descrito por APIs, então o inventário de ativos sai de poucas chamadas (com o AWS Config ou a AWS CLI, por exemplo) em vez de levantamentos manuais. A AWS não entrega um CMDB pronto para o cliente manter, não faz varreduras de descoberta em nome dele e o EC2 não gera relatórios de ativos automaticamente no S3.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "A AWS fornece um banco de dados de gerenciamento de configuração (CMDB) para os usuários manterem",
+                false,
+            ],
+            ["A AWS executa varreduras de descoberta da infraestrutura em nome do cliente", false],
+            [
+                "O Amazon EC2 gera um relatório de ativos e o grava no bucket do Amazon S3 indicado pelo cliente",
+                false,
+            ],
+            [
+                "Os usuários obtêm os metadados dos ativos de forma confiável com poucas chamadas de API",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Como se chama o conceito de usar o AWS Identity and Access Management (IAM) para conceder acesso somente aos recursos necessários para executar uma tarefa?",
+        explanation:
+            "O princípio do privilégio mínimo concede apenas as permissões necessárias para a tarefa, o que reduz o impacto de erros e de credenciais comprometidas. Acesso restrito e acesso conforme a necessidade são descrições genéricas, não o nome do princípio, e acesso por token se refere a credenciais temporárias, não ao escopo das permissões.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Acesso restrito", false],
+            ["Acesso conforme a necessidade", false],
+            ["Acesso com privilégio mínimo", true],
+            ["Acesso por token", false],
+        ],
+    },
+    {
+        statement:
+            "Pelo modelo de responsabilidade compartilhada da AWS, qual destas é uma responsabilidade do cliente?",
+        explanation:
+            "O cliente configura o que roda sobre a infraestrutura: sistema operacional convidado, rede da VPC e regras de firewall, como os grupos de segurança. Proteger hardware, instalações e redes, obter certificações e atestados de terceiros e disponibilizar relatórios de conformidade aos clientes (pelo AWS Artifact) são responsabilidades da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Proteger o hardware, as instalações e as redes que executam os serviços da AWS",
+                false,
+            ],
+            ["Fornecer relatórios e certificados de conformidade aos clientes sob NDA", false],
+            ["Configurar o sistema operacional, a rede e o firewall das instâncias", true],
+            ["Obter certificações do setor e atestados independentes de terceiros", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço gerenciado da AWS oferece orientação em tempo real sobre as práticas recomendadas de segurança da AWS?",
+        explanation:
+            "O AWS Trusted Advisor inspeciona o ambiente e recomenda ações com base em práticas recomendadas, inclusive de segurança, como grupos de segurança abertos, MFA no usuário raiz e permissões de buckets. O X-Ray rastreia requisições de aplicações, o CloudWatch monitora métricas e logs e o Systems Manager automatiza a operação dos recursos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS X-Ray", false],
+            ["AWS Trusted Advisor", true],
+            ["Amazon CloudWatch", false],
+            ["AWS Systems Manager", false],
+        ],
+    },
+    {
+        statement:
+            "Pelo modelo de responsabilidade compartilhada, qual destas tarefas de correção de vulnerabilidades cabe à AWS?",
+        explanation:
+            "O firmware dos servidores físicos que hospedam as instâncias é mantido pela AWS, pois o cliente não tem acesso ao hardware. Aplicar patches no sistema operacional convidado e ajustar Network ACLs e grupos de segurança para fechar portas vulneráveis são tarefas do cliente, dentro da segurança na nuvem.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Atualizar as Network ACLs para bloquear o tráfego nas portas vulneráveis", false],
+            ["Aplicar patches nos sistemas operacionais das instâncias do Amazon EC2", false],
+            ["Atualizar o firmware dos hosts físicos que executam as instâncias do EC2", true],
+            [
+                "Atualizar as regras dos grupos de segurança para bloquear as portas vulneráveis",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "De acordo com o modelo de responsabilidade compartilhada da AWS, pelo que a AWS é responsável?",
+        explanation:
+            "A AWS opera a infraestrutura de rede que conecta data centers, Zonas de Disponibilidade e Regiões. Configurar a Amazon VPC (sub-redes, rotas e gateways), cuidar do código das aplicações e gerenciar o tráfego que chega a elas, com balanceadores de carga e DNS, são tarefas do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Configurar as sub-redes e as rotas da Amazon VPC", false],
+            ["Gerenciar e atualizar o código das aplicações", false],
+            ["Controlar o tráfego que chega às aplicações", false],
+            ["Gerenciar a infraestrutura de rede subjacente", true],
+        ],
+    },
+    {
+        statement:
+            "Qual ferramenta da AWS identifica grupos de segurança que liberam acesso irrestrito da internet a determinadas portas?",
+        explanation:
+            "O AWS Trusted Advisor tem verificações de segurança que sinalizam grupos de segurança com acesso irrestrito (0.0.0.0/0) a portas específicas, como SSH e RDP. O AWS Organizations governa várias contas, o AWS Cost Explorer analisa custos e uso, e o painel do Amazon EC2 mostra as regras, mas não aponta quais estão abertas demais.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Organizations", false],
+            ["AWS Trusted Advisor", true],
+            ["AWS Cost Explorer", false],
+            ["Painel do Amazon EC2", false],
+        ],
+    },
+    {
+        statement: "Qual das atividades a seguir é responsabilidade da AWS?",
+        explanation:
+            "Ao fim da vida útil, a AWS destrói fisicamente as mídias de armazenamento seguindo padrões do setor, para que nenhum dado vaze. Criar usuários e grupos do IAM, aplicar patches no sistema operacional convidado e configurar a segurança das instâncias do Amazon EC2 são tarefas do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criar usuários e grupos do IAM e anexar as políticas", false],
+            ["Destruir fisicamente as mídias de armazenamento ao fim da vida útil", true],
+            ["Aplicar patches nos sistemas operacionais convidados das instâncias", false],
+            ["Configurar as opções de segurança das instâncias do Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Quais tarefas um cliente deve executar quando suspeita que uma conta da AWS foi comprometida? (Selecione DUAS opções.)",
+        explanation:
+            "Diante da suspeita, troque senhas e rotacione chaves de acesso para invalidar credenciais roubadas e acione o AWS Support para ajudar na investigação e na correção. Remover o MFA enfraquece a proteção, mudar de Região não tira o acesso do invasor e excluir o CloudTrail apaga o histórico necessário para entender o que aconteceu.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Trocar senhas e rotacionar chaves de acesso", true],
+            ["Remover os dispositivos MFA da conta", false],
+            ["Mover os recursos para outra Região", false],
+            ["Excluir as trilhas e os logs do AWS CloudTrail", false],
+            ["Entrar em contato com o AWS Support", true],
+        ],
+    },
+    {
+        statement:
+            "Um usuário executa uma aplicação na AWS e percebe que um ou mais endereços IP pertencentes à AWS estão participando de um ataque distribuído de negação de serviço (DDoS). Quem ele deve contatar PRIMEIRO?",
+        explanation:
+            "Uso de recursos da AWS em atividades maliciosas, como DDoS, invasões e spam, deve ser reportado à equipe AWS Trust & Safety (antes chamada AWS Abuse), que investiga e interrompe o abuso. O AWS Support, o Technical Account Manager e os arquitetos de soluções ajudam o cliente com o próprio ambiente, mas não são o canal de denúncia.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Support", false],
+            ["Technical Account Manager (TAM) da AWS", false],
+            ["Arquiteto de soluções da AWS", false],
+            ["Equipe AWS Trust & Safety", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS oferece Network ACLs de entrada e saída para reforçar a segurança da conectividade externa das instâncias do Amazon EC2?",
+        explanation:
+            "As Network ACLs são recursos da Amazon VPC: funcionam como firewall stateless no nível da sub-rede, com regras de entrada e saída, e complementam os grupos de segurança das instâncias. O IAM controla identidades e permissões, o Amazon Connect é uma central de atendimento e o Amazon API Gateway publica e gerencia APIs.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS IAM", false],
+            ["Amazon Connect", false],
+            ["Amazon VPC", true],
+            ["Amazon API Gateway", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação web na AWS está recebendo uma enxurrada de requisições maliciosas vindas sempre do mesmo conjunto de endereços IP. Qual serviço da AWS pode proteger a aplicação e bloquear esse tráfego?",
+        explanation:
+            "O AWS WAF permite criar regras com conjuntos de endereços IP para bloquear essas origens e filtrar padrões maliciosos na camada de aplicação. O IAM controla as permissões de identidades, o Amazon GuardDuty detecta ameaças mas não bloqueia tráfego por conta própria e o Amazon SNS apenas envia notificações.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS IAM", false],
+            ["Amazon GuardDuty", false],
+            ["Amazon SNS", false],
+            ["AWS WAF", true],
+        ],
+    },
+    {
+        statement:
+            "Onde os usuários podem encontrar e contratar soluções de segurança de fornecedores terceiros?",
+        explanation:
+            "O AWS Marketplace é um catálogo digital com software de fornecedores independentes, incluindo firewalls, detecção de intrusão e ferramentas de conformidade, prontos para contratar e implantar. O AWS Service Catalog organiza produtos aprovados para uso interno, o AWS CloudFormation provisiona infraestrutura como código e o AWS CodeDeploy automatiza implantações.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Service Catalog", false],
+            ["AWS Marketplace", true],
+            ["AWS CloudFormation", false],
+            ["AWS CodeDeploy", false],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada da AWS, quem é responsável pela segurança e pela conformidade?",
+        explanation:
+            "Segurança e conformidade são divididas: a AWS responde pela segurança da nuvem (instalações, hardware, rede global e virtualização) e o cliente, pela segurança na nuvem (dados, IAM, configurações e aplicações). Nenhuma das partes responde sozinha, e órgãos reguladores não assumem responsabilidade operacional no modelo.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Somente o cliente é responsável", false],
+            ["Somente a AWS é responsável", false],
+            ["A AWS e o cliente dividem a responsabilidade", true],
+            ["A AWS divide a responsabilidade com o órgão regulador do setor", false],
+        ],
+    },
+    {
+        statement: "Qual serviço da AWS é usado para criptografar volumes do Amazon EBS?",
+        explanation:
+            "A criptografia do Amazon EBS usa chaves do AWS Key Management Service (AWS KMS), que cria, controla e registra o uso das chaves que protegem os dados em repouso. O AWS Certificate Manager cuida de certificados SSL/TLS para dados em trânsito, o Systems Manager automatiza a operação e o AWS Config registra configurações.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Certificate Manager (ACM)", false],
+            ["AWS Systems Manager", false],
+            ["AWS KMS", true],
+            ["AWS Config", false],
+        ],
+    },
+    {
+        statement:
+            "O que está entre as responsabilidades do cliente no modelo de responsabilidade compartilhada da AWS?",
+        explanation:
+            "A segurança das aplicações (código, controle de acesso e autenticação) fica do lado do cliente, que as desenvolve e configura. A infraestrutura de virtualização, a infraestrutura de rede global e a segurança física do hardware fazem parte da segurança da nuvem, que é responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Infraestrutura de virtualização", false],
+            ["Infraestrutura de rede", false],
+            ["Segurança das aplicações", true],
+            ["Segurança física do hardware", false],
+        ],
+    },
+    {
+        statement:
+            "Qual destas atividades é responsabilidade da AWS no modelo de responsabilidade compartilhada?",
+        explanation:
+            "Servidores, armazenamento e equipamentos de rede dos data centers são mantidos exclusivamente pela AWS. Configurar aplicações de terceiros, proteger o acesso às aplicações e aos dados e gerenciar AMIs personalizadas são tarefas do cliente, parte da segurança na nuvem.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Configurar aplicações de terceiros", false],
+            ["Manter o hardware físico dos data centers", true],
+            ["Proteger o acesso às aplicações e aos dados", false],
+            ["Gerenciar AMIs personalizadas do Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Como um administrador de sistemas pode acrescentar uma camada extra de segurança ao login de um usuário no Console de Gerenciamento da AWS?",
+        explanation:
+            "A autenticação multifator exige, além da senha, um código ou uma chave de um dispositivo, o que acrescenta uma camada ao login. O Amazon GuardDuty detecta atividades suspeitas e o AWS CloudTrail registra os eventos de login, mas nenhum dos dois muda a autenticação, e auditar funções do IAM revisa permissões sem proteger o login.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Monitorar os logins com o Amazon GuardDuty", false],
+            ["Auditar periodicamente as funções do IAM", false],
+            ["Ativar a autenticação multifator (MFA)", true],
+            ["Registrar os logins com o AWS CloudTrail", false],
+        ],
+    },
+    {
+        statement:
+            "Onde um cliente encontra informações sobre as ações proibidas na infraestrutura da AWS?",
+        explanation:
+            "A Política de Uso Aceitável da AWS (Acceptable Use Policy) define o que não é permitido fazer com os serviços, como atividades ilegais, ataques a redes e envio de spam. O AWS Trusted Advisor recomenda boas práticas, o IAM controla permissões de acesso e o console de faturamento mostra custos, faturas e pagamentos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Trusted Advisor", false],
+            ["AWS Identity and Access Management (IAM)", false],
+            ["Console de Faturamento da AWS", false],
+            ["Política de Uso Aceitável da AWS", true],
+        ],
+    },
+    {
+        statement:
+            "Quais são práticas recomendadas para gerenciar os usuários do IAM? (Selecione DUAS opções.)",
+        explanation:
+            "Exigir MFA acrescenta um segundo fator ao login e impedir a reutilização evita a volta a senhas já expostas, e as duas regras podem ser configuradas no IAM. Compartilhar um usuário apaga a rastreabilidade, e guardar senha em texto simples ou repeti-la em outros sites facilita o acesso indevido.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Impedir que os usuários reutilizem senhas anteriores", true],
+            ["Exigir autenticação multifator (MFA) dos usuários", true],
+            ["Exigir que as senhas sejam guardadas em texto simples", false],
+            ["Compartilhar um mesmo usuário do IAM entre a equipe", false],
+            ["Recomendar a mesma senha na AWS e em outros sites", false],
+        ],
+    },
+    {
+        statement:
+            "Qual situação deve ser reportada à equipe AWS Trust & Safety, responsável pelas denúncias de abuso?",
+        explanation:
+            "Tentativas de invasão, DDoS, spam ou malware originados de recursos da AWS são abuso e devem ser reportados à AWS Trust & Safety (antiga equipe AWS Abuse). Interrupções em uma Zona de Disponibilidade aparecem no AWS Health Dashboard, falha de acesso a um bucket do S3 é questão de permissões e troca de forma de pagamento é assunto de faturamento.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Uma Zona de Disponibilidade apresenta interrupção de serviço", false],
+            ["Uma tentativa de invasão é feita a partir de um endereço IP da AWS", true],
+            [
+                "Um usuário não consegue acessar um bucket do Amazon S3 a partir de um IP da AWS",
+                false,
+            ],
+            ["Um usuário precisa trocar a forma de pagamento porque ela foi comprometida", false],
+        ],
+    },
+    {
+        statement: "Quais destes são componentes da Amazon VPC? (Selecione DUAS opções.)",
+        explanation:
+            "Sub-redes dividem o intervalo de endereços IP da VPC, e gateways de internet conectam a VPC à internet; ambos são componentes da Amazon VPC, assim como tabelas de rotas e Network ACLs. Objetos e buckets pertencem ao Amazon S3, e chaves de acesso são credenciais do IAM.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Objetos", false],
+            ["Sub-redes", true],
+            ["Buckets de armazenamento", false],
+            ["Gateways de internet", true],
+            ["Chaves de acesso", false],
+        ],
+    },
+    {
+        statement:
+            "Qual função os usuários podem executar com o AWS Key Management Service (AWS KMS)?",
+        explanation:
+            "O AWS KMS cria e controla as chaves criptográficas usadas para criptografar e descriptografar dados em serviços da AWS e em aplicações, com o uso registrado no AWS CloudTrail. Chaves de acesso do usuário raiz e de usuários do IAM são credenciais gerenciadas no IAM, onde também se configuram os dispositivos de MFA.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criar e gerenciar as chaves de acesso do usuário raiz da conta da AWS", false],
+            ["Criar e gerenciar as chaves de acesso de um usuário do IAM", false],
+            ["Criar e gerenciar chaves para criptografar e descriptografar dados", true],
+            ["Criar e gerenciar chaves de dispositivos de autenticação multifator (MFA)", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS permitem gerar chaves de criptografia que podem ser usadas para criptografar dados? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS KMS gera e gerencia chaves de criptografia em infraestrutura gerenciada pela AWS, e o AWS CloudHSM gera chaves em módulos de hardware (HSM) dedicados ao cliente. O ACM emite certificados SSL/TLS, o Amazon Macie classifica dados sensíveis no S3 e o IAM controla permissões.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Key Management Service (AWS KMS)", true],
+            ["AWS CloudHSM", true],
+            ["Amazon Macie", false],
+            ["AWS Certificate Manager (ACM)", false],
+            ["AWS Identity and Access Management (IAM)", false],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada da AWS, quais itens são gerenciados pelo cliente? (Selecione DUAS opções.)",
+        explanation:
+            "O cliente configura grupos de segurança e Network ACLs e aplica patches no sistema operacional convidado das instâncias EC2. No Amazon RDS, a AWS cuida dos patches do sistema operacional, e o descarte de discos e o acesso físico aos data centers também são responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Descarte de dispositivos físicos de armazenamento", false],
+            ["Configuração de grupos de segurança e Network ACLs", true],
+            ["Aplicação de patches no sistema operacional de uma instância do Amazon RDS", false],
+            ["Controle do acesso físico aos data centers", false],
+            ["Aplicação de patches no sistema operacional de uma instância do Amazon EC2", true],
+        ],
+    },
+    {
+        statement: "Ao executar uma aplicação na Nuvem AWS, pelo que o cliente é responsável?",
+        explanation:
+            "O cliente cuida do que roda na nuvem, como as atualizações e correções do software da própria aplicação. Hardware físico, hipervisor e controle de quem entra nos data centers fazem parte da segurança da nuvem, que é responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Gerenciar o hardware físico dos servidores", false],
+            ["Atualizar o hipervisor da infraestrutura", false],
+            ["Definir quem pode entrar no data center", false],
+            ["Gerenciar as atualizações da aplicação", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS ajuda a identificar atividades maliciosas ou não autorizadas em contas e cargas de trabalho da AWS?",
+        explanation:
+            "O Amazon GuardDuty detecta ameaças continuamente, analisando logs do AWS CloudTrail, VPC Flow Logs e DNS com machine learning e inteligência de ameaças. O Amazon Rekognition analisa imagens, o Trusted Advisor recomenda boas práticas e o CloudWatch monitora métricas e logs.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon Rekognition", false],
+            ["AWS Trusted Advisor", false],
+            ["Amazon GuardDuty", true],
+            ["Amazon CloudWatch", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa hospeda uma aplicação web em um contêiner Docker no Amazon EC2. Qual das tarefas a seguir é responsabilidade da AWS?",
+        explanation:
+            "Com o Docker rodando direto no EC2, a AWS cuida da infraestrutura física, como a manutenção do hardware nos data centers. Escalar a aplicação, orquestrar os contêineres e manter o sistema operacional convidado atualizado ficam com o cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Escalar a aplicação web e os serviços desenvolvidos com Docker", false],
+            ["Provisionar e agendar contêineres no cluster e manter sua disponibilidade", false],
+            ["Fazer a manutenção do hardware nas instalações que executam a Nuvem AWS", true],
+            ["Gerenciar o sistema operacional convidado, incluindo atualizações e patches", false],
+        ],
+    },
+    {
+        statement:
+            "Quais ações representam boas práticas de uso do AWS Identity and Access Management (IAM)? (Selecione DUAS opções.)",
+        explanation:
+            "Exigir senhas fortes e fazer a rotação periódica das chaves de acesso reduzem o risco de credenciais comprometidas. Credenciais devem ser individuais, o console usa senha e não chaves de acesso, e funções do IAM são o jeito recomendado de delegar permissões.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Configurar uma política de senhas forte para os usuários", true],
+            ["Compartilhar credenciais entre usuários que trabalham na mesma Região", false],
+            ["Usar chaves de acesso para entrar no Console de Gerenciamento da AWS", false],
+            ["Fazer a rotação periódica das chaves de acesso de longo prazo", true],
+            ["Evitar o uso de funções do IAM para delegar permissões", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso ou serviço da AWS pode ser usado para capturar informações sobre o tráfego de entrada e de saída na infraestrutura de uma VPC?",
+        explanation:
+            "O VPC Flow Logs registra metadados do tráfego IP que entra e sai das interfaces de rede da VPC, como origem, destino, porta e se o tráfego foi aceito. O CloudTrail registra chamadas de API, o Config registra configurações de recursos e o Trusted Advisor faz recomendações.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Config", false],
+            ["VPC Flow Logs", true],
+            ["AWS Trusted Advisor", false],
+            ["AWS CloudTrail", false],
+        ],
+    },
+    {
+        statement:
+            "Quais tarefas são responsabilidade do cliente no modelo de responsabilidade compartilhada da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O cliente responde pela configuração das próprias aplicações e pelos grupos de segurança que controlam o acesso aos recursos. Acesso físico às instalações, ciclo de vida do hardware e proteção da rede física que conecta Regiões e Zonas de Disponibilidade são da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Gerenciar o acesso às instalações da infraestrutura", false],
+            ["Gerenciar o ciclo de vida do hardware da infraestrutura de nuvem", false],
+            ["Gerenciar a configuração das aplicações do usuário", true],
+            ["Proteger a rede física da nuvem", false],
+            ["Configurar os grupos de segurança", true],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação web é hospedada na AWS com um Elastic Load Balancer, várias instâncias do Amazon EC2 e o Amazon RDS. Quais medidas de segurança são responsabilidade da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "A AWS protege a rede subjacente contra falsificação de IP e captura de pacotes e aplica os patches do sistema operacional e do mecanismo no RDS, que é gerenciado. Antivírus nas instâncias EC2, criptografia entre EC2 e load balancer e grupos de segurança são do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Executar uma varredura de vírus nas instâncias EC2", false],
+            ["Proteger contra falsificação de IP e captura de pacotes (sniffing)", true],
+            ["Instalar os patches de segurança mais recentes na instância do RDS", true],
+            ["Criptografar a comunicação entre as instâncias EC2 e o load balancer", false],
+            ["Configurar um grupo de segurança e uma Network ACL para as instâncias EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Por exigência de conformidade, uma empresa precisa de um bucket do Amazon S3 que não possa ter nenhum objeto público. Como isso pode ser feito?",
+        explanation:
+            "O S3 Block Public Access, no nível da conta ou do bucket, se sobrepõe a políticas e ACLs que concederiam acesso público, impedindo objetos públicos. Reunião e aprovação manual não impõem a regra tecnicamente, e um monitor próprio só corrige depois que o problema acontece.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Ativar o S3 Block Public Access pelo Console de Gerenciamento da AWS", true],
+            ["Reunir a equipe para reforçar que só objetos privados devem ser enviados", false],
+            ["Exigir que todo objeto seja aprovado manualmente antes do upload", false],
+            ["Criar um serviço que monitore os uploads e remova os objetos públicos", false],
+        ],
+    },
+    {
+        statement:
+            "Segundo o modelo de responsabilidade compartilhada da AWS, qual das tarefas a seguir é responsabilidade do cliente?",
+        explanation:
+            "Quem roda banco de dados em instâncias EC2 gerencia o sistema operacional convidado e aplica os patches. No Amazon RDS e no Amazon DynamoDB, que são serviços gerenciados, a AWS cuida do sistema operacional, e o hipervisor é sempre responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Instalar patches de segurança nos hipervisores Xen e KVM", false],
+            ["Instalar patches do sistema operacional do Amazon DynamoDB", false],
+            [
+                "Instalar patches do sistema operacional em instâncias de banco de dados no Amazon EC2",
+                true,
+            ],
+            [
+                "Instalar patches do sistema operacional em instâncias de banco de dados do Amazon RDS",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS facilita criar e gerenciar usuários e grupos da AWS e dar a eles acesso seguro aos recursos, sem custo adicional?",
+        explanation:
+            "O IAM cria usuários, grupos e funções e controla, por políticas, o acesso aos recursos da AWS, sem cobrança adicional. O Amazon Cognito gerencia usuários de aplicações web e mobile, o AWS Directory Service é um diretório gerenciado e pago e o Firewall Manager centraliza regras de firewall.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Directory Service for Microsoft Active Directory", false],
+            ["Amazon Cognito", false],
+            ["AWS Identity and Access Management (IAM)", true],
+            ["AWS Firewall Manager", false],
+        ],
+    },
+    {
+        statement:
+            "Um usuário precisa gerar um relatório com o status das principais verificações de segurança de uma conta AWS, incluindo as permissões dos buckets do Amazon S3, se o MFA está ativado no usuário raiz e se algum grupo de segurança permite acesso irrestrito. Onde todas essas informações podem ser encontradas em um só lugar?",
+        explanation:
+            "O AWS Trusted Advisor reúne verificações de segurança como permissões de buckets S3, MFA no usuário raiz e grupos de segurança com acesso irrestrito. O relatório de credenciais cobre só usuários do IAM, o CloudTrail registra chamadas de API e o CloudWatch mostra métricas e logs.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Painel personalizado do Amazon CloudWatch", false],
+            ["Trilhas do AWS CloudTrail", false],
+            ["Relatório do AWS Trusted Advisor", true],
+            ["Relatório de credenciais do IAM", false],
+        ],
+    },
+    {
+        statement:
+            "Usar o AWS Config para registrar, auditar e avaliar mudanças nos recursos da AWS, garantindo rastreabilidade, é um exemplo de qual pilar do AWS Well-Architected Framework?",
+        explanation:
+            "Habilitar a rastreabilidade, monitorando e auditando ações e mudanças no ambiente, é princípio de design do pilar de segurança, e o AWS Config aplica isso ao registrar e avaliar configurações. Excelência operacional foca em executar sistemas, e os outros dois pilares tratam de recursos e custos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Segurança, que trata da proteção de dados, sistemas e ativos", true],
+            ["Excelência operacional, que trata de executar e monitorar sistemas", false],
+            ["Eficiência de desempenho, que trata do uso eficiente de recursos", false],
+            ["Otimização de custos, que trata de evitar gastos desnecessários", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço ou recurso da AWS ajuda a restringir os serviços, os recursos e as ações de API que os usuários e as funções de cada conta-membro podem acessar?",
+        explanation:
+            "As políticas de controle de serviço (SCPs) do AWS Organizations definem o máximo de permissões das contas-membro, limitando serviços, recursos e ações de API. O Amazon Cognito autentica usuários de aplicações, o AWS Shield protege contra DDoS e o Firewall Manager centraliza regras de firewall.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Amazon Cognito", false],
+            ["AWS Organizations", true],
+            ["AWS Shield", false],
+            ["AWS Firewall Manager", false],
+        ],
+    },
+    {
+        statement:
+            "Um usuário quer criptografar os dados recebidos, armazenados e gerenciados pelo AWS CloudTrail. Qual serviço da AWS oferece esse recurso?",
+        explanation:
+            "O CloudTrail se integra ao AWS KMS para criptografar os arquivos de log com chaves gerenciadas no KMS (SSE-KMS). O ACM e o AWS Private CA emitem certificados usados na criptografia em trânsito, e o Secrets Manager guarda e rotaciona segredos, como senhas de banco de dados.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Secrets Manager", false],
+            ["AWS Private Certificate Authority (AWS Private CA)", false],
+            ["AWS Key Management Service (AWS KMS)", true],
+            ["AWS Certificate Manager (ACM)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa de proteção ampliada contra ataques de negação de serviço distribuído (DDoS) em seu site e de assistência de especialistas da AWS durante esses eventos. Qual serviço gerenciado da AWS atende a esses requisitos?",
+        explanation:
+            "O AWS Shield Advanced amplia a proteção contra DDoS com visibilidade dos ataques, proteção de custos e acesso 24 horas à equipe de resposta a DDoS da AWS. O AWS WAF filtra requisições web, o Firewall Manager centraliza regras e o GuardDuty detecta ameaças, sem equipe de resposta.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Shield Advanced", true],
+            ["AWS Firewall Manager", false],
+            ["AWS WAF", false],
+            ["Amazon GuardDuty", false],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada da AWS, quais são responsabilidades do cliente? (Selecione DUAS opções.)",
+        explanation:
+            "O cliente protege os dados em trânsito, por exemplo com TLS, e cuida da autenticação da integridade dos dados, verificando que não foram alterados. Segurança física e ambiental, dispositivos físicos de rede e descarte de discos são responsabilidade da AWS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Segurança física e ambiental", false],
+            ["Dispositivos físicos de rede, incluindo firewalls", false],
+            ["Descarte de dispositivos de armazenamento", false],
+            ["Segurança dos dados em trânsito", true],
+            ["Autenticação da integridade dos dados", true],
+        ],
+    },
+    {
+        statement:
+            "Em uma conta AWS independente, que não faz parte do AWS Organizations, quais tarefas só podem ser executadas depois de entrar com as credenciais do usuário raiz? (Selecione DUAS opções.)",
+        explanation:
+            "Em conta independente, encerrar a conta e ativar o acesso de usuários do IAM ao console de faturamento exigem o usuário raiz. Criar políticas, associar funções a instâncias EC2 e gerar chaves de acesso podem ser feitos por usuários do IAM com as permissões adequadas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Encerrar definitivamente a conta AWS", true],
+            ["Criar uma nova política do IAM", false],
+            ["Ativar o acesso do IAM ao console de faturamento", true],
+            ["Associar uma função do IAM a uma instância do Amazon EC2", false],
+            ["Gerar chaves de acesso para usuários do IAM", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é o recurso MAIS eficaz para se manter atualizado sobre os anúncios de segurança da AWS?",
+        explanation:
+            "Os AWS Security Bulletins publicam avisos sobre vulnerabilidades recém-descobertas e as ações recomendadas para os serviços da AWS. O AWS Health Dashboard informa eventos que afetam seus recursos, o re:Post Knowledge Center traz respostas técnicas e o Inspector aponta falhas nas suas cargas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Health Dashboard", false],
+            ["AWS re:Post Knowledge Center", false],
+            ["AWS Security Bulletins", true],
+            ["Amazon Inspector", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer conceder acesso total a um bucket do Amazon S3 para um usuário específico. Qual elemento da política do bucket S3 contém os dados do usuário, ou seja, indica quem precisa de acesso ao bucket?",
+        explanation:
+            "Em uma política de bucket, o elemento Principal indica quem recebe ou tem negado o acesso: usuário, conta, função ou serviço. Action lista as operações permitidas, como s3:GetObject, Resource indica o bucket ou os objetos afetados e Statement é o bloco que agrupa esses elementos.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Principal", true],
+            ["Action", false],
+            ["Resource", false],
+            ["Statement", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa cargas de trabalho no Amazon EC2 e no Amazon S3. Segundo o modelo de responsabilidade compartilhada, qual tarefa cabe à AWS?",
+        explanation:
+            "A AWS mantém a infraestrutura que executa os serviços, incluindo o hipervisor que isola as instâncias, e aplica as atualizações dele. Escolher as chaves de criptografia no S3, aplicar políticas do IAM e manter o sistema operacional das instâncias EC2 são tarefas do cliente.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Escolher as chaves de criptografia dos objetos armazenados no S3", false],
+            ["Criar e aplicar políticas do IAM para os usuários da conta", false],
+            ["Aplicar patches no sistema operacional de uma instância do Amazon EC2", false],
+            ["Aplicar atualizações no hipervisor que executa as instâncias", true],
+        ],
+    },
+    {
+        statement:
+            "Uma grande empresa contratou um desenvolvedor que precisa de credenciais da AWS. Quais boas práticas de segurança devem ser seguidas? (Selecione DUAS opções.)",
+        explanation:
+            "Dar acesso só aos recursos necessários aplica o princípio do privilégio mínimo, e exigir tamanho mínimo de senha fortalece as credenciais. O usuário raiz nunca deve ser compartilhado, o grupo de administradores dá acesso amplo demais e o usuário precisa poder trocar a própria senha.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Conceder acesso apenas aos recursos da AWS necessários para o trabalho", true],
+            ["Compartilhar com o desenvolvedor as credenciais do usuário raiz da conta", false],
+            ["Adicionar o desenvolvedor ao grupo de administradores no AWS IAM", false],
+            [
+                "Configurar uma política de senhas que impeça o desenvolvedor de trocar a senha",
+                false,
+            ],
+            ["Garantir que a política de senhas da conta exija um tamanho mínimo", true],
+        ],
+    },
+    {
+        statement:
+            "Qual das tarefas a seguir é necessária para implantar na AWS uma carga de trabalho em conformidade com o PCI DSS?",
+        explanation:
+            "A AWS mantém a certificação PCI DSS da infraestrutura, mas o cliente precisa escolher serviços que estejam no escopo do PCI DSS e aplicar os controles exigidos na própria aplicação. Não existe chamado de suporte que ative conformidade, e nem todo serviço da AWS está no escopo.",
+        topic: "Segurança e identidade",
+        options: [
+            [
+                "Usar qualquer serviço da AWS e implementar os controles do PCI DSS na camada de aplicação",
+                false,
+            ],
+            [
+                "Usar um serviço no escopo do PCI DSS e abrir um chamado no AWS Support para ativar a conformidade na aplicação",
+                false,
+            ],
+            [
+                "Usar qualquer serviço da AWS e abrir um chamado no AWS Support para ativar a conformidade com o PCI DSS",
+                false,
+            ],
+            [
+                "Usar um serviço da AWS no escopo do PCI DSS e aplicar os controles do PCI DSS na camada de aplicação",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor web teme que um ataque DDoS atinja sua aplicação. Quais serviços ou recursos da AWS ajudam a proteger contra esse tipo de ataque? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Shield mitiga ataques DDoS nas camadas de rede e transporte, e o Amazon CloudFront distribui e absorve o tráfego nos pontos de presença antes que ele chegue à origem. CloudTrail e Config registram atividades e configurações, e o Health Dashboard informa eventos dos serviços.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Shield", true],
+            ["AWS CloudTrail", false],
+            ["Amazon CloudFront", true],
+            ["AWS Config", false],
+            ["AWS Health Dashboard", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer dar a um funcionário acesso ao Amazon RDS, limitando a interação à AWS CLI e aos SDKs da AWS. Qual combinação de ações atende a esses requisitos seguindo o princípio do privilégio mínimo? (Selecione DUAS opções.)",
+        explanation:
+            "Um usuário do IAM com chaves de acesso e sem senha de console usa a AWS CLI e os SDKs, e a política com acesso ao RDS limita as permissões ao necessário. Senha de console contraria o requisito, e acesso de administrador viola o privilégio mínimo.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Criar um usuário do IAM com senha de console e sem chaves de acesso", false],
+            ["Criar um usuário do IAM com chaves de acesso e sem senha de console", true],
+            ["Criar uma função do IAM apenas com acesso ao console da AWS", false],
+            ["Criar uma política do IAM com acesso de administrador e anexá-la ao usuário", false],
+            ["Criar uma política do IAM com acesso ao Amazon RDS e anexá-la ao usuário", true],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é responsabilidade do cliente ao usar o Amazon RDS?",
+        explanation:
+            "No Amazon RDS, o cliente controla quem se conecta ao banco configurando os grupos de segurança. A AWS aplica os patches do sistema operacional, executa os backups automáticos que permitem a recuperação pontual e substitui instâncias que falham, por ser um serviço gerenciado.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Aplicar patches no sistema operacional do hardware subjacente", false],
+            [
+                "Controlar o tráfego de entrada e saída do banco de dados com grupos de segurança",
+                true,
+            ],
+            [
+                "Executar os backups que permitem a recuperação pontual da instância de banco de dados",
+                false,
+            ],
+            ["Substituir instâncias de banco de dados que falharam", false],
+        ],
+    },
+    {
+        statement: "Qual é a responsabilidade do cliente ao usar o AWS Lambda?",
+        explanation:
+            "No AWS Lambda, a AWS gerencia servidores, sistema operacional, runtime e escalabilidade, e o cliente cuida da aplicação: o código das funções, suas configurações e permissões. A criptografia do código em repouso já é feita pela AWS por padrão, com opção de usar chaves próprias no KMS.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Configuração do sistema operacional", false],
+            ["Gerenciamento da aplicação", true],
+            ["Gerenciamento da plataforma", false],
+            ["Criptografia do código", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d2.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d2.ts
@@ -187,11 +187,11 @@ export const QUESTOES_CLOUDCERTPREP_D2: Questao[] = [
         statement:
             "Quais serviços da AWS podem ser usados para reunir informações sobre a atividade de uma conta AWS? (Selecione DUAS opções.)",
         explanation:
-            "O AWS CloudTrail registra as chamadas de API e as ações feitas na conta, e o Amazon CloudWatch coleta métricas, logs e eventos dos recursos, permitindo acompanhar essa atividade e criar alertas. O CloudFront é uma CDN, o Cloud9 é um IDE na nuvem e o CloudHSM oferece módulos de segurança de hardware.",
+            "O AWS CloudTrail registra as chamadas de API e as ações feitas na conta, e o Amazon CloudWatch coleta métricas, logs e eventos dos recursos, permitindo acompanhar essa atividade e criar alertas. O CloudFront é uma CDN, o CloudFormation provisiona recursos a partir de modelos e o CloudHSM oferece módulos de segurança de hardware.",
         topic: "Segurança e identidade",
         options: [
             ["Amazon CloudFront", false],
-            ["AWS Cloud9", false],
+            ["AWS CloudFormation", false],
             ["AWS CloudTrail", true],
             ["AWS CloudHSM", false],
             ["Amazon CloudWatch", true],
@@ -566,11 +566,11 @@ export const QUESTOES_CLOUDCERTPREP_D2: Questao[] = [
     {
         statement: "Qual destes serviços ajuda as empresas a auditar a conformidade na AWS?",
         explanation:
-            "O AWS CloudTrail mantém o histórico de chamadas de API e eventos da conta, uma trilha de auditoria usada para comprovar conformidade e investigar incidentes. O CloudFront distribui conteúdo, o Migration Hub acompanha migrações e o CloudWatch monitora métricas e logs de operação, sem essa trilha de auditoria.",
+            "O AWS CloudTrail mantém o histórico de chamadas de API e eventos da conta, uma trilha de auditoria usada para comprovar conformidade e investigar incidentes. O CloudFront distribui conteúdo, o Lightsail oferece servidores virtuais simples e o CloudWatch monitora métricas e logs de operação, sem essa trilha de auditoria.",
         topic: "Segurança e identidade",
         options: [
             ["Amazon CloudFront", false],
-            ["AWS Migration Hub", false],
+            ["Amazon Lightsail", false],
             ["Amazon CloudWatch", false],
             ["AWS CloudTrail", true],
         ],

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d3.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d3.ts
@@ -1,0 +1,3104 @@
+// Questões do simulado AWS Certified Cloud Practitioner (CLF-C02), domínio 3 da prova
+// (Cloud Technology and Services), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aws-ccp-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D3: Questao[] = [
+    {
+        statement:
+            "A AWS permite que os usuários gerenciem seus recursos por meio de uma interface web. Qual é o nome dessa interface?",
+        explanation:
+            "O Console de Gerenciamento da AWS é a interface gráfica, acessada pelo navegador, para gerenciar os recursos. A AWS CLI funciona por comandos digitados no terminal, a API é acessada por requisições HTTP feitas por programas e os SDKs são bibliotecas usadas no código das aplicações.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Command Line Interface (AWS CLI)", false],
+            ["API de serviços da AWS", false],
+            ["SDKs da AWS", false],
+            ["Console de Gerenciamento da AWS", true],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação é executada em instâncias do Amazon EC2. Qual das opções a seguir é um exemplo de escalabilidade horizontal?",
+        explanation:
+            "Escalar horizontalmente é adicionar mais instâncias do mesmo tamanho para dividir a carga entre elas. Trocar a instância por uma maior, aumentar a capacidade de computação de uma única instância ou adicionar memória RAM a ela são exemplos de escalabilidade vertical.",
+        topic: "Computação",
+        options: [
+            ["Substituir a instância atual por outra maior e mais potente", false],
+            [
+                "Aumentar a capacidade de computação de uma única instância conforme a demanda cresce",
+                false,
+            ],
+            ["Adicionar mais memória RAM a uma das instâncias existentes", false],
+            ["Adicionar mais instâncias do mesmo tamanho para atender ao aumento de tráfego", true],
+        ],
+    },
+    {
+        statement:
+            "Quais medidas ajudam a manter protegidos os dados armazenados em volumes do Amazon EBS? (Selecione DUAS opções.)",
+        explanation:
+            "Os snapshots criam cópias pontuais dos volumes, guardadas no Amazon S3, e a criptografia em repouso com o AWS KMS protege os dados contra acesso indevido. O EBS não replica volumes entre zonas (a replicação ocorre dentro da própria zona), o Multi-Attach só compartilha o volume entre instâncias e aumentar o tamanho não protege os dados.",
+        topic: "Armazenamento",
+        options: [
+            ["Criar snapshots periódicos de cada volume do EBS", true],
+            ["Ativar a criptografia dos dados do EBS em repouso", true],
+            ["Replicar os volumes do EBS entre Zonas de Disponibilidade", false],
+            ["Ativar o Multi-Attach do volume em várias instâncias", false],
+            ["Aumentar regularmente o tamanho do volume do EBS", false],
+        ],
+    },
+    {
+        statement:
+            "O que o Amazon CloudFront utiliza para distribuir conteúdo com baixa latência a usuários do mundo todo?",
+        explanation:
+            "O CloudFront guarda o conteúdo em cache nos locais de borda, pontos de presença espalhados pelo mundo e próximos dos usuários. O Global Accelerator é outro serviço, que roteia o tráfego pela rede da AWS até endpoints regionais sem fazer cache, e Regiões e Zonas de Disponibilidade são onde as cargas de trabalho são implantadas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["AWS Global Accelerator", false],
+            ["Regiões da AWS", false],
+            ["Locais de borda da AWS", true],
+            ["Zonas de Disponibilidade da AWS", false],
+        ],
+    },
+    {
+        statement: "Qual serviço fornece DNS (Sistema de Nomes de Domínio) na Nuvem AWS?",
+        explanation:
+            "O Amazon Route 53 é o serviço de DNS da AWS, escalável e altamente disponível, que traduz nomes de domínio em endereços IP e direciona os usuários às aplicações. O AWS Config registra a configuração dos recursos, o CloudFront é a rede de entrega de conteúdo (CDN) e o Amazon EMR processa big data.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon Route 53", true],
+            ["AWS Config", false],
+            ["Amazon CloudFront", false],
+            ["Amazon EMR", false],
+        ],
+    },
+    {
+        statement:
+            "Para eliminar pontos únicos de falha, a boa prática é automatizar ao máximo tanto a detecção quanto a reação a falhas. Quais serviços da AWS ajudam nisso? (Selecione DUAS opções.)",
+        explanation:
+            "O Elastic Load Balancing faz verificações de integridade e para de enviar tráfego a destinos com falha, e o Amazon EC2 Auto Scaling substitui automaticamente as instâncias não íntegras. O Athena consulta dados no S3, o ECR guarda imagens de contêiner e o Inspector procura vulnerabilidades de software, não falhas de infraestrutura.",
+        topic: "Computação",
+        options: [
+            ["Elastic Load Balancing", true],
+            ["Amazon EC2 Auto Scaling", true],
+            ["Amazon Athena", false],
+            ["Amazon Elastic Container Registry", false],
+            ["Amazon Inspector", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor vai criar uma aplicação web de duas camadas cuja camada de dados usa MySQL. Qual opção oferece um banco de dados compatível com MySQL com backups automáticos feitos pela AWS?",
+        explanation:
+            "O Amazon Aurora é um banco de dados relacional gerenciado e compatível com MySQL, e a AWS faz os backups automáticos contínuos. No MySQL instalado no EC2, os backups ficam por conta do cliente, o DynamoDB é um banco NoSQL de chave-valor e o Neptune é um banco de grafos, nenhum dos dois compatível com MySQL.",
+        topic: "Banco de dados",
+        options: [
+            ["MySQL instalado em uma instância do Amazon EC2", false],
+            ["Amazon Aurora", true],
+            ["Amazon DynamoDB", false],
+            ["Amazon Neptune", false],
+        ],
+    },
+    {
+        statement: "O que o AWS Health Dashboard oferece? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Health Dashboard mostra uma visão personalizada de como os eventos da AWS afetam os serviços e recursos da sua conta e traz orientações para agir sobre eles. As verificações de integridade de instâncias são do EC2 Auto Scaling, as recomendações de custo vêm do Trusted Advisor e a busca de vulnerabilidades é do Amazon Inspector.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Orientações para resolver eventos da AWS que afetam seus recursos", true],
+            ["Uma visão personalizada do estado dos serviços da AWS que você utiliza", true],
+            ["Verificações de integridade das instâncias de um grupo do Auto Scaling", false],
+            ["Recomendações de otimização de custos para os recursos da conta", false],
+            ["Um painel com as vulnerabilidades encontradas nas suas aplicações", false],
+        ],
+    },
+    {
+        statement: "Quais afirmações sobre o Amazon S3 estão INCORRETAS? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon S3 é armazenamento de objetos, então não executa aplicações (isso é papel de serviços de computação como o EC2 e o Lambda), e escala automaticamente, sem ajuste manual. As demais são verdadeiras: capacidade praticamente ilimitada, qualquer número de objetos com tamanho máximo por objeto e durabilidade de 11 noves.",
+        topic: "Armazenamento",
+        options: [
+            ["Oferece armazenamento praticamente ilimitado para qualquer tipo de dado", false],
+            ["É capaz de executar qualquer tipo de aplicação ou sistema de back-end", true],
+            ["Armazena qualquer número de objetos, mas limita o tamanho de cada um", false],
+            ["Precisa ser escalado manualmente para armazenar e recuperar mais dados", true],
+            ["Foi projetado para oferecer 99,999999999% (11 noves) de durabilidade", false],
+        ],
+    },
+    {
+        statement: "Quais são recursos do Amazon CloudWatch Logs? (Selecione DUAS opções.)",
+        explanation:
+            "O CloudWatch Logs permite monitorar os logs em tempo real, com filtros e alarmes, e configurar por quanto tempo cada grupo de logs é mantido. O serviço é cobrado por ingestão e armazenamento, não gera resumos pelo Amazon SNS (que só envia notificações) e o OpenSearch Service é um destino opcional e pago.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Resumos dos logs enviados pelo Amazon SNS", false],
+            ["Análises gratuitas no Amazon OpenSearch Service", false],
+            ["Armazenamento dos logs sem nenhum custo", false],
+            ["Monitoramento dos dados de log em tempo real", true],
+            ["Período de retenção dos logs configurável", true],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS são indicados para leitura e gravação de dados que mudam constantemente? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon RDS lida com leituras e gravações frequentes em bancos relacionais, e o Amazon EFS oferece um sistema de arquivos compartilhado com leitura e gravação simultâneas por várias instâncias. O S3 Glacier Deep Archive é para arquivamento raro, o DataSync só transfere dados e o Redshift é um data warehouse voltado a análises.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Glacier Deep Archive", false],
+            ["Amazon RDS", true],
+            ["AWS DataSync", false],
+            ["Amazon Redshift", false],
+            ["Amazon EFS", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS permite executar consultas interativas com SQL padrão diretamente sobre dados armazenados no Amazon S3, pagando por consulta?",
+        explanation:
+            "O Amazon Athena é um serviço de consultas interativas sem servidor que roda SQL padrão direto sobre os dados no S3, cobrando pelo volume lido em cada consulta. O AWS Glue prepara e transforma dados (ETL), o Amazon EMR executa frameworks de big data como Spark e Hadoop e o Amazon QuickSight cria painéis de BI.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Glue", false],
+            ["Amazon EMR", false],
+            ["Amazon QuickSight", false],
+            ["Amazon Athena", true],
+        ],
+    },
+    {
+        statement:
+            "Qual das opções a seguir descreve corretamente a relação entre Regiões, Zonas de Disponibilidade e locais de borda da AWS?",
+        explanation:
+            "Cada Região é uma área geográfica com várias Zonas de Disponibilidade, e cada zona reúne um ou mais data centers. Os locais de borda são pontos de presença à parte, usados por serviços como o CloudFront, e não ficam dentro das zonas nem contêm Regiões.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Os data centers contêm as Regiões", false],
+            ["As Regiões contêm Zonas de Disponibilidade", true],
+            ["As Zonas de Disponibilidade contêm locais de borda", false],
+            ["Os locais de borda contêm Regiões", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa transcodificar um grande número de arquivos de vídeo independentes. Qual abordagem segue os princípios de arquitetura da AWS?",
+        explanation:
+            "Como os arquivos são independentes, processá-los em várias instâncias ao mesmo tempo aplica a escalabilidade horizontal e o paralelismo recomendados pela AWS, reduzindo o tempo total. Uma única instância, mesmo grande ou com GPU, processa em sequência, e hardware dedicado atende a isolamento e licenças, não à vazão.",
+        topic: "Computação",
+        options: [
+            ["Processar os arquivos em várias instâncias em paralelo", true],
+            ["Usar uma única instância grande fora do horário de pico", false],
+            ["Usar servidores com hardware dedicado ao cliente", false],
+            ["Usar uma única instância grande com GPU", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem executar um banco de dados Microsoft SQL Server? (Selecione DUAS opções.)",
+        explanation:
+            "O SQL Server pode rodar em instâncias do Amazon EC2, com o cliente instalando e administrando o banco, ou no Amazon RDS for SQL Server, em que a AWS cuida de patches e backups. O Aurora só é compatível com MySQL e PostgreSQL, o Redshift é um data warehouse e o S3 é armazenamento de objetos.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon EC2", true],
+            ["Amazon RDS", true],
+            ["Amazon Aurora", false],
+            ["Amazon Redshift", false],
+            ["Amazon S3", false],
+        ],
+    },
+    {
+        statement: "Qual vantagem de economia de tempo o Amazon Rekognition oferece?",
+        explanation:
+            "O Amazon Rekognition usa deep learning para detectar automaticamente objetos, cenas, rostos e textos em imagens e vídeos, dispensando a revisão manual. Ele não aplica marcas-d'água nem redimensiona imagens (tarefas de edição) e não depende de pessoas no Mechanical Turk, já que a análise é feita por modelos treinados.",
+        topic: "Machine learning",
+        options: [
+            ["Aplica marcas-d'água automaticamente em imagens", false],
+            ["Detecta automaticamente os objetos que aparecem em imagens", true],
+            ["Redimensiona milhões de imagens de forma automática", false],
+            ["Distribui a detecção de objetos para pessoas pelo Amazon Mechanical Turk", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço armazena objetos, oferece acesso a eles em tempo real e tem recursos de versionamento e de ciclo de vida?",
+        explanation:
+            "O Amazon S3 guarda dados como objetos com acesso imediato, permite ativar o versionamento para recuperar versões anteriores e usa políticas de ciclo de vida para mover ou excluir objetos. O EFS é armazenamento de arquivos, o EBS oferece volumes em bloco para o EC2 e o Storage Gateway conecta ambientes locais ao armazenamento da AWS.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon EFS", false],
+            ["AWS Storage Gateway", false],
+            ["Amazon S3", true],
+            ["Amazon EBS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer expandir sua operação de uma Região da AWS para uma segunda Região. O que a empresa precisa fazer para começar a usar a nova Região?",
+        explanation:
+            "As Regiões ficam disponíveis para qualquer conta no modelo de autoatendimento: basta começar a criar recursos nela pelo console, pela CLI ou pela API (as Regiões desativadas por padrão só precisam ser ativadas antes na própria conta). Não há contrato por Região, Zonas de Disponibilidade não podem ser movidas e o console é acessado pelo navegador.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Pedir a um gerente de contas da AWS um novo contrato para a Região", false],
+            ["Mover uma das Zonas de Disponibilidade para a nova Região", false],
+            ["Começar a criar e implantar os recursos na segunda Região", true],
+            ["Baixar o Console de Gerenciamento da AWS da nova Região", false],
+        ],
+    },
+    {
+        statement: "Por que é vantajoso usar o Elastic Load Balancing com as aplicações?",
+        explanation:
+            "O Elastic Load Balancing distribui o tráfego entre vários destinos e se adapta sozinho às variações constantes no volume e no padrão das requisições. Quem adiciona ou remove instâncias é o EC2 Auto Scaling, não há conversão de Application Load Balancer para Classic Load Balancer e o serviço é cobrado por hora e por uso.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Permite converter Application Load Balancers em Classic Load Balancers", false],
+            ["Consegue lidar com mudanças constantes nos padrões de tráfego de rede", true],
+            [
+                "Adiciona e remove instâncias do Amazon EC2 automaticamente conforme a demanda",
+                false,
+            ],
+            ["É oferecido sem nenhum custo para os usuários", false],
+        ],
+    },
+    {
+        statement:
+            "Entre as opções abaixo, qual é o armazenamento durável de menor custo para guardar backups de banco de dados que precisam estar disponíveis para recuperação imediata?",
+        explanation:
+            "A classe S3 Standard guarda os backups com alta durabilidade, recuperação em milissegundos e custo por GB bem menor que o de volumes do EBS (classes como a S3 Standard-IA saem ainda mais baratas para acesso raro). O S3 Glacier Flexible Retrieval leva de minutos a horas e o armazenamento de instância é temporário.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Standard", true],
+            ["S3 Glacier Flexible Retrieval", false],
+            ["Amazon EBS", false],
+            ["Armazenamento de instância do Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Qual tipo de armazenamento da AWS é temporário e tem os dados apagados quando a instância é interrompida ou encerrada?",
+        explanation:
+            "O armazenamento de instância fica em discos fisicamente ligados ao host e é efêmero: os dados se perdem quando a instância é interrompida, hibernada ou encerrada. Volumes do EBS persistem independentemente da instância, e o EFS e o S3 guardam os dados até que sejam excluídos, sem depender de nenhuma instância.",
+        topic: "Armazenamento",
+        options: [
+            ["Volume do Amazon EBS", false],
+            ["Armazenamento de instância", true],
+            ["Sistema de arquivos do Amazon EFS", false],
+            ["Bucket do Amazon S3", false],
+        ],
+    },
+    {
+        statement:
+            "Qual grupo reúne apenas serviços da plataforma sem servidor (serverless) da AWS?",
+        explanation:
+            "Step Functions, DynamoDB e SNS são totalmente sem servidor: não há instâncias para provisionar e a escala é automática. Nos outros grupos há um serviço baseado em servidores: o Amazon EC2 exige gerenciar instâncias, o Lightsail oferece servidores virtuais e o Elastic Beanstalk implanta a aplicação em instâncias do EC2.",
+        topic: "Computação",
+        options: [
+            ["Amazon EC2, Amazon S3 e Amazon Athena", false],
+            ["Amazon Kinesis, Amazon SQS e Amazon Lightsail", false],
+            ["AWS Step Functions, Amazon DynamoDB e Amazon SNS", true],
+            ["Amazon Athena, Amazon Cognito e AWS Elastic Beanstalk", false],
+        ],
+    },
+    {
+        statement:
+            "Qual opção da AWS deve ser usada para guardar backups de dados por longo prazo e com baixo custo?",
+        explanation:
+            "A classe S3 Glacier Flexible Retrieval foi feita para arquivamento e backups de longo prazo, com custo de armazenamento muito baixo e recuperação em minutos ou horas. O Amazon RDS é um banco de dados transacional, o DataSync apenas transfere dados e os volumes do EBS custam bem mais por GB para guardar backups pouco acessados.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon Relational Database Service (Amazon RDS)", false],
+            ["S3 Glacier Flexible Retrieval", true],
+            ["AWS DataSync", false],
+            ["Amazon Elastic Block Store (Amazon EBS)", false],
+        ],
+    },
+    {
+        statement: "Qual serviço tem como finalidade PRINCIPAL o controle de versão de software?",
+        explanation:
+            "O AWS CodeCommit é um serviço gerenciado de repositórios Git privados, feito para versionar código com segurança. O CodeBuild compila o código e roda testes, o CodeDeploy automatiza implantações e a AWS CLI é a ferramenta de linha de comando para gerenciar serviços; nenhum deles é voltado a controle de versão.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS CodeBuild", false],
+            ["AWS Command Line Interface (AWS CLI)", false],
+            ["AWS CodeDeploy", false],
+            ["AWS CodeCommit", true],
+        ],
+    },
+    {
+        statement:
+            "Qual componente da infraestrutura global da AWS consiste em um ou mais data centers distintos, com energia e rede redundantes, e se conecta a outros do mesmo tipo por links de baixa latência?",
+        explanation:
+            "Uma Zona de Disponibilidade reúne um ou mais data centers com energia, rede e conectividade redundantes, ligada às outras zonas da mesma Região por links de baixa latência. A Região é a área geográfica que agrupa várias zonas, os locais de borda são pontos de presença para entrega de conteúdo e a VPC é uma rede virtual, não um componente físico.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Zona de Disponibilidade", true],
+            ["Local de borda da AWS", false],
+            ["Região da AWS", false],
+            ["Rede privada virtual (VPC)", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é um componente da infraestrutura global da AWS?",
+        explanation:
+            "As Regiões são componentes físicos da infraestrutura global da AWS, cada uma com várias Zonas de Disponibilidade isoladas entre si. Contas e unidades organizacionais servem para organizar e governar o uso da AWS, e grupos de segurança são firewalls virtuais das instâncias; nada disso faz parte da infraestrutura física.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Contas da AWS", false],
+            ["Regiões da AWS", true],
+            ["Grupos de segurança", false],
+            ["Unidades organizacionais", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai migrar suas aplicações para uma nuvem privada virtual (VPC) na AWS, e essas aplicações precisarão acessar recursos on-premises. Quais ações permitem essa conectividade? (Selecione DUAS opções.)",
+        explanation:
+            "Uma VPN Site-to-Site com um gateway privado virtual cria um túnel criptografado pela internet até a VPC, e o AWS Direct Connect oferece um link de rede privado e dedicado; os dois estendem a rede local até a AWS. O Service Catalog gerencia portfólios de produtos aprovados, o Athena consulta dados no S3 e o CloudFront é uma CDN.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            [
+                "Usar o AWS Service Catalog para listar os recursos on-premises que podem ser migrados",
+                false,
+            ],
+            [
+                "Criar uma conexão VPN entre um dispositivo on-premises e um gateway privado virtual da VPC",
+                true,
+            ],
+            [
+                "Usar o Amazon Athena para consultar os dados nos servidores de banco de dados on-premises",
+                false,
+            ],
+            [
+                "Conectar o data center on-premises da empresa à VPC por meio do AWS Direct Connect",
+                true,
+            ],
+            [
+                "Usar o Amazon CloudFront para restringir o acesso ao conteúdo estático dos servidores web on-premises",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Como os grupos do Amazon EC2 Auto Scaling ajudam a manter uma aplicação web altamente disponível?",
+        explanation:
+            "Um grupo do Auto Scaling abrange várias Zonas de Disponibilidade da mesma Região e adiciona ou substitui instâncias com falha para manter a capacidade desejada. Ele não atua entre Regiões; aproximar conteúdo dos usuários é papel do Amazon CloudFront, e distribuir requisições é função do Elastic Load Balancing.",
+        topic: "Computação",
+        options: [
+            [
+                "Adicionando automaticamente instâncias em várias Regiões da AWS conforme a demanda global",
+                false,
+            ],
+            [
+                "Adicionando ou substituindo instâncias automaticamente em várias Zonas de Disponibilidade",
+                true,
+            ],
+            [
+                "Mantendo o conteúdo estático da aplicação em locais mais próximos dos usuários finais",
+                false,
+            ],
+            [
+                "Distribuindo as requisições de entrada entre as instâncias da camada de servidores web",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS permitem estender uma arquitetura on-premises para a Nuvem AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Direct Connect cria uma conexão de rede dedicada entre o data center e a AWS, e o AWS Storage Gateway integra o armazenamento local ao armazenamento na nuvem. O EBS é armazenamento em bloco usado só dentro da AWS, o CloudFront é uma CDN e o Amazon Connect é uma central de atendimento.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon Elastic Block Store (Amazon EBS)", false],
+            ["AWS Direct Connect", true],
+            ["Amazon CloudFront", false],
+            ["AWS Storage Gateway", true],
+            ["Amazon Connect", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa pretende hospedar por conta própria um banco de dados na AWS e precisa desligá-lo todas as noites para manutenção e economia de custos, sem perder os dados. Qual opção a empresa deve usar?",
+        explanation:
+            "Os volumes do EBS são persistentes e independentes do ciclo de vida da instância, então os dados continuam lá quando a instância EC2 é interrompida à noite. O armazenamento de instância é temporário e perde os dados ao parar a instância, e Redshift e DynamoDB são serviços gerenciados, que não permitem hospedar o próprio banco.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon Redshift", false],
+            ["Amazon DynamoDB", false],
+            ["Amazon EC2 com armazenamento de instância", false],
+            ["Amazon EC2 com volumes do Amazon EBS", true],
+        ],
+    },
+    {
+        statement: "Qual serviço fornece armazenamento de objetos na AWS?",
+        explanation:
+            "O Amazon S3 é o serviço de armazenamento de objetos: cada item fica em um bucket como objeto, com dados, metadados e uma chave única. O EBS e o armazenamento de instância oferecem armazenamento em bloco para instâncias EC2 (o segundo é temporário), e o EFS é armazenamento de arquivos.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon EBS", false],
+            ["Armazenamento de instância do Amazon EC2", false],
+            ["Amazon EFS", false],
+            ["Amazon S3", true],
+        ],
+    },
+    {
+        statement:
+            "Qual classe de armazenamento do Amazon S3 é a mais indicada para dados com padrões de acesso imprevisíveis?",
+        explanation:
+            "O S3 Intelligent-Tiering move os objetos automaticamente entre níveis de acesso conforme o uso muda, sem taxa de recuperação, o que otimiza o custo quando não se sabe a frequência de acesso. O S3 Standard é caro para dados parados, o S3 Standard-IA cobra por recuperação e o S3 Glacier Flexible Retrieval serve para arquivamento com recuperação lenta.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Intelligent-Tiering", true],
+            ["S3 Glacier Flexible Retrieval", false],
+            ["S3 Standard", false],
+            ["S3 Standard-IA", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço garante que as mensagens trocadas entre componentes de software não se percam se um ou mais componentes falharem?",
+        explanation:
+            "O Amazon SQS é uma fila de mensagens gerenciada: as mensagens ficam armazenadas até que um consumidor as processe, então nada se perde se um componente estiver fora do ar. O SES envia e-mails, o Direct Connect é uma conexão de rede dedicada e o Amazon Connect é uma central de atendimento em nuvem.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon SQS", true],
+            ["Amazon SES", false],
+            ["AWS Direct Connect", false],
+            ["Amazon Connect", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem ser usados como recurso de computação? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon EC2 fornece servidores virtuais redimensionáveis e o AWS Lambda executa código sem servidor em resposta a eventos; os dois entregam capacidade de computação. A Amazon VPC é rede isolada, o CloudWatch coleta métricas e logs e o S3 armazena objetos; nenhum deles executa código.",
+        topic: "Computação",
+        options: [
+            ["Amazon VPC", false],
+            ["Amazon CloudWatch", false],
+            ["Amazon S3", false],
+            ["Amazon EC2", true],
+            ["AWS Lambda", true],
+        ],
+    },
+    {
+        statement:
+            "Sua empresa está criando uma aplicação que vai armazenar e recuperar fotos e vídeos. Qual serviço você deve recomendar como mecanismo de armazenamento subjacente?",
+        explanation:
+            "O Amazon S3 armazena qualquer volume de dados não estruturados, como fotos e vídeos, com alta durabilidade e escala praticamente ilimitada. O EBS é armazenamento em bloco anexado a instâncias, o armazenamento de instância é temporário e se perde quando a instância para, e o SQS é uma fila de mensagens, que não guarda arquivos.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon EBS", false],
+            ["Amazon SQS", false],
+            ["Amazon S3", true],
+            ["Armazenamento de instância do Amazon EC2", false],
+        ],
+    },
+    {
+        statement: "O que o Amazon ElastiCache oferece?",
+        explanation:
+            "O Amazon ElastiCache é um cache em memória gerenciado que guarda dados acessados com frequência na RAM e entrega leituras com latência de submilissegundos. Banco relacional gerenciado descreve o Amazon RDS, a loja de softwares é o AWS Marketplace e o DNS na nuvem é o Amazon Route 53.",
+        topic: "Banco de dados",
+        options: [
+            ["Um cache em memória para aplicações com grande volume de leitura", true],
+            ["Um serviço gerenciado de banco de dados relacional", false],
+            ["Uma loja on-line de softwares prontos para iniciar com poucos cliques", false],
+            ["Um sistema de nomes de domínio (DNS) na nuvem", false],
+        ],
+    },
+    {
+        statement:
+            "Você trabalha em dois projetos que exigem configurações de rede completamente diferentes. O que você deve usar na AWS para isolar os recursos e as configurações de rede de cada projeto?",
+        explanation:
+            "A Amazon VPC cria redes virtuais logicamente isoladas, cada uma com seus próprios intervalos de IP, sub-redes, tabelas de rotas e gateways, o que permite configurações de rede independentes por projeto. Gateway de internet e grupo de segurança são componentes dentro de uma VPC, e o CloudFront é uma CDN.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Um gateway de internet dedicado a cada projeto", false],
+            ["Uma nuvem privada virtual (Amazon VPC) para cada projeto", true],
+            ["Um grupo de segurança dedicado a cada projeto", false],
+            ["Uma distribuição do Amazon CloudFront dedicada a cada projeto", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização precisa analisar e processar um grande número de conjuntos de dados. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O Amazon EMR é uma plataforma gerenciada de big data que executa frameworks de processamento distribuído, como Apache Spark e Hadoop, para analisar grandes volumes de dados. O Amazon MQ é um broker de mensagens, o SNS envia notificações no modelo pub/sub e o SQS é uma fila de mensagens; nenhum deles processa dados em escala.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon EMR", true],
+            ["Amazon MQ", false],
+            ["Amazon SNS", false],
+            ["Amazon SQS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS oferece o maior nível de controle sobre a infraestrutura virtual subjacente?",
+        explanation:
+            "No Amazon EC2 o cliente escolhe o sistema operacional, o tipo de instância, a rede e o armazenamento, e pode instalar e configurar qualquer software, o que dá o maior controle sobre a infraestrutura. Redshift, DynamoDB e RDS são serviços gerenciados em que a AWS cuida da infraestrutura e esconde essas camadas do cliente.",
+        topic: "Computação",
+        options: [
+            ["Amazon Redshift", false],
+            ["Amazon DynamoDB", false],
+            ["Amazon EC2", true],
+            ["Amazon RDS", false],
+        ],
+    },
+    {
+        statement:
+            "Como parte da sua infraestrutura global, a AWS mantém um grande número de locais de borda, usados pelo Amazon CloudFront. Qual das opções a seguir NÃO é um benefício do uso desses locais de borda?",
+        explanation:
+            "Distribuir o tráfego entre várias instâncias é função do Elastic Load Balancing, não dos locais de borda. Os locais de borda guardam respostas em cache perto dos usuários, entregam conteúdo com baixa latência e também aceleram o envio de arquivos, como no S3 Transfer Acceleration e nas requisições de envio que passam pelo CloudFront.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Manter em cache as respostas mais requisitadas", false],
+            ["Agilizar o envio de arquivos pelos usuários", false],
+            ["Distribuir o tráfego entre várias instâncias", true],
+            ["Entregar conteúdo a usuários globais com baixa latência", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço permite executar aplicações em contêineres em um cluster de instâncias do Amazon EC2?",
+        explanation:
+            "O Amazon ECS é um serviço gerenciado de orquestração que executa e gerencia contêineres Docker em um cluster de instâncias EC2 ou no AWS Fargate. O AWS Glue é um serviço de integração e ETL de dados, o AWS CloudShell é um terminal no navegador e o AWS Health Dashboard informa eventos que afetam os serviços da AWS.",
+        topic: "Computação",
+        options: [
+            ["Amazon ECS", true],
+            ["AWS Glue", false],
+            ["AWS CloudShell", false],
+            ["AWS Health Dashboard", false],
+        ],
+    },
+    {
+        statement:
+            "Quais práticas ajudam a reduzir os custos do Amazon S3? (Selecione DUAS opções.)",
+        explanation:
+            "Classes como S3 Standard-IA e S3 Glacier custam menos para dados pouco acessados, então combiná-las por caso de uso e automatizar a transição com regras de ciclo de vida reduz a conta. O preço do S3 não varia por Zona de Disponibilidade, o EBS custa mais por GB provisionado e o versionamento aumenta o volume armazenado.",
+        topic: "Armazenamento",
+        options: [
+            [
+                "Criar regras de ciclo de vida que movam arquivos antigos para uma classe S3 Glacier",
+                true,
+            ],
+            ["Usar a combinação certa de classes de armazenamento para cada caso de uso", true],
+            ["Escolher a Zona de Disponibilidade certa para o bucket do S3", false],
+            ["Mover todos os dados do S3 Standard para volumes do Amazon EBS", false],
+            [
+                "Ativar o versionamento em todos os buckets para guardar as versões antigas dos arquivos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços ou recursos da AWS ajudam a manter uma arquitetura altamente disponível e tolerante a falhas? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Auto Scaling adiciona e substitui instâncias conforme a demanda ou quando alguma falha, e o Elastic Load Balancing envia o tráfego só para destinos íntegros. O Direct Connect é conectividade dedicada, o CloudFormation provisiona infraestrutura mas não reage a falhas em execução e as ACLs de rede filtram tráfego nas sub-redes.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["AWS Direct Connect", false],
+            ["AWS Auto Scaling", true],
+            ["Elastic Load Balancing", true],
+            ["AWS CloudFormation", false],
+            ["Listas de controle de acesso (ACLs) de rede", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso da AWS usa os locais de borda do Amazon CloudFront, distribuídos pelo mundo, para acelerar o envio de arquivos para o Amazon S3?",
+        explanation:
+            "O S3 Transfer Acceleration recebe os envios no local de borda mais próximo do usuário e leva os dados até o bucket pela rede global da AWS, mais rápida que a internet pública. O AWS WAF é um firewall de aplicações web, o AWS DataSync transfere dados pela rede sem usar locais de borda e a replicação entre Regiões copia objetos entre buckets.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Transfer Acceleration", true],
+            ["AWS WAF", false],
+            ["AWS DataSync", false],
+            ["S3 Cross-Region Replication", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem ser usados para melhorar o desempenho de uma aplicação global e reduzir a latência para os usuários? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Global Accelerator leva o tráfego dos usuários pela rede global da AWS até o endpoint íntegro mais próximo, e o Amazon CloudFront entrega conteúdo em cache a partir de locais de borda perto dos usuários. O KMS gerencia chaves de criptografia, o Direct Connect liga o data center à AWS e o Glue é um serviço de ETL.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Key Management Service (AWS KMS)", false],
+            ["AWS Global Accelerator", true],
+            ["AWS Direct Connect", false],
+            ["AWS Glue", false],
+            ["Amazon CloudFront", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço sem servidor (serverless) da AWS permite executar aplicações sem nenhuma carga administrativa de servidores?",
+        explanation:
+            "O AWS Lambda executa código em resposta a eventos sem que você provisione, gerencie ou escale servidores. O Amazon Lightsail oferece servidores virtuais simplificados que ainda precisam ser administrados, o Amazon RDS é um banco gerenciado baseado em instâncias e no Amazon EC2 você configura e mantém as próprias instâncias.",
+        topic: "Computação",
+        options: [
+            ["Amazon Lightsail", false],
+            ["AWS Lambda", true],
+            ["Amazon RDS", false],
+            ["Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem ser usados para armazenar arquivos de uma aplicação executada em instâncias do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon EFS é um sistema de arquivos gerenciado que várias instâncias EC2 podem montar ao mesmo tempo, e o Amazon EBS fornece volumes em bloco anexados a uma instância, onde os arquivos ficam gravados. O SNS envia notificações, o ECS orquestra contêineres e o EMR processa big data; nenhum deles é um destino para armazenar arquivos.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon EFS", true],
+            ["Amazon SNS", false],
+            ["Amazon EBS", true],
+            ["Amazon ECS", false],
+            ["Amazon EMR", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço de armazenamento as instâncias de banco de dados do Amazon RDS usam como armazenamento principal?",
+        explanation:
+            "As instâncias do Amazon RDS guardam os dados e os logs do banco em volumes do Amazon EBS, armazenamento em bloco persistente e de baixa latência. O S3 Glacier Flexible Retrieval é para arquivamento, o EFS é um sistema de arquivos compartilhado e o S3 é armazenamento de objetos acessado por API; nenhum serve de disco para o banco.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Glacier Flexible Retrieval", false],
+            ["Amazon EBS", true],
+            ["Amazon EFS", false],
+            ["Amazon S3", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está desenvolvendo uma nova aplicação baseada em microsserviços, que apresenta problemas de desempenho e latência. Qual serviço da AWS deve ser usado para investigar esses problemas?",
+        explanation:
+            "O AWS X-Ray faz rastreamento distribuído: mostra o caminho de cada requisição entre os microsserviços e ajuda a achar gargalos e a causa da latência. O AWS Config registra mudanças de configuração dos recursos, o Amazon Inspector procura vulnerabilidades e o AWS CloudTrail registra chamadas de API para auditoria.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Config", false],
+            ["AWS X-Ray", true],
+            ["Amazon Inspector", false],
+            ["AWS CloudTrail", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS foram projetados com tolerância a falhas Multi-AZ nativa, replicando os dados entre várias Zonas de Disponibilidade sem configuração adicional? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon S3 guarda os objetos de forma redundante em pelo menos três Zonas de Disponibilidade (fora as classes de uma só zona, como S3 One Zone-IA e S3 Express One Zone), e o Amazon DynamoDB replica as tabelas automaticamente entre três AZs da Região. Volumes do EBS e sistemas de arquivos do FSx for Lustre ficam em uma única AZ, e uma instância EC2 também roda em uma só AZ.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Amazon FSx for Lustre", false],
+            ["Amazon EC2", false],
+            ["Amazon S3", true],
+            ["Amazon EBS", false],
+            ["Amazon DynamoDB", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos do Amazon RDS ajudam a manter o banco de dados disponível quando a instância principal falha? (Selecione DUAS opções.)",
+        explanation:
+            "A implantação Multi-AZ mantém uma instância em espera sincronizada em outra Zona de Disponibilidade, com failover automático, e uma réplica de leitura pode ser promovida a banco independente se a principal falhar. Locais de borda servem à entrega de conteúdo, grupos de parâmetros ajustam o mecanismo e a aplicação automática de patches só o mantém atualizado.",
+        topic: "Banco de dados",
+        options: [
+            ["Grupos de parâmetros do banco", false],
+            ["Implantação Multi-AZ", true],
+            ["Aplicação automática de patches", false],
+            ["Réplicas de leitura", true],
+            ["Locais de borda", false],
+        ],
+    },
+    {
+        statement:
+            "Uma desenvolvedora implantou uma aplicação na Região us-west-1 (Norte da Califórnia) e percebeu que cerca de 30% do tráfego vem da Ásia. Sem tirar a aplicação dessa Região, o que ela pode fazer para reduzir a latência dos usuários asiáticos?",
+        explanation:
+            "O Amazon CloudFront guarda o conteúdo em cache em locais de borda próximos aos usuários da Ásia, que passam a ser atendidos perto de onde estão, sem mover a origem. Várias Zonas de Disponibilidade aumentam a disponibilidade, mas ficam na mesma Região; instâncias maiores e sub-redes privadas não encurtam a distância até a Ásia.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            [
+                "Replicar os recursos atuais em várias Zonas de Disponibilidade da mesma Região",
+                false,
+            ],
+            ["Trocar as instâncias por um tipo de instância com mais CPU e memória", false],
+            ["Mover o banco de dados da aplicação para uma sub-rede privada", false],
+            ["Usar o Amazon CloudFront com cache em locais de borda na Ásia", true],
+        ],
+    },
+    {
+        statement:
+            "As classes de armazenamento S3 Glacier são indicadas para guardar quais tipos de dados? (Selecione DUAS opções.)",
+        explanation:
+            "As classes S3 Glacier custam pouco para dados raramente acessados que precisam ser mantidos por muito tempo, como arquivamento ativo e dados históricos guardados para análises futuras. Arquivos de site acessados o tempo todo pedem uma classe de acesso frequente, registros de banco em uso exigem RDS ou DynamoDB e dados em cache ficam no ElastiCache.",
+        topic: "Armazenamento",
+        options: [
+            ["Arquivamento ativo de dados que ainda são consultados de vez em quando", true],
+            ["Dados analíticos históricos guardados por anos para análises futuras", true],
+            ["Arquivos de um site dinâmico que são acessados o tempo todo pelos usuários", false],
+            ["Registros de um banco de dados transacional em uso ativo pela aplicação", false],
+            ["Dados em cache que a aplicação precisa ler em submilissegundos", false],
+        ],
+    },
+    {
+        statement: "O que o AWS Elastic Beanstalk oferece?",
+        explanation:
+            "O AWS Elastic Beanstalk é uma plataforma como serviço (PaaS): você envia o código e ele cuida da implantação, do provisionamento de capacidade, do balanceamento de carga, do Auto Scaling e do monitoramento. O mecanismo sem servidor do ECS é o AWS Fargate, o armazenamento de arquivos escalável é o Amazon EFS e o NoSQL gerenciado é o DynamoDB.",
+        topic: "Computação",
+        options: [
+            ["Uma solução PaaS que automatiza a implantação de aplicações", true],
+            ["Um mecanismo de computação sem servidor para o Amazon ECS", false],
+            [
+                "Uma solução escalável de armazenamento de arquivos para a AWS e servidores locais",
+                false,
+            ],
+            ["Um serviço de banco de dados NoSQL totalmente gerenciado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa implantou uma nova aplicação web em várias instâncias do Amazon EC2 e precisa distribuir o tráfego HTTP de entrada entre elas, encaminhando cada requisição conforme o caminho da URL. O que a empresa deve usar?",
+        explanation:
+            "O Application Load Balancer atua na camada 7 e distribui o tráfego HTTP e HTTPS entre as instâncias com regras por caminho da URL ou cabeçalho de host. A recuperação automática restaura uma instância com falha, o Auto Scaling ajusta a quantidade de instâncias e o Network Load Balancer atua na camada 4, sem ler o caminho da URL.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Recuperação automática do Amazon EC2", false],
+            ["Amazon EC2 Auto Scaling", false],
+            ["Network Load Balancer", false],
+            ["Application Load Balancer", true],
+        ],
+    },
+    {
+        statement:
+            "Um cliente passou muito tempo configurando uma instância do Amazon EC2 recém-implantada. Com o aumento da carga de trabalho, ele decidiu provisionar outra instância com configuração idêntica. Como ele pode fazer isso?",
+        explanation:
+            "Uma AMI criada a partir da instância configurada guarda o sistema operacional, os softwares e as configurações, e serve de modelo para lançar instâncias idênticas. O AWS Config avalia a conformidade das configurações e não gera imagens, o snapshot do EBS copia só um volume e grupos de segurança são regras de firewall, não a configuração do servidor.",
+        topic: "Computação",
+        options: [
+            [
+                "Criando um modelo do AWS Config a partir da instância antiga e lançando a nova com ele",
+                false,
+            ],
+            ["Criando um snapshot do Amazon EBS a partir da instância antiga", false],
+            ["Copiando os grupos de segurança da instância antiga para uma instância nova", false],
+            [
+                "Criando uma AMI a partir da instância antiga e lançando a nova instância com ela",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais vantagens o Amazon Relational Database Service (Amazon RDS) oferece? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon RDS reduz a carga administrativa ao automatizar backups, patches e failover, e permite redimensionar a capacidade de computação da instância quando a carga muda. O controle total do host é característica do EC2, a troca de tipo de instância no RDS é uma modificação feita pelo cliente, e documentos e chave-valor são modelos do DynamoDB.",
+        topic: "Banco de dados",
+        options: [
+            ["Menor carga administrativa na operação do banco", true],
+            ["Controle total sobre o host subjacente", false],
+            ["Capacidade de computação redimensionável", true],
+            [
+                "Troca automática para tipos de instância maiores ou menores conforme a demanda",
+                false,
+            ],
+            ["Suporte a estruturas de dados de documentos e chave-valor", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS mostra o status atual de todos os serviços da AWS em todas as Regiões?",
+        explanation:
+            "A página de integridade dos serviços do AWS Health Dashboard mostra o status operacional de todos os serviços da AWS em todas as Regiões, e a visão da conta avisa sobre eventos que afetam os seus recursos. O Service Catalog gerencia catálogos de produtos aprovados, o console é só a interface web e o CloudWatch monitora os seus próprios recursos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Service Catalog", false],
+            ["Console de Gerenciamento da AWS", false],
+            ["Amazon CloudWatch", false],
+            ["AWS Health Dashboard", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço ou recurso da AWS permite chamar os serviços da AWS a partir de diferentes linguagens de programação?",
+        explanation:
+            "Os AWS SDKs oferecem bibliotecas para linguagens como Python, Java, JavaScript e .NET, que permitem chamar os serviços da AWS direto do código da aplicação. A AWS CLI usa comandos no terminal, o AWS CodeDeploy automatiza implantações e o Console de Gerenciamento é a interface gráfica no navegador.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS SDKs (kits de desenvolvimento)", true],
+            ["Interface de linha de comando da AWS (AWS CLI)", false],
+            ["AWS CodeDeploy", false],
+            ["Console de Gerenciamento da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Empresas de desenvolvimento de aplicações migram para a AWS para reduzir o tempo de lançamento e aumentar a satisfação dos clientes. Quais ferramentas de automação da AWS ajudam a implantar aplicações mais rápido? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CloudFormation implanta a infraestrutura automaticamente a partir de modelos de código, e o AWS Elastic Beanstalk implanta a aplicação a partir do código enviado, cuidando da capacidade e do balanceamento. O Application Migration Service faz migrações lift and shift de servidores, o IAM controla acessos e o Macie encontra dados sensíveis no S3.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS CloudFormation", true],
+            ["AWS Application Migration Service", false],
+            ["AWS Identity and Access Management (IAM)", false],
+            ["AWS Elastic Beanstalk", true],
+            ["Amazon Macie", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS escalam automaticamente, sem nenhuma intervenção sua? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon S3 absorve qualquer volume de dados e taxa de requisições sem ajuste manual, e o AWS Lambda aumenta sozinho as execuções simultâneas conforme chegam eventos. O EC2 só escala se você configurar o Auto Scaling, os planos do Lightsail têm capacidade fixa e um volume do EBS tem tamanho provisionado que só muda se você alterar.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Amazon EC2", false],
+            ["Amazon S3", true],
+            ["AWS Lambda", true],
+            ["Amazon Lightsail", false],
+            ["Amazon EBS", false],
+        ],
+    },
+    {
+        statement: "Como o Elastic Load Balancing melhora a confiabilidade de uma aplicação?",
+        explanation:
+            "O Elastic Load Balancing faz verificações de integridade nos destinos registrados e só encaminha requisições para os que respondem bem, então instâncias com falha deixam de receber tráfego. Ele não distribui tráfego entre buckets do S3, não replica dados entre AZs e não cria réplicas de leitura, que são recurso do Amazon RDS.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Distribuindo o tráfego entre vários buckets do Amazon S3", false],
+            ["Replicando os dados em várias Zonas de Disponibilidade", false],
+            ["Criando réplicas de leitura do banco de dados", false],
+            ["Garantindo que só destinos íntegros recebam tráfego", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa planeja migrar uma grande quantidade de dados arquivados para a AWS. Os dados precisam ser mantidos por 5 anos e devem poder ser recuperados em até 5 horas após a solicitação. Qual é a opção de armazenamento mais econômica?",
+        explanation:
+            "O S3 Glacier Flexible Retrieval tem armazenamento de baixo custo e recuperação padrão de 3 a 5 horas, o que atende ao prazo. O S3 Glacier Deep Archive é mais barato, mas a recuperação padrão leva até 12 horas; o S3 Standard e o Amazon EFS atendem ao prazo, mas custam bem mais para guardar dados arquivados por anos.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Glacier Flexible Retrieval", true],
+            ["S3 Glacier Deep Archive", false],
+            ["S3 Standard", false],
+            ["Amazon Elastic File System (Amazon EFS)", false],
+        ],
+    },
+    {
+        statement: "Para quais finalidades o Amazon S3 pode ser usado? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon S3 pode hospedar sites estáticos servindo HTML, CSS e JavaScript direto do bucket e é uma origem comum para o CloudFront entregar mídia pelos locais de borda. Sites com uso intenso de CPU pedem computação como o EC2, volume de inicialização é papel do EBS e processamento de fluxos de dados é função do Amazon Kinesis.",
+        topic: "Armazenamento",
+        options: [
+            ["Hospedagem de sites estáticos com HTML, CSS e JavaScript", true],
+            ["Hospedagem de sites que exigem uso intenso e contínuo de CPU", false],
+            ["Volume de inicialização para instâncias do Amazon EC2", false],
+            ["Origem de mídia para distribuições do Amazon CloudFront", true],
+            ["Processamento de fluxos de dados em qualquer escala", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa planeja migrar para a AWS um banco de dados com alta atividade de leitura e gravação. Qual é a opção de armazenamento mais adequada?",
+        explanation:
+            "O Amazon EBS oferece volumes de armazenamento em bloco anexados a instâncias EC2, com a baixa latência de E/S que bancos com muita leitura e gravação exigem. O Storage Gateway conecta ambientes on-premises à nuvem, o S3 é armazenamento de objetos e o S3 Glacier Deep Archive serve para arquivamento de longo prazo.",
+        topic: "Armazenamento",
+        options: [
+            ["AWS Storage Gateway", false],
+            ["Amazon S3", false],
+            ["Amazon EBS", true],
+            ["Amazon S3 Glacier Deep Archive", false],
+        ],
+    },
+    {
+        statement: "O que o AWS Service Catalog oferece às organizações?",
+        explanation:
+            "O AWS Service Catalog permite criar e gerenciar catálogos de serviços de TI aprovados, padronizando a governança e o autoatendimento. Descrições e casos de uso estão na documentação da AWS, explorar catálogos de software lembra o AWS Marketplace e usar linguagens de programação para definir infraestrutura é o AWS CDK.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Permite encontrar rapidamente descrições e casos de uso dos serviços da AWS", false],
+            ["Permite explorar os diferentes catálogos de serviços oferecidos pela AWS", false],
+            ["Simplifica a organização e a governança de serviços de TI comumente usados", true],
+            ["Permite implantar infraestrutura usando linguagens de programação conhecidas", false],
+        ],
+    },
+    {
+        statement:
+            "Quais fatores devem ser considerados ao escolher a tecnologia de banco de dados mais adequada para uma carga de trabalho? (Selecione DUAS opções.)",
+        explanation:
+            "O volume de leituras e gravações por segundo define a vazão necessária, e a natureza das consultas indica se o melhor é um banco relacional (JOINs complexos) ou NoSQL (buscas por chave). Zonas de Disponibilidade tratam de alta disponibilidade, soberania dos dados influencia a escolha da Região e usuários do IAM tratam de acesso.",
+        topic: "Banco de dados",
+        options: [
+            ["A quantidade de Zonas de Disponibilidade da Região", false],
+            ["Os requisitos de soberania dos dados", false],
+            ["O número de leituras e gravações por segundo", true],
+            ["A natureza das consultas que serão executadas", true],
+            ["O número de usuários do IAM da conta da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual das opções a seguir NÃO é uma característica do Amazon Elastic Compute Cloud (Amazon EC2)?",
+        explanation:
+            "O Amazon EC2 fornece servidores virtuais cujo sistema operacional e software ficam sob gestão do cliente, então é um serviço baseado em servidor, e não serverless como o AWS Lambda. Eliminar o investimento inicial em hardware, iniciar quantos servidores forem necessários e escalar a capacidade são características reais do EC2.",
+        topic: "Computação",
+        options: [
+            ["O Amazon EC2 é considerado um serviço sem servidor (serverless)", true],
+            ["O Amazon EC2 elimina a necessidade de investir em hardware antecipadamente", false],
+            ["O Amazon EC2 permite iniciar quantos servidores virtuais forem necessários", false],
+            ["O Amazon EC2 oferece capacidade de computação escalável", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço de computação da AWS executa código somente quando é acionado por eventos?",
+        explanation:
+            "O AWS Lambda é o serviço de computação sem servidor que executa código em resposta a eventos, como uma requisição HTTP ou o upload de um arquivo, e cobra só pelo tempo de execução. Amazon Lightsail, AWS Elastic Beanstalk e Amazon EC2 mantêm servidores em funcionamento contínuo, mesmo sem eventos.",
+        topic: "Computação",
+        options: [
+            ["AWS Lambda", true],
+            ["Amazon Lightsail", false],
+            ["AWS Elastic Beanstalk", false],
+            ["Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Assim como os fornecedores tradicionais de TI, a AWS oferece uma grande variedade de servidores virtuais para atender às necessidades dos clientes. Como esses servidores virtuais são chamados na AWS?",
+        explanation:
+            "Na AWS, os servidores virtuais são as instâncias do Amazon EC2, que oferecem capacidade de computação redimensionável. Snapshots do EBS são cópias pontuais de volumes, a VPC é uma rede virtual isolada e uma AMI é o modelo usado para iniciar instâncias, e não o servidor em si.",
+        topic: "Computação",
+        options: [
+            ["Snapshots do Amazon EBS", false],
+            ["Amazon VPC", false],
+            ["Imagens de máquina da Amazon (AMIs)", false],
+            ["Instâncias do Amazon EC2", true],
+        ],
+    },
+    {
+        statement: "Quais são os benefícios de usar o Amazon DynamoDB? (Selecione DUAS opções.)",
+        explanation:
+            "O DynamoDB é um banco NoSQL sem servidor que ajusta automaticamente a vazão conforme o tráfego e mantém latência de milissegundos de um dígito em qualquer escala. Ele não tem instâncias para redimensionar, não é relacional e não executa mecanismos de terceiros como CouchDB ou MongoDB.",
+        topic: "Banco de dados",
+        options: [
+            ["Escala automaticamente para atender à vazão de leitura e gravação", true],
+            ["Oferece instâncias redimensionáveis que acompanham a demanda atual", false],
+            ["Suporta modelos de dados relacionais e não relacionais na mesma tabela", false],
+            ["Oferece latência extremamente baixa, de milissegundos de um dígito", true],
+            ["Suporta mecanismos NoSQL populares, como CouchDB e MongoDB", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS pode ser usado para enviar mensagens de texto (SMS) promocionais para clientes em diversos países?",
+        explanation:
+            "O Amazon SNS envia notificações por SMS, e-mail e push para assinantes e usuários finais em diversos países, inclusive mensagens promocionais. O Amazon SES envia apenas e-mails, o Amazon MQ é um broker de mensagens entre aplicações e o Amazon SQS é uma fila para desacoplar componentes.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon SES", false],
+            ["Amazon MQ", false],
+            ["Amazon SNS", true],
+            ["Amazon SQS", false],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir permitem criar novas instâncias do Amazon RDS? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CloudFormation cria instâncias do RDS a partir de modelos de infraestrutura como código, e o Console de Gerenciamento da AWS permite criá-las pela interface gráfica. O CodeDeploy implanta código de aplicação, o CloudTrail só registra as chamadas de API e o AWS DMS migra dados para um banco que já existe.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS CodeDeploy", false],
+            ["AWS CloudTrail", false],
+            ["AWS CloudFormation", true],
+            ["AWS Database Migration Service (AWS DMS)", false],
+            ["Console de Gerenciamento da AWS", true],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso do Amazon RDS permite tirar parte da carga de leitura da instância principal do banco de dados?",
+        explanation:
+            "As réplicas de leitura do Amazon RDS são cópias somente leitura que atendem consultas e aliviam a instância principal. Snapshots e backups automatizados servem para recuperar dados, e a instância em espera de uma implantação Multi-AZ existe para failover e não atende leituras.",
+        topic: "Banco de dados",
+        options: [
+            ["Snapshots do banco de dados", false],
+            ["Implantação Multi-AZ com uma instância em espera", false],
+            ["Backups automatizados", false],
+            ["Réplicas de leitura", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa hospeda uma aplicação web em uma única instância do Amazon EC2, que chega perto de 100% de uso de CPU nos horários de pico. Em vez de aumentar o servidor verticalmente, a empresa decidiu executar três instâncias EC2 em paralelo e dividir o tráfego entre elas. Qual serviço da AWS deve ser usado para distribuir o tráfego de forma equilibrada?",
+        explanation:
+            "O Application Load Balancer distribui as requisições HTTP e HTTPS entre várias instâncias EC2 saudáveis, equilibrando a carga. O Global Accelerator direciona usuários globais pela rede da AWS, o CloudFront entrega conteúdo em cache nos locais de borda e o Auto Scaling ajusta a quantidade de instâncias, sem distribuir o tráfego.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Global Accelerator", false],
+            ["Application Load Balancer", true],
+            ["Amazon CloudFront", false],
+            ["Grupo do Amazon EC2 Auto Scaling", false],
+        ],
+    },
+    {
+        statement:
+            "Qual abordagem ajuda a eliminar o erro humano e a automatizar a criação e a atualização do ambiente na AWS?",
+        explanation:
+            "Com infraestrutura como código, ferramentas como o AWS CloudFormation criam e atualizam recursos a partir de modelos, de forma repetível e sem passos manuais. Testes automatizados validam código de aplicação, o CodeDeploy só implanta aplicações e um host dedicado muda o isolamento físico, sem automatizar nada.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Usar ferramentas de automação de testes de software", false],
+            ["Usar o AWS CodeDeploy para criar e automatizar o ambiente na AWS", false],
+            ["Usar código para provisionar e operar a infraestrutura na AWS", true],
+            ["Migrar todas as aplicações para um host dedicado", false],
+        ],
+    },
+    {
+        statement:
+            "Ao planejar uma nova implantação, uma equipe precisa escolher a Região da AWS que vai hospedar os recursos. Quais fatores devem ser considerados? (Selecione DUAS opções.)",
+        explanation:
+            "A soberania dos dados pode exigir que as informações fiquem em determinado país, e os preços dos serviços variam entre Regiões. Todas as Regiões seguem o mesmo padrão de segurança, a quantidade de VPCs é decidida depois da escolha e a conta da AWS é global, sem vínculo com uma Região.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["O nível de segurança oferecido pela Região", false],
+            ["Os requisitos de soberania dos dados", true],
+            ["O custo dos serviços na Região", true],
+            ["O número planejado de VPCs", false],
+            ["A Região em que a conta da AWS foi criada", false],
+        ],
+    },
+    {
+        statement: "Qual é uma vantagem de usar grupos do Amazon EC2 Auto Scaling?",
+        explanation:
+            "Um grupo do Auto Scaling mantém e ajusta a quantidade de instâncias EC2 distribuídas em várias Zonas de Disponibilidade, o que aumenta a disponibilidade e a tolerância a falhas. Cache em locais de borda é o CloudFront, o grupo atua dentro de uma única Região e distribuir tráfego é papel do Elastic Load Balancing.",
+        topic: "Computação",
+        options: [
+            ["Armazena respostas em cache nos locais de borda para reduzir a latência", false],
+            [
+                "Escala instâncias EC2 em várias Zonas de Disponibilidade, aumentando a tolerância a falhas",
+                true,
+            ],
+            [
+                "Escala instâncias EC2 em várias Regiões para reduzir a latência de usuários globais",
+                false,
+            ],
+            [
+                "Distribui o tráfego da aplicação entre várias Zonas de Disponibilidade para melhorar o desempenho",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer estender o armazenamento do seu data center para a AWS de forma econômica, dando às aplicações locais acesso ao armazenamento na nuvem. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O AWS Storage Gateway é um serviço de armazenamento híbrido que dá às aplicações on-premises acesso ao armazenamento na AWS, estendendo a capacidade local a baixo custo. O Transfer Family e o DataSync apenas movem arquivos entre ambientes, e os volumes do Amazon EBS só podem ser anexados a instâncias EC2.",
+        topic: "Armazenamento",
+        options: [
+            ["AWS Transfer Family", false],
+            ["AWS Storage Gateway", true],
+            ["AWS DataSync", false],
+            ["Amazon EBS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando uma plataforma de armazenamento em nuvem para seus clientes e precisa de um serviço cuja capacidade cresça automaticamente, com o menor custo possível. Qual serviço de armazenamento da AWS deve ser usado?",
+        explanation:
+            "O Amazon S3 oferece armazenamento de objetos praticamente ilimitado, que cresce automaticamente e cobra apenas pelo que está armazenado. Volumes do EBS e sistemas do FSx for Windows File Server têm capacidade provisionada, e o Storage Gateway conecta ambientes on-premises à nuvem, sem servir de base para a plataforma.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon S3", true],
+            ["Amazon EBS", false],
+            ["Amazon FSx for Windows File Server", false],
+            ["AWS Storage Gateway", false],
+        ],
+    },
+    {
+        statement:
+            "Quais das ofertas da AWS a seguir são serviços sem servidor (serverless)? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Lambda executa código sem servidores para provisionar, e o Amazon DynamoDB é um banco NoSQL sem servidor que escala sozinho. No Amazon EC2 o cliente gerencia as instâncias, o Elastic Beanstalk cria instâncias EC2 para a aplicação e o RDS for MySQL roda em classes de instância escolhidas pelo cliente.",
+        topic: "Computação",
+        options: [
+            ["Amazon EC2", false],
+            ["AWS Lambda", true],
+            ["Amazon DynamoDB", true],
+            ["AWS Elastic Beanstalk", false],
+            ["Amazon RDS for MySQL", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS permite automatizar a configuração, o gerenciamento e a aplicação de patches em instâncias do Amazon EC2 em grande escala?",
+        explanation:
+            "O AWS Systems Manager automatiza tarefas operacionais em frotas de instâncias, como gerenciamento de configuração, aplicação de patches (Patch Manager) e execução de comandos, sem acessar cada servidor. O AWS Config registra e avalia configurações, o Auto Scaling ajusta a quantidade de instâncias e o CloudFormation provisiona recursos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Config", false],
+            ["AWS Systems Manager", true],
+            ["Amazon EC2 Auto Scaling", false],
+            ["AWS CloudFormation", false],
+        ],
+    },
+    {
+        statement:
+            "Um cliente quer armazenar objetos no ambiente da AWS e permitir que eles sejam baixados pela internet. Qual serviço da AWS pode ser usado para isso?",
+        explanation:
+            "O Amazon S3 armazena objetos que podem ser disponibilizados para download pela internet por meio de URLs, controlados por políticas de acesso ou URLs pré-assinadas. Volumes do EBS e o armazenamento de instância são discos de instâncias EC2, e o EFS é um sistema de arquivos montado via NFS, sem acesso público direto.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon EBS", false],
+            ["Amazon EFS", false],
+            ["Amazon S3", true],
+            ["Armazenamento de instância do EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer acompanhar métricas das requisições HTTP e HTTPS feitas a uma distribuição do Amazon CloudFront, como o total de requisições e a taxa de erros, e criar alarmes com base nelas. Qual serviço deve ser usado?",
+        explanation:
+            "O Amazon CloudWatch recebe as métricas do CloudFront, como número de requisições e taxas de erro 4xx e 5xx, e permite criar painéis e alarmes. O AWS WAF filtra e bloqueia requisições conforme regras, o AWS Trusted Advisor recomenda boas práticas e o AWS CloudTrail registra chamadas de API.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS WAF", false],
+            ["Amazon CloudWatch", true],
+            ["AWS Trusted Advisor", false],
+            ["AWS CloudTrail", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização tem uma aplicação legada monolítica e quer desacoplar seus componentes: cada parte deve enviar mensagens para uma fila, onde elas ficam armazenadas até que outro componente as processe no próprio ritmo. Qual serviço da AWS atende a esse requisito?",
+        explanation:
+            "O Amazon SQS é uma fila de mensagens gerenciada: as mensagens ficam armazenadas até serem consumidas, o que permite que os componentes funcionem de forma independente. O SNS envia cada mensagem a vários assinantes (pub/sub), o EventBridge roteia eventos por regras e o Step Functions orquestra fluxos de trabalho.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon SQS", true],
+            ["Amazon SNS", false],
+            ["Amazon EventBridge", false],
+            ["AWS Step Functions", false],
+        ],
+    },
+    {
+        statement:
+            "As Zonas de Disponibilidade de uma Região são interligadas por conexões de baixa latência. Qual é um benefício dessas conexões?",
+        explanation:
+            "A baixa latência entre as Zonas de Disponibilidade permite replicar dados de forma síncrona, confirmando a gravação em outra zona sem prejudicar o desempenho. Conexão privada com o data center é o AWS Direct Connect, alta disponibilidade global exige várias Regiões e provisionar recursos automaticamente é papel do Auto Scaling.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Criar uma conexão privada com o data center da empresa", false],
+            ["Alcançar alta disponibilidade em escala global", false],
+            ["Automatizar o provisionamento de novos recursos de computação", false],
+            ["Tornar possível a replicação síncrona dos dados", true],
+        ],
+    },
+    {
+        statement:
+            "Quais afirmações sobre as linguagens de programação compatíveis com o AWS Lambda são verdadeiras? (Selecione DUAS opções.)",
+        explanation:
+            "O Lambda tem runtimes nativos para linguagens como Node.js, Python, Java, .NET e Ruby, e aceita outras linguagens por meio de runtimes personalizados que usam a Runtime API. Ele não depende de plugins de conversão, não é uma linguagem e sua função principal é justamente executar código.",
+        topic: "Computação",
+        options: [
+            [
+                "O Lambda só aceita Python e Node.js, mas plugins de terceiros convertem outras linguagens",
+                false,
+            ],
+            [
+                "O Lambda oferece suporte nativo a várias linguagens, como Node.js, Python e Java",
+                true,
+            ],
+            [
+                "O Lambda é a linguagem de programação proprietária da AWS para microsserviços",
+                false,
+            ],
+            [
+                "O Lambda não trabalha com linguagens de programação, pois é um serviço sem servidor",
+                false,
+            ],
+            [
+                "O Lambda aceita qualquer linguagem por meio de um runtime personalizado (Runtime API)",
+                true,
+            ],
+        ],
+    },
+    {
+        statement: "O que o AWS X-Ray permite fazer? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS X-Ray rastreia as requisições enquanto elas passam pelos componentes da aplicação, mostrando gargalos e erros, o que ajuda a analisar e melhorar o desempenho. Desacoplar componentes é uma decisão de arquitetura, com filas como o SQS, e implantar aplicações em instâncias EC2 ou em servidores on-premises é papel do AWS CodeDeploy.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Desacoplar automaticamente os componentes de uma aplicação monolítica", false],
+            ["Rastrear requisições para identificar problemas na aplicação", true],
+            ["Ajudar a analisar e melhorar o desempenho da aplicação", true],
+            ["Implantar aplicações em instâncias do Amazon EC2", false],
+            ["Implantar aplicações em servidores on-premises", false],
+        ],
+    },
+    {
+        statement:
+            "Qual afirmação sobre as Zonas de Disponibilidade e os locais de borda da AWS é verdadeira?",
+        explanation:
+            "Uma Zona de Disponibilidade é um conjunto isolado de data centers dentro de uma Região, enquanto os locais de borda formam uma rede separada, espalhada por mais de cem cidades e usada por serviços como o CloudFront. Locais de borda não ficam dentro de Zonas de Disponibilidade, nem o contrário, e área geográfica com várias zonas é a definição de Região.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            [
+                "Os locais de borda ficam em Zonas de Disponibilidade separadas pelo mundo para atender clientes globais",
+                false,
+            ],
+            [
+                "Uma Zona de Disponibilidade fica dentro de um local de borda para distribuir conteúdo com baixa latência",
+                false,
+            ],
+            [
+                "Uma Zona de Disponibilidade é uma área geográfica com vários locais de borda isolados",
+                false,
+            ],
+            [
+                "Zonas de Disponibilidade ficam dentro de Regiões, e locais de borda existem em várias cidades do mundo",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um cliente planeja migrar seus bancos de dados Microsoft SQL Server para a AWS. Quais serviços da AWS ele pode usar para executar o SQL Server? (Selecione DUAS opções.)",
+        explanation:
+            "O SQL Server pode rodar no Amazon EC2, instalado e gerenciado pelo cliente, ou no Amazon RDS for SQL Server, com patches e backups gerenciados pela AWS. O DynamoDB é um banco NoSQL próprio da AWS, o AWS DMS apenas migra os dados e o Lambda executa funções orientadas a eventos, sem hospedar bancos.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon DynamoDB", false],
+            ["Amazon EC2", true],
+            ["Amazon RDS", true],
+            ["AWS Database Migration Service (AWS DMS)", false],
+            ["AWS Lambda", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS monitora a disponibilidade de endpoints e desvia automaticamente o tráfego dos recursos que apresentam falha?",
+        explanation:
+            "O Amazon Route 53 faz verificações de integridade (health checks) nos endpoints e, com o roteamento de failover, deixa de direcionar usuários para os recursos que falharam. O CloudWatch monitora métricas mas não roteia tráfego, o Direct Connect cria um link dedicado com o data center e o API Gateway publica APIs.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Direct Connect", false],
+            ["Amazon Route 53", true],
+            ["Amazon CloudWatch", false],
+            ["Amazon API Gateway", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está desenvolvendo uma aplicação que vai usar reconhecimento facial para marcar pessoas em fotos automaticamente. Qual serviço da AWS deve ser usado para o reconhecimento facial?",
+        explanation:
+            "O Amazon Rekognition analisa imagens e vídeos com deep learning e oferece detecção e comparação de rostos, o que permite marcar pessoas em fotos automaticamente. O Comprehend analisa textos, o Textract extrai texto de documentos digitalizados e o Personalize gera recomendações personalizadas.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Comprehend", false],
+            ["Amazon Textract", false],
+            ["Amazon Personalize", false],
+            ["Amazon Rekognition", true],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir são exemplos de bancos de dados gerenciados pela AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Neptune (grafos) e o Amazon RDS for MySQL (relacional) são bancos gerenciados: a AWS cuida de provisionamento, patches, backups e recuperação. SQL Server ou MySQL instalados no EC2 e MongoDB em contêineres no EKS são bancos autogerenciados, em que essas tarefas ficam com o cliente.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon Neptune", true],
+            ["Microsoft SQL Server no EC2", false],
+            ["MySQL no EC2", false],
+            ["Amazon RDS for MySQL", true],
+            ["MongoDB em contêineres no Amazon EKS", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são os principais benefícios de usar o AWS CloudFormation? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS CloudFormation permite descrever toda a infraestrutura em um modelo de texto (JSON ou YAML) e provisionar e atualizar os recursos de forma repetível e controlada. Implantar aplicações sem cuidar da infraestrutura é o Elastic Beanstalk, permissões do IAM continuam definidas pelo cliente e compilar código é papel do AWS CodeBuild.",
+        topic: "Ferramentas e suporte",
+        options: [
+            [
+                "Permite implantar aplicações sem se preocupar com a infraestrutura subjacente",
+                false,
+            ],
+            ["Aplica automaticamente recursos avançados de segurança do IAM", false],
+            ["Automatiza o provisionamento e a atualização da infraestrutura com segurança", true],
+            ["Permite modelar toda a infraestrutura em um simples arquivo de texto", true],
+            ["Compila e gera o build do código da aplicação rapidamente", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa hospeda cargas de trabalho críticas em uma Região da AWS. Para evitar perda de dados e garantir a continuidade do negócio, ela precisa manter uma cópia espelhada do ambiente atual em outra Região, e a política interna exige que esse ambiente de contingência fique disponível em minutos se a Região principal sofrer uma interrupção. Qual serviço da AWS atende a esses requisitos?",
+        explanation:
+            "O AWS Elastic Disaster Recovery replica continuamente os servidores para uma área de preparação em outra Região e inicia instâncias prontas em minutos durante uma interrupção. O Application Migration Service migra servidores, o AWS Backup restaura cópias de backup, sem ambiente em espera, e o DataSync só transfere arquivos.",
+        topic: "Armazenamento",
+        options: [
+            ["AWS Elastic Disaster Recovery", true],
+            ["AWS Application Migration Service", false],
+            ["AWS Backup", false],
+            ["AWS DataSync", false],
+        ],
+    },
+    {
+        statement:
+            "Qual classe de armazenamento do Amazon S3 é a mais adequada para hospedar os arquivos estáticos de um site de e-commerce popular, com padrão de acesso estável e frequente?",
+        explanation:
+            "O S3 Standard é feito para dados acessados com frequência, com baixa latência e sem taxa de recuperação, ideal para arquivos de um site muito visitado. O Standard-IA cobra por recuperação, o Intelligent-Tiering compensa quando o padrão de acesso é imprevisível e o Glacier Deep Archive é para arquivamento raramente acessado.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Standard-IA", false],
+            ["S3 Intelligent-Tiering", false],
+            ["S3 Glacier Deep Archive", false],
+            ["S3 Standard", true],
+        ],
+    },
+    {
+        statement: "Qual das afirmações a seguir sobre a Amazon VPC é verdadeira?",
+        explanation:
+            "Na Amazon VPC, o cliente controla todo o ambiente de rede virtual: intervalos de IP, sub-redes, tabelas de rotas, gateways e grupos de segurança. Controlar o acesso de usuários aos recursos é papel do IAM, a configuração da VPC é responsabilidade do cliente e revisar a arquitetura é função da AWS Well-Architected Tool.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            [
+                "A Amazon VPC permite controlar como os usuários interagem com todos os outros recursos da AWS",
+                false,
+            ],
+            [
+                "Os clientes da AWS têm controle total sobre o ambiente de rede virtual da sua Amazon VPC",
+                true,
+            ],
+            [
+                "A AWS é responsável por todos os detalhes de gerenciamento e configuração da Amazon VPC",
+                false,
+            ],
+            [
+                "A Amazon VPC ajuda os clientes a revisar a arquitetura na AWS e adotar boas práticas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir são baseadas em servidores, com instâncias que o cliente escolhe e dimensiona? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon RDS for PostgreSQL roda em classes de instância escolhidas pelo cliente, e os clusters do Amazon EMR são formados por instâncias EC2 para processar big data. Tabelas do DynamoDB, funções do Lambda e tarefas do Fargate são sem servidor: a AWS provisiona e gerencia toda a capacidade.",
+        topic: "Computação",
+        options: [
+            ["Amazon RDS for PostgreSQL", true],
+            ["Tabelas do Amazon DynamoDB", false],
+            ["Funções do AWS Lambda", false],
+            ["Tarefas do AWS Fargate", false],
+            ["Clusters do Amazon EMR", true],
+        ],
+    },
+    {
+        statement: "Quais são casos de uso do Amazon EMR? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon EMR é uma plataforma gerenciada de clusters para executar frameworks de big data como Apache Spark e Hadoop, processando e analisando grandes volumes de dados. Backup barato é caso das classes S3 Glacier, mover exabytes do data center cabe a serviços de transferência de dados e contêineres Docker ficam com o Amazon ECS.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Fazer backup de grandes volumes de dados a um custo muito baixo", false],
+            ["Mover dados em escala de exabytes de data centers on-premises para a AWS", false],
+            ["Analisar e processar volumes muito grandes de dados em tempo hábil", true],
+            ["Executar e escalar Apache Spark, Hadoop e outros frameworks de big data", true],
+            ["Executar e gerenciar com facilidade contêineres Docker", false],
+        ],
+    },
+    {
+        statement:
+            "No Amazon RDS, quais tarefas a AWS executa em nome do cliente? (Selecione DUAS opções.)",
+        explanation:
+            "No Amazon RDS, a AWS provisiona e configura a instância do banco e cuida do sistema operacional, incluindo patches e manutenção. Continuam com o cliente as regras dos grupos de segurança, os usuários e permissões de acesso ao banco e a otimização das consultas feitas pela aplicação.",
+        topic: "Banco de dados",
+        options: [
+            ["Configuração inicial do banco de dados", true],
+            ["Otimização das consultas SQL da aplicação", false],
+            ["Gerenciamento do sistema operacional", true],
+            ["Gerenciamento de usuários e permissões de acesso ao banco", false],
+            ["Definição das regras dos grupos de segurança", false],
+        ],
+    },
+    {
+        statement: "Qual é o principal benefício do AWS Storage Gateway?",
+        explanation:
+            "O AWS Storage Gateway conecta aplicações on-premises ao armazenamento da AWS por protocolos padrão como NFS, SMB e iSCSI, guardando os dados no Amazon S3 e em outros serviços. Jobs de ETL são do AWS Glue, transferência por SFTP é do AWS Transfer Family e chaves em hardware dedicado são do AWS CloudHSM.",
+        topic: "Armazenamento",
+        options: [
+            ["Automatiza a criação, a manutenção e a execução de jobs de ETL", false],
+            ["Transfere arquivos por SFTP diretamente para o Amazon S3", false],
+            ["Integra ambientes de TI on-premises ao armazenamento na nuvem", true],
+            ["Oferece armazenamento de chaves em hardware para conformidade regulatória", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço pode ser usado para direcionar o tráfego dos usuários de todo o mundo ao endpoint que oferece o melhor desempenho para a aplicação?",
+        explanation:
+            "O AWS Global Accelerator leva o tráfego dos usuários pela rede global da AWS até o endpoint saudável com melhor desempenho, usando IPs estáticos. O Transit Gateway interliga VPCs e redes on-premises, o DAX é um cache em memória para o DynamoDB e o S3 Transfer Acceleration só acelera transferências para buckets do S3.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Global Accelerator", true],
+            ["AWS Transit Gateway", false],
+            ["Amazon DynamoDB Accelerator (DAX)", false],
+            ["Amazon S3 Transfer Acceleration", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação de IoT em tempo real precisa de latência inferior a um milissegundo no acesso aos dados. Qual serviço da AWS deve ser utilizado?",
+        explanation:
+            "O Amazon ElastiCache é um armazenamento de dados em memória que responde em menos de um milissegundo, ideal para aplicações em tempo real. O Redshift é um data warehouse para análises, o Athena consulta dados no S3 com SQL em segundos e o OpenSearch Service é voltado a busca e análise de logs.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon Redshift", false],
+            ["Amazon Athena", false],
+            ["Amazon OpenSearch Service", false],
+            ["Amazon ElastiCache", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS ajuda os desenvolvedores a compilar e testar o código de suas aplicações?",
+        explanation:
+            "O AWS CodeBuild é um serviço de integração contínua totalmente gerenciado que compila o código-fonte, executa testes e gera pacotes prontos para implantação. O CodeDeploy automatiza implantações, o CodeCommit hospeda repositórios Git e o CodePipeline orquestra as etapas do pipeline de entrega.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS CodeDeploy", false],
+            ["AWS CodeCommit", false],
+            ["AWS CodePipeline", false],
+            ["AWS CodeBuild", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa enfrenta muitos problemas com sua central de atendimento atual e quer oferecer um serviço melhor aos clientes. Qual serviço da AWS fornece uma central de atendimento baseada na nuvem?",
+        explanation:
+            "O Amazon Connect é uma central de atendimento em nuvem que pode ser configurada em minutos, com cobrança pelo uso e sem infraestrutura para gerenciar. O Direct Connect é uma conexão de rede dedicada com a AWS, o WorkSpaces oferece desktops virtuais e o Amazon SES envia e-mails em grande volume.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Direct Connect", false],
+            ["Amazon Connect", true],
+            ["Amazon WorkSpaces", false],
+            ["Amazon Simple Email Service (Amazon SES)", false],
+        ],
+    },
+    {
+        statement:
+            "Você gerencia um blog na AWS com três ambientes: desenvolvimento, teste e produção. O que permite agrupar os recursos de cada ambiente para visualizá-los e gerenciá-los em um só lugar?",
+        explanation:
+            "O AWS Resource Groups agrupa recursos por tags ou por pilha do CloudFormation, permitindo ver e gerenciar juntos os recursos de cada ambiente. Grupos de posicionamento definem como as instâncias EC2 ficam no hardware, o console sozinho não cria visões por ambiente e o Service Catalog publica produtos aprovados.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Resource Groups", true],
+            ["Grupos de posicionamento do Amazon EC2", false],
+            ["Console de Gerenciamento da AWS", false],
+            ["AWS Service Catalog", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação web está com problemas de desempenho e demora muito para carregar. Qual serviço da AWS ajuda a identificar os gargalos para corrigir esses problemas?",
+        explanation:
+            "O AWS X-Ray rastreia as requisições enquanto elas passam pelos componentes da aplicação e mostra onde estão os gargalos e a origem da latência. O Detective investiga achados de segurança, o Security Hub centraliza alertas de segurança e o Shield protege contra ataques DDoS.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Detective", false],
+            ["AWS X-Ray", true],
+            ["AWS Security Hub", false],
+            ["AWS Shield", false],
+        ],
+    },
+    {
+        statement:
+            "O Amazon RDS oferece vários mecanismos de banco de dados à escolha. Qual das opções a seguir NÃO é um mecanismo compatível com o Amazon RDS?",
+        explanation:
+            "O Teradata não está disponível no Amazon RDS. Os mecanismos compatíveis são Amazon Aurora (MySQL e PostgreSQL), MySQL, MariaDB, PostgreSQL, Oracle, Microsoft SQL Server e Db2, então PostgreSQL, Oracle e SQL Server podem ser escolhidos ao criar uma instância de banco de dados no RDS.",
+        topic: "Banco de dados",
+        options: [
+            ["PostgreSQL", false],
+            ["Oracle", false],
+            ["Microsoft SQL Server", false],
+            ["Teradata", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa um software de banco de dados relacional que não está entre os mecanismos oferecidos pelos serviços gerenciados da AWS e quer instalá-lo e administrá-lo por conta própria. Qual serviço deve usar?",
+        explanation:
+            "O Amazon EC2 oferece servidores virtuais com acesso ao sistema operacional, onde o cliente instala e administra qualquer software de banco de dados. O RDS e o Aurora são gerenciados e aceitam só os mecanismos oferecidos pela AWS, e o DynamoDB é um banco NoSQL gerenciado, sem instalação de software.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon EC2", true],
+            ["Amazon RDS", false],
+            ["Amazon Aurora", false],
+            ["Amazon DynamoDB", false],
+        ],
+    },
+    {
+        statement:
+            "Em alguns serviços, a AWS replica os dados automaticamente em várias Zonas de Disponibilidade para manter a tolerância a falhas se um servidor ou uma Zona de Disponibilidade inteira falhar. Quais serviços fazem essa replicação automaticamente? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon S3 Standard grava os objetos em pelo menos três Zonas de Disponibilidade e o DynamoDB replica as tabelas em várias zonas da Região, sem configuração extra. Volumes do EBS e o EFS One Zone ficam em uma única zona, e o armazenamento de instância é efêmero e não tem réplica.",
+        topic: "Armazenamento",
+        options: [
+            ["Armazenamento de instância do Amazon EC2", false],
+            ["Amazon S3 (classe S3 Standard)", true],
+            ["Tabelas do Amazon DynamoDB", true],
+            ["Volumes do Amazon EBS", false],
+            ["Sistemas de arquivos do Amazon EFS One Zone", false],
+        ],
+    },
+    {
+        statement:
+            "Como é possível recuperar objetos do Amazon S3 que foram excluídos ou sobrescritos por engano?",
+        explanation:
+            "Com o versionamento do S3, o bucket guarda todas as versões de cada objeto, então uma exclusão ou sobrescrita acidental pode ser desfeita restaurando a versão anterior. A política de bucket controla permissões, o ciclo de vida move ou expira objetos e a criptografia protege a confidencialidade, sem recuperar dados.",
+        topic: "Armazenamento",
+        options: [
+            ["Habilitando o versionamento do S3 no bucket", true],
+            ["Configurando uma política de bucket do S3", false],
+            ["Configurando uma política de ciclo de vida do S3", false],
+            ["Ativando a criptografia padrão do bucket com o AWS KMS", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir NÃO é um benefício do AWS Lambda?",
+        explanation:
+            "O Lambda é sem servidor: a AWS cuida da infraestrutura e o cliente não tem acesso ao sistema operacional, o que é característica do Amazon EC2. Executar código sem gerenciar servidores, escalar automaticamente conforme as requisições e não cobrar quando o código está parado são benefícios reais do Lambda.",
+        topic: "Computação",
+        options: [
+            ["Executa código sem provisionar nem gerenciar servidores", false],
+            ["Escala automaticamente conforme o número de requisições", false],
+            ["Não cobra nada enquanto o código não está em execução", false],
+            ["Permite administrar o sistema operacional do servidor", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS é um sistema gerenciado de repositórios que permite armazenar, versionar e gerenciar o código das aplicações?",
+        explanation:
+            "O AWS CodeCommit é um serviço gerenciado de controle de versão que hospeda repositórios Git privados, com armazenamento seguro e histórico do código. O CodePipeline orquestra as etapas de entrega, o CodeBuild compila e testa o código e o CodeDeploy automatiza a implantação das aplicações.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS CodePipeline", false],
+            ["AWS CodeCommit", true],
+            ["AWS CodeBuild", false],
+            ["AWS CodeDeploy", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS pode direcionar os usuários finais para a Região da AWS que oferece a menor latência, reduzindo o tempo de resposta da aplicação?",
+        explanation:
+            "O Amazon Route 53 oferece roteamento baseado em latência, que responde às consultas DNS com o endpoint da Região que dá a menor latência ao usuário. O CloudFront entrega conteúdo em cache nos locais de borda, o Elastic Load Balancing distribui tráfego dentro de uma Região e o Direct Connect liga o data center à AWS.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon CloudFront", false],
+            ["Elastic Load Balancing", false],
+            ["AWS Direct Connect", false],
+            ["Amazon Route 53", true],
+        ],
+    },
+    {
+        statement:
+            "Quais procedimentos podem reduzir a latência quando os usuários finais baixam os arquivos de mídia de uma aplicação? (Selecione DUAS opções.)",
+        explanation:
+            "Guardar a mídia na Região mais próxima encurta a distância percorrida pelos dados, e o CloudFront entrega os arquivos do S3 a partir de locais de borda perto dos usuários. Mais capacidade no servidor e réplicas em várias zonas não mudam essa distância, e o S3 Glacier Flexible Retrieval deixa a recuperação mais lenta.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Armazenar os arquivos de mídia na Região mais próxima dos usuários finais", true],
+            [
+                "Guardar os arquivos em um volume EBS adicional e aumentar a capacidade do servidor",
+                false,
+            ],
+            ["Replicar os arquivos de mídia em pelo menos duas Zonas de Disponibilidade", false],
+            ["Mover os arquivos de mídia para a classe S3 Glacier Flexible Retrieval", false],
+            ["Armazenar os arquivos no Amazon S3 e distribuí-los com o Amazon CloudFront", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer usar o Amazon Elastic Container Service (Amazon ECS) para executar suas aplicações em contêineres. Por exigência de conformidade, ela precisa manter visibilidade e controle totais sobre o cluster de servidores subjacente. Qual tipo de inicialização do Amazon ECS atende a esses requisitos?",
+        explanation:
+            "No tipo de inicialização EC2, os contêineres rodam em instâncias EC2 que a própria empresa provisiona e gerencia, com controle sobre tipo de instância, sistema operacional e configuração do cluster. No Fargate a AWS gerencia os servidores e esconde o cluster, e Lightsail e Lambda não são tipos de inicialização do ECS.",
+        topic: "Computação",
+        options: [
+            ["Tipo de inicialização EC2", true],
+            ["Tipo de inicialização Fargate", false],
+            ["Tipo de inicialização Lightsail", false],
+            ["Tipo de inicialização Lambda", false],
+        ],
+    },
+    {
+        statement:
+            "As instâncias do Amazon EC2 são conceitualmente parecidas com servidores tradicionais, mas usá-las da mesma forma que um servidor físico é só o ponto de partida. Quais são os principais benefícios de usar instâncias do Amazon EC2 em vez de servidores tradicionais? (Selecione DUAS opções.)",
+        explanation:
+            "Com o EC2, a empresa distribui instâncias por várias Zonas de Disponibilidade e as substitui rapidamente, o que facilita arquiteturas tolerantes a falhas, e ajusta a capacidade em minutos, e não em semanas de compra de hardware. Acesso remoto e controle de acesso à rede existem nos dois cenários, e backups exigem configuração.",
+        topic: "Computação",
+        options: [
+            ["Facilitam arquiteturas com tolerância a falhas", true],
+            ["Oferecem acesso remoto transparente à empresa", false],
+            ["Impedem que usuários não autorizados entrem na rede", false],
+            ["Fazem backup automático dos dados sem configuração", false],
+            ["Podem ser dimensionadas manualmente em menos tempo", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa uma grande aplicação web que precisa estar sempre disponível. A aplicação fica lenta quando o uso de CPU passa de 60%. Como a empresa pode ser avisada quando o uso de CPU de qualquer instância EC2 da conta atingir 60%?",
+        explanation:
+            "Os alarmes do Amazon CloudWatch acompanham métricas como a utilização de CPU e disparam notificações ou ações quando um limite é atingido. O CloudFront é uma rede de entrega de conteúdo, o AWS Config registra configurações dos recursos e não métricas de desempenho, e o SNS só entrega a notificação que o alarme gera.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Usar o Amazon CloudFront para monitorar o uso de CPU das instâncias", false],
+            ["Definir no AWS Config um limite de CPU de 60% para receber notificações", false],
+            ["Criar alarmes do Amazon CloudWatch que avisem quando a CPU atingir 60%", true],
+            ["Usar o Amazon SNS para monitorar a utilização de CPU dos servidores", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação usa um esquema de dados relacional e precisa de consultas com junções (joins) entre tabelas e de transações complexas executadas com frequência. Qual serviço é o mais indicado?",
+        explanation:
+            "O Amazon RDS é um banco de dados relacional gerenciado, com SQL, junções entre tabelas e transações ACID para cargas transacionais. O Redshift é um data warehouse para análises, o Athena consulta arquivos no S3 sem processar transações e o DynamoDB é um banco NoSQL de chave-valor que não faz junções.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon RDS", true],
+            ["Amazon Redshift", false],
+            ["Amazon Athena", false],
+            ["Amazon DynamoDB", false],
+        ],
+    },
+    {
+        statement:
+            "O que deve ser considerado ao armazenar dados na classe S3 Glacier Deep Archive?",
+        explanation:
+            "O S3 Glacier Deep Archive é a classe mais barata do S3, feita para arquivamento de longo prazo, e a restauração de um objeto leva até 12 horas (ou até 48 horas na opção em lote). Ela aceita dados em qualquer formato, não serve para acesso frequente e é usada pela API do S3, sem anexar nada a instâncias.",
+        topic: "Armazenamento",
+        options: [
+            ["Os dados precisam estar compactados antes do envio", false],
+            ["A classe é indicada para dados acessados com frequência", false],
+            ["A recuperação dos dados não é imediata e pode levar horas", true],
+            ["É preciso anexar a classe a uma instância EC2 para gravar", false],
+        ],
+    },
+    {
+        statement:
+            "Os volumes do Amazon EBS são replicados automaticamente dentro da mesma Zona de Disponibilidade. Qual benefício essa replicação oferece?",
+        explanation:
+            "Como cada volume do EBS é replicado dentro da sua Zona de Disponibilidade, a falha de um componente de hardware não causa perda de dados, o que garante durabilidade. Elasticidade é ajustar a capacidade à demanda, rastreabilidade é auditar ações e mudanças, e agilidade é a rapidez para provisionar recursos.",
+        topic: "Armazenamento",
+        options: [
+            ["Elasticidade", false],
+            ["Durabilidade", true],
+            ["Rastreabilidade", false],
+            ["Agilidade", false],
+        ],
+    },
+    {
+        statement: "Para que é usado o Amazon ElastiCache? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon ElastiCache é um serviço gerenciado de cache em memória (Valkey, Memcached e Redis OSS) que guarda dados acessados com frequência e reduz a latência, melhorando o desempenho das aplicações. Locais de borda são do CloudFront, backups de longo prazo ficam no S3 Glacier e distribuir requisições é papel do Elastic Load Balancing.",
+        topic: "Banco de dados",
+        options: [
+            ["Fornecer um armazenamento de dados em memória", true],
+            ["Reduzir custos de entrega usando locais de borda", false],
+            ["Melhorar o desempenho de aplicações web com cache", true],
+            ["Guardar arquivos de backup de longo prazo com baixo custo", false],
+            ["Distribuir as requisições entre várias instâncias", false],
+        ],
+    },
+    {
+        statement:
+            "A elasticidade da Nuvem AWS permite que os clientes economizem em comparação com provedores de hospedagem tradicionais. O que os clientes podem fazer para aproveitar essa elasticidade? (Selecione DUAS opções.)",
+        explanation:
+            "O EC2 Auto Scaling adiciona e remove instâncias conforme a demanda, e a computação sem servidor cobra só pelo tempo de execução, então nos dois casos o cliente paga apenas pelo que usa. Várias zonas ou outra Região melhoram a disponibilidade, e Instâncias Reservadas para o pico fixam uma capacidade que fica ociosa.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Implantar os recursos em várias Zonas de Disponibilidade", false],
+            ["Usar o Amazon EC2 Auto Scaling conforme a demanda", true],
+            ["Implantar os recursos em outra Região da AWS", false],
+            ["Comprar Instâncias Reservadas para toda a capacidade de pico", false],
+            ["Usar computação sem servidor sempre que possível", true],
+        ],
+    },
+    {
+        statement:
+            "Qual é a quantidade máxima de dados que pode ser armazenada no Amazon S3 em uma única conta da AWS?",
+        explanation:
+            "O Amazon S3 oferece capacidade praticamente ilimitada: não há teto para o total de dados ou de objetos em uma conta, em um bucket ou em uma Região, e o serviço escala sozinho. O único limite de tamanho vale para cada objeto (até 50 TB), e não para o volume total armazenado.",
+        topic: "Armazenamento",
+        options: [
+            ["100 petabytes por Região", false],
+            ["Praticamente ilimitada", true],
+            ["5 terabytes por bucket", false],
+            ["10 exabytes por conta", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS entrega dados, vídeos, aplicações e APIs a usuários do mundo todo com baixa latência e altas velocidades de transferência?",
+        explanation:
+            "O Amazon CloudFront é a rede de entrega de conteúdo (CDN) da AWS: guarda cópias em cache em locais de borda pelo mundo e entrega dados, vídeos, aplicações e APIs com baixa latência. O Route 53 resolve nomes DNS, o Elastic Load Balancing distribui tráfego dentro de uma Região e o Direct Connect liga o data center à AWS.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon Route 53", false],
+            ["Elastic Load Balancing", false],
+            ["Amazon CloudFront", true],
+            ["AWS Direct Connect", false],
+        ],
+    },
+    {
+        statement:
+            "Qual elemento da infraestrutura global da AWS é formado por um ou mais data centers distintos, cada um com energia, rede e conectividade redundantes, instalados em estruturas separadas?",
+        explanation:
+            "Uma Zona de Disponibilidade é formada por um ou mais data centers distintos, com energia, rede e conectividade redundantes, em instalações separadas dentro de uma Região. A Região é a área geográfica que reúne várias zonas, e os locais de borda e os caches regionais de borda guardam conteúdo do CloudFront perto dos usuários.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Regiões da AWS", false],
+            ["Zonas de Disponibilidade", true],
+            ["Locais de borda (pontos de presença)", false],
+            ["Caches regionais de borda", false],
+        ],
+    },
+    {
+        statement: "A existência de várias Regiões na Nuvem AWS é um exemplo de qual conceito?",
+        explanation:
+            "As Regiões espalhadas pelo mundo fazem parte da infraestrutura global da AWS, junto com as Zonas de Disponibilidade e os locais de borda. Agilidade é a rapidez para provisionar e experimentar, elasticidade é ajustar os recursos à demanda e pagamento conforme o uso é um modelo de cobrança.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Agilidade", false],
+            ["Infraestrutura global", true],
+            ["Elasticidade", false],
+            ["Pagamento conforme o uso", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS pode ser usado para iniciar instâncias manualmente, escolhendo a configuração conforme os requisitos de recursos?",
+        explanation:
+            "O Amazon EC2 permite iniciar manualmente instâncias de servidores virtuais, escolhendo tipo de instância, sistema operacional e demais configurações. O EBS fornece volumes de armazenamento em bloco para essas instâncias, o S3 guarda objetos e o ECS orquestra contêineres, sem ser a forma de iniciar instâncias.",
+        topic: "Computação",
+        options: [
+            ["Amazon EBS", false],
+            ["Amazon S3", false],
+            ["Amazon EC2", true],
+            ["Amazon ECS", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS permitem conectar uma nuvem privada virtual (Amazon VPC) a um data center on-premises? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Site-to-Site VPN cria um túnel criptografado pela internet entre a rede local e a VPC, e o AWS Direct Connect oferece uma conexão física dedicada e privada até a AWS. O CloudFront entrega conteúdo em locais de borda, o API Gateway publica APIs e o emparelhamento de VPC só liga uma VPC a outra.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Site-to-Site VPN", true],
+            ["Amazon CloudFront", false],
+            ["Amazon API Gateway", false],
+            ["AWS Direct Connect", true],
+            ["Emparelhamento de VPC (VPC peering)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa implantou vários bancos de dados relacionais em instâncias do Amazon EC2. Todo mês, o fornecedor do software de banco de dados lança novos patches de segurança que precisam ser aplicados. Qual é a forma MAIS eficiente de aplicar esses patches?",
+        explanation:
+            "O AWS Systems Manager (com o Patch Manager e as janelas de manutenção) aplica patches nas instâncias EC2 de forma automática e agendada, sem acesso manual a cada servidor. Aplicar à mão não escala, o console do RDS só vale para bancos gerenciados pelo RDS e o AWS Config apenas avalia a conformidade, sem aplicar patches.",
+        topic: "Ferramentas e suporte",
+        options: [
+            [
+                "Conectar-se a cada instância todo mês e aplicar manualmente os patches do fornecedor",
+                false,
+            ],
+            [
+                "Ativar a aplicação automática de patches das instâncias no console do Amazon RDS",
+                false,
+            ],
+            [
+                "Criar uma regra no AWS Config com o nível de patch exigido para as instâncias",
+                false,
+            ],
+            [
+                "Usar o AWS Systems Manager para automatizar os patches conforme um agendamento",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual mecanismo permite que os desenvolvedores acessem os serviços da AWS a partir do código de suas aplicações?",
+        explanation:
+            "Os SDKs da AWS oferecem bibliotecas para linguagens como Python, Java, JavaScript e Go, que permitem chamar os serviços da AWS diretamente no código da aplicação. O console é uma interface gráfica no navegador, o CloudShell é um terminal no navegador para comandos e o CodePipeline automatiza pipelines de entrega.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["SDKs da AWS", true],
+            ["Console de Gerenciamento da AWS", false],
+            ["AWS CodePipeline", false],
+            ["AWS CloudShell", false],
+        ],
+    },
+    {
+        statement: "O que é o Amazon CloudWatch?",
+        explanation:
+            "O Amazon CloudWatch é o serviço de monitoramento da AWS: coleta métricas, logs e eventos dos recursos e aplicações e permite criar alarmes com limites e notificações. Registrar chamadas de API é papel do CloudTrail, rastrear requisições é do X-Ray e processar fluxos de dados em tempo real é do Amazon Kinesis.",
+        topic: "Ferramentas e suporte",
+        options: [
+            [
+                "Um serviço que registra as chamadas de API e a atividade da conta para fins de auditoria",
+                false,
+            ],
+            [
+                "Um serviço que rastreia as requisições entre os componentes da aplicação para achar gargalos",
+                false,
+            ],
+            [
+                "Um serviço que coleta métricas e dados operacionais dos recursos, com alarmes configuráveis",
+                true,
+            ],
+            [
+                "Um serviço que captura e processa fluxos de dados em tempo real de aplicações e sistemas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual dos serviços a seguir escala automaticamente para acompanhar um aumento esperado no tráfego web?",
+        explanation:
+            "O Elastic Load Balancing aumenta sozinho a capacidade de receber requisições conforme o tráfego cresce e distribui a carga entre destinos saudáveis. O CodePipeline automatiza entregas de software, volumes do EBS são redimensionados manualmente e o Direct Connect tem velocidade de porta fixa, sem escalar com o tráfego.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS CodePipeline", false],
+            ["Elastic Load Balancing", true],
+            ["Volumes do Amazon EBS", false],
+            ["Conexões do AWS Direct Connect", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço oferece armazenamento de objetos online, altamente durável e com capacidade praticamente ilimitada?",
+        explanation:
+            "O Amazon S3 é o armazenamento de objetos da AWS, com capacidade praticamente ilimitada e durabilidade projetada de 99,999999999% (11 noves). O Amazon EBS oferece volumes de armazenamento em bloco para instâncias EC2, e o Amazon EFS e o Amazon FSx fornecem sistemas de arquivos compartilhados.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon S3", true],
+            ["Amazon EBS", false],
+            ["Amazon EFS", false],
+            ["Amazon FSx", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são os principais componentes da infraestrutura global da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Regiões e Zonas de Disponibilidade são a base da infraestrutura global: cada Região é uma área geográfica com várias Zonas de Disponibilidade isoladas. Resource Groups organizam recursos por tags, grupos de segurança são firewalls virtuais e AMIs são modelos para iniciar instâncias.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Zonas de Disponibilidade", true],
+            ["Resource Groups", false],
+            ["Grupos de segurança", false],
+            ["Regiões da AWS", true],
+            ["Imagens de máquina da Amazon (AMIs)", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços ou recursos da AWS ajudam a integrar a Nuvem AWS a um data center on-premises, conectando as redes ou resolvendo nomes entre os dois ambientes? (Selecione DUAS opções.)",
+        explanation:
+            "O Route 53 pode direcionar usuários tanto para recursos na AWS quanto para servidores on-premises, e o gateway privado virtual é o lado da VPC na conexão VPN com o data center. O Classic Load Balancer só registra instâncias EC2, o Auto Scaling age apenas dentro da AWS e as métricas padrão do CloudWatch cobrem só recursos da AWS.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon Route 53 (DNS)", true],
+            ["Gateway privado virtual", true],
+            ["Classic Load Balancer", false],
+            ["Amazon EC2 Auto Scaling", false],
+            ["Métricas padrão do Amazon CloudWatch", false],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir são características do Amazon S3? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon S3 guarda dados como objetos em buckets e foi projetado para 99,999999999% de durabilidade. Sistemas de arquivos em rede ou compartilhados descrevem serviços como o Amazon EFS, e o armazenamento local corresponde ao armazenamento de instância do EC2, que é temporário.",
+        topic: "Armazenamento",
+        options: [
+            ["Um sistema de arquivos global", false],
+            ["Um armazenamento de objetos", true],
+            ["Um armazenamento local", false],
+            ["Um sistema de arquivos em rede", false],
+            ["Um armazenamento durável", true],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem ser combinados para entregar grandes volumes de vídeo on-line com a menor latência possível? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon S3 armazena os vídeos com alta durabilidade e escala, e o Amazon CloudFront os entrega a partir de locais de borda próximos dos espectadores. O Storage Gateway integra ambientes on-premises, o EFS é um sistema de arquivos compartilhado e o S3 Glacier Deep Archive é arquivamento, com recuperação em horas.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Storage Gateway", false],
+            ["Amazon S3", true],
+            ["Amazon EFS", false],
+            ["S3 Glacier Deep Archive", false],
+            ["Amazon CloudFront", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos podem ser configurados no console da Amazon Virtual Private Cloud (Amazon VPC)? (Selecione DUAS opções.)",
+        explanation:
+            "Grupos de segurança e sub-redes são recursos nativos da VPC e aparecem no console da Amazon VPC. Distribuições do CloudFront e zonas hospedadas do Route 53 são configuradas nos consoles desses serviços, e os balanceadores de carga ficam no console do Amazon EC2.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Distribuições do Amazon CloudFront", false],
+            ["Zonas hospedadas do Route 53", false],
+            ["Regras de grupos de segurança", true],
+            ["Sub-redes públicas e privadas", true],
+            ["Balanceadores de carga (ELB)", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS são globais, sem que seus recursos precisem ser criados em uma Região específica? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Route 53 e o Amazon CloudFront são serviços globais: não são criados em uma Região e operam a partir da rede de locais de borda da AWS. Instâncias EC2, buckets do S3 e ambientes do Elastic Beanstalk são criados em uma Região específica, mesmo que o nome de um bucket seja único no mundo.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Amazon Route 53", true],
+            ["Amazon EC2", false],
+            ["Amazon S3", false],
+            ["Amazon CloudFront", true],
+            ["AWS Elastic Beanstalk", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso do Amazon RDS ajuda a criar bancos de dados com redundância global, mantendo uma cópia atualizada continuamente em outra Região da AWS?",
+        explanation:
+            "As réplicas de leitura entre Regiões copiam os dados de forma assíncrona para outra Região e podem ser promovidas a instância principal se a Região original falhar. Snapshots são cópias pontuais que exigem restauração, patches automáticos são manutenção e IOPS provisionadas tratam de desempenho.",
+        topic: "Banco de dados",
+        options: [
+            ["Snapshots do banco de dados", false],
+            ["Aplicação automática de patches", false],
+            ["Réplicas de leitura entre Regiões", true],
+            ["Armazenamento com IOPS provisionadas", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso adiciona elasticidade às instâncias do Amazon EC2 para acompanhar a variação da demanda das cargas de trabalho?",
+        explanation:
+            "O Amazon EC2 Auto Scaling acompanha métricas definidas e adiciona ou remove instâncias conforme a demanda, o que dá elasticidade à aplicação. Resource Groups só organizam recursos, políticas de ciclo de vida movem ou expiram objetos no S3 e o Application Load Balancer distribui o tráfego sem mudar a quantidade de instâncias.",
+        topic: "Computação",
+        options: [
+            ["Resource Groups", false],
+            ["Políticas de ciclo de vida", false],
+            ["Application Load Balancer", false],
+            ["Amazon EC2 Auto Scaling", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço é um banco de dados relacional compatível com MySQL cujo armazenamento cresce automaticamente conforme os dados aumentam, sem que seja preciso provisionar a capacidade de armazenamento antes?",
+        explanation:
+            "No Amazon Aurora, compatível com MySQL e PostgreSQL, o volume do cluster cresce sozinho conforme os dados, sem provisionar armazenamento. No RDS para MySQL é preciso alocar o armazenamento na criação (o autoscaling é opcional), o EC2 é só computação e o Lightsail oferece planos simplificados de capacidade definida.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon Elastic Compute Cloud (Amazon EC2)", false],
+            ["Amazon RDS para MySQL", false],
+            ["Amazon Lightsail", false],
+            ["Amazon Aurora", true],
+        ],
+    },
+    {
+        statement:
+            "Quais tipos de balanceador de carga estão disponíveis no Elastic Load Balancing (ELB)? (Selecione DUAS opções.)",
+        explanation:
+            "O Elastic Load Balancing oferece Application Load Balancer, Network Load Balancer, Gateway Load Balancer e o Classic Load Balancer, de geração anterior. O balanceamento entre zonas é um recurso configurável, o F5 BIG-IP é um produto de terceiros e o Auto Scaling é um serviço separado que ajusta a capacidade.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Classic Load Balancer", true],
+            ["Cross-Zone Load Balancer", false],
+            ["F5 BIG-IP Load Balancer", false],
+            ["Application Load Balancer", true],
+            ["Auto Scaling Load Balancer", false],
+        ],
+    },
+    {
+        statement:
+            "Quais dos serviços da AWS a seguir fornecem recursos de computação? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Lambda executa código sem servidor em resposta a eventos, e o Amazon ECS executa contêineres em instâncias EC2 ou no AWS Fargate. O Amazon ECR apenas armazena imagens de contêiner, o Amazon EBS fornece volumes de armazenamento em bloco e o CodeDeploy automatiza implantações em recursos de computação.",
+        topic: "Computação",
+        options: [
+            ["AWS Lambda", true],
+            ["Amazon ECS", true],
+            ["AWS CodeDeploy", false],
+            ["Amazon ECR", false],
+            ["Amazon EBS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS permite implantar infraestrutura como código, automatizando o provisionamento de recursos?",
+        explanation:
+            "O AWS CloudFormation implementa infraestrutura como código: os recursos são descritos em templates JSON ou YAML e provisionados de forma automática e repetível. O AWS Config registra a configuração dos recursos, o CodeDeploy implanta código de aplicação e o Trusted Advisor recomenda boas práticas.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Config", false],
+            ["AWS CloudFormation", true],
+            ["AWS CodeDeploy", false],
+            ["AWS Trusted Advisor", false],
+        ],
+    },
+    {
+        statement: "Quais serviços da AWS usam os locais de borda da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon CloudFront armazena e entrega conteúdo a partir dos locais de borda, e o AWS Shield mitiga ataques DDoS nesses mesmos pontos, antes que o tráfego chegue à origem. EC2, RDS e ElastiCache são serviços regionais, executados em Zonas de Disponibilidade dentro de uma Região.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon CloudFront", true],
+            ["AWS Shield", true],
+            ["Amazon EC2", false],
+            ["Amazon RDS", false],
+            ["Amazon ElastiCache", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é um serviço de banco de dados da AWS?",
+        explanation:
+            "O Amazon Redshift é um data warehouse totalmente gerenciado, um banco de dados relacional colunar para consultas analíticas com SQL. O EBS fornece volumes de armazenamento em bloco para instâncias EC2, o EFS é um sistema de arquivos compartilhado e o S3 Glacier Deep Archive é uma classe de armazenamento para arquivamento.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon Redshift", true],
+            ["Amazon EBS", false],
+            ["S3 Glacier Deep Archive", false],
+            ["Amazon EFS", false],
+        ],
+    },
+    {
+        statement:
+            "Quais afirmações descrevem corretamente a relação entre Regiões da AWS, Zonas de Disponibilidade e locais de borda? (Selecione DUAS opções.)",
+        explanation:
+            "Cada Região tem várias Zonas de Disponibilidade, então há mais Zonas do que Regiões, e os locais de borda somam centenas de pontos de presença, bem mais que as dezenas de Regiões. Um local de borda não é uma Zona de Disponibilidade: fica fora das Regiões e serve para entregar conteúdo com baixa latência.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Há mais Regiões da AWS do que Zonas de Disponibilidade", false],
+            ["Há mais locais de borda do que Regiões da AWS", true],
+            ["Um local de borda é uma Zona de Disponibilidade", false],
+            ["Há mais Regiões da AWS do que locais de borda", false],
+            ["Há mais Zonas de Disponibilidade do que Regiões da AWS", true],
+        ],
+    },
+    {
+        statement:
+            "O que ajuda uma empresa a oferecer uma experiência de menor latência a usuários no mundo todo?",
+        explanation:
+            "Os locais de borda, usados pelo Amazon CloudFront, guardam cópias do conteúdo perto de cada usuário e reduzem a latência onde quer que ele esteja. Nenhuma Região é central para o mundo todo, uma segunda Zona de Disponibilidade melhora a disponibilidade e não a distância, e um cache na própria Região só ajuda quem está perto dela.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Usar uma Região da AWS central em relação a todos os usuários", false],
+            ["Usar uma segunda Zona de Disponibilidade na Região atual", false],
+            ["Habilitar cache na Região da AWS que já está em uso", false],
+            ["Usar locais de borda para aproximar o conteúdo dos usuários", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço de rede da AWS permite que uma empresa crie uma rede virtual dentro da AWS?",
+        explanation:
+            "A Amazon VPC cria uma rede virtual logicamente isolada na AWS, com controle sobre intervalos de IP, sub-redes, tabelas de rotas e gateways. O AWS Config registra a configuração dos recursos, o Route 53 é o serviço de DNS e o Direct Connect liga uma rede externa à AWS, sem criar a rede virtual.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Config", false],
+            ["Amazon Route 53", false],
+            ["AWS Direct Connect", false],
+            ["Amazon VPC", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço você usaria para enviar alertas com base em alarmes do Amazon CloudWatch?",
+        explanation:
+            "O Amazon SNS é o serviço de notificações acionado pelos alarmes do CloudWatch: publica a mensagem em um tópico e a entrega aos assinantes por e-mail, SMS ou HTTP. O CloudTrail registra chamadas de API, o Trusted Advisor recomenda boas práticas e o Amazon SQS é uma fila de mensagens consumida por aplicações, sem enviar alertas.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon SNS", true],
+            ["AWS CloudTrail", false],
+            ["AWS Trusted Advisor", false],
+            ["Amazon SQS", false],
+        ],
+    },
+    {
+        statement:
+            "Ao projetar uma aplicação web típica de três camadas, quais serviços ou recursos da AWS aumentam a disponibilidade e reduzem o impacto de falhas? (Selecione DUAS opções.)",
+        explanation:
+            "O EC2 Auto Scaling substitui instâncias com falha e ajusta a capacidade, e distribuir os recursos em várias Zonas de Disponibilidade evita que a falha de uma derrube a aplicação. Network ACLs só filtram tráfego, alarmes apenas notificam sem corrigir nada e pontos de presença são locais de borda, onde as camadas da aplicação não são hospedadas.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Amazon EC2 Auto Scaling para as instâncias da aplicação", true],
+            ["Network ACLs da VPC para verificar a integridade do serviço", false],
+            ["Recursos distribuídos em várias Zonas de Disponibilidade", true],
+            ["Alarmes do CloudWatch que avisam quando uma instância falha", false],
+            ["Recursos distribuídos em vários pontos de presença da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é uma característica da replicação entre Regiões (Cross-Region Replication) do Amazon S3?",
+        explanation:
+            "Na replicação entre Regiões do S3, os buckets de origem e de destino podem ser da mesma conta ou de contas diferentes. O versionamento precisa estar ativado nos dois buckets, a replicação existe justamente para copiar objetos entre Regiões diferentes e nenhuma Região precisa ser desativada na conta.",
+        topic: "Armazenamento",
+        options: [
+            [
+                "Os buckets de origem e de destino precisam estar com o versionamento desativado",
+                false,
+            ],
+            ["Os buckets de origem e de destino não podem ficar em Regiões diferentes", false],
+            ["Os buckets podem pertencer à mesma conta da AWS ou a contas diferentes", true],
+            [
+                "O dono do bucket de origem precisa desativar as Regiões de origem e de destino na conta",
+                false,
+            ],
+        ],
+    },
+    {
+        statement: "O que o Amazon Route 53 permite que os usuários façam?",
+        explanation:
+            "O Amazon Route 53 é o serviço de DNS da AWS: registra nomes de domínio, gerencia registros DNS e roteia o tráfego para os endpoints. Criptografia em trânsito e certificados SSL/TLS ficam com serviços como o AWS Certificate Manager, e a conexão dedicada é o AWS Direct Connect.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Criptografar os dados em trânsito entre os serviços", false],
+            ["Registrar nomes de domínio para as aplicações", true],
+            ["Gerar e gerenciar certificados SSL/TLS", false],
+            ["Estabelecer uma conexão de rede dedicada com a AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer um serviço da AWS que monitore continuamente a integridade dos endpoints da sua aplicação, implantados em várias Regiões, e direcione o tráfego automaticamente para um endpoint regional íntegro, melhorando a disponibilidade. Qual serviço atende a esses requisitos?",
+        explanation:
+            "O AWS Global Accelerator verifica a integridade dos endpoints e envia os usuários ao endpoint íntegro mais próximo pela rede global da AWS, com failover entre Regiões. O Elastic Load Balancing atua dentro de uma única Região, o CloudWatch monitora e alerta sem rotear tráfego, e o CloudFront é uma CDN que entrega conteúdo em cache.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Elastic Load Balancing", false],
+            ["Amazon CloudWatch", false],
+            ["AWS Global Accelerator", true],
+            ["Amazon CloudFront", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem ser usados para migrar dados de data centers locais para a AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS DataSync automatiza e acelera a transferência de grandes volumes de arquivos e objetos do armazenamento local para a AWS, e o AWS DMS migra bancos de dados com o mínimo de indisponibilidade. O Lambda executa código, o SQS troca mensagens entre componentes e o API Gateway publica APIs.",
+        topic: "Migração",
+        options: [
+            ["AWS DataSync", true],
+            ["AWS Lambda", false],
+            ["Amazon Simple Queue Service (Amazon SQS)", false],
+            ["AWS Database Migration Service (AWS DMS)", true],
+            ["Amazon API Gateway", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de comércio eletrônico prevê um grande aumento no tráfego do site em duas datas promocionais muito populares. Qual serviço ou recurso da AWS pode ser configurado para ajustar os recursos dinamicamente conforme essa mudança na demanda?",
+        explanation:
+            "O Amazon EC2 Auto Scaling adiciona instâncias quando a demanda sobe e as remove quando ela cai, acompanhando os picos das datas promocionais. O CloudTrail registra chamadas de API, o Config acompanha as configurações dos recursos e o SageMaker Canvas pode prever a demanda, mas nenhum deles ajusta a capacidade.",
+        topic: "Computação",
+        options: [
+            ["AWS CloudTrail", false],
+            ["Amazon EC2 Auto Scaling", true],
+            ["Amazon SageMaker Canvas", false],
+            ["AWS Config", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa uma aplicação de comércio eletrônico hospedada na Europa. Para reduzir a latência dos usuários que acessam o site de outras partes do mundo, ela quer armazenar em cache o conteúdo estático acessado com frequência mais perto desses usuários. Qual serviço da AWS atende a esses requisitos?",
+        explanation:
+            "O Amazon CloudFront armazena o conteúdo estático em cache nos locais de borda e o entrega a partir do ponto mais próximo de cada usuário, reduzindo a latência global. O ElastiCache é um cache em memória usado pela própria aplicação, e o EFS e o EBS são armazenamento de arquivos e em bloco dentro de uma Região.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon ElastiCache", false],
+            ["Amazon CloudFront", true],
+            ["Amazon Elastic File System (Amazon EFS)", false],
+            ["Amazon Elastic Block Store (Amazon EBS)", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços da AWS podem ser escalados com o AWS Auto Scaling? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Auto Scaling ajusta a quantidade de instâncias do Amazon EC2 em grupos do Auto Scaling e a capacidade de leitura e gravação de tabelas do Amazon DynamoDB, entre outros recursos. O S3 escala sozinho sem configuração, o Route 53 é DNS sem capacidade a provisionar e o Redshift tem mecanismos próprios de escalabilidade.",
+        topic: "Computação",
+        options: [
+            ["Amazon EC2", true],
+            ["Amazon DynamoDB", true],
+            ["Amazon S3", false],
+            ["Amazon Route 53", false],
+            ["Amazon Redshift", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer colocar o AWS Global Accelerator na frente das suas aplicações. Quais benefícios ela obtém com isso? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Global Accelerator leva o tráfego dos usuários pela rede global da AWS até o endpoint íntegro mais próximo, o que aumenta a disponibilidade e reduz a latência. Ele não reduz o custo dos serviços, e a durabilidade e a segurança dos dados armazenados dependem dos serviços de armazenamento, criptografia e controle de acesso.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Menor custo para executar serviços na AWS", false],
+            ["Maior disponibilidade das aplicações na AWS", true],
+            ["Maior durabilidade dos dados armazenados na AWS", false],
+            ["Menor latência para acessar aplicações na AWS", true],
+            ["Maior segurança dos dados armazenados na AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS pode ser usado para converter texto em fala com som natural?",
+        explanation:
+            "O Amazon Polly usa aprendizado profundo para transformar texto em fala natural, em vários idiomas e vozes. O Transcribe faz o caminho inverso (fala para texto), o Rekognition analisa imagens e vídeos, e o Lex cria interfaces conversacionais e chatbots que entendem voz e texto.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Polly", true],
+            ["Amazon Transcribe", false],
+            ["Amazon Rekognition", false],
+            ["Amazon Lex", false],
+        ],
+    },
+    {
+        statement:
+            "Qual componente da infraestrutura global da AWS é usado para armazenar em cache cópias de conteúdo e entregá-las mais rápido aos usuários ao redor do mundo?",
+        explanation:
+            "Os locais de borda são pontos de presença usados pelo Amazon CloudFront e por outros serviços para manter cópias do conteúdo perto dos usuários finais. Regiões são áreas geográficas onde as cargas são implantadas, Zonas de Disponibilidade são data centers isolados dentro de uma Região para redundância, e os data centers em si não formam uma camada de cache.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["Regiões da AWS", false],
+            ["Zonas de Disponibilidade", false],
+            ["Locais de borda", true],
+            ["Data centers", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço de armazenamento híbrido da AWS permite que as aplicações locais de um usuário usem o armazenamento na Nuvem AWS de forma transparente?",
+        explanation:
+            "O AWS Storage Gateway é um serviço de armazenamento híbrido que dá às aplicações locais acesso ao armazenamento da AWS por interfaces de arquivo, volume e fita. O AWS Backup centraliza backups, o AWS Elastic Disaster Recovery replica servidores para recuperação de desastres e o AWS Direct Connect é um link de rede dedicado.",
+        topic: "Armazenamento",
+        options: [
+            ["AWS Backup", false],
+            ["AWS Elastic Disaster Recovery", false],
+            ["AWS Direct Connect", false],
+            ["AWS Storage Gateway", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está avaliando serviços da AWS para executar suas cargas de trabalho. Quais das opções a seguir são serviços de computação? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon Lightsail oferece servidores virtuais simplificados e o AWS Batch executa trabalhos de computação em lote provisionando os recursos necessários, então ambos são serviços de computação. O Systems Manager gerencia a operação dos recursos, o CloudFormation provisiona infraestrutura como código e o Config registra configurações.",
+        topic: "Computação",
+        options: [
+            ["Amazon Lightsail", true],
+            ["AWS Systems Manager", false],
+            ["AWS CloudFormation", false],
+            ["AWS Batch", true],
+            ["AWS Config", false],
+        ],
+    },
+    {
+        statement:
+            "O que pode ser usado para automatizar a configuração e o gerenciamento de ambientes AWS com várias contas, seguros e alinhados às boas práticas de arquitetura?",
+        explanation:
+            "O AWS Control Tower automatiza a criação de um ambiente com várias contas (landing zone) e aplica controles (guardrails) de segurança e governança baseados em boas práticas. O GuardDuty detecta ameaças, o Security Hub consolida alertas de segurança e o Well-Architected Tool revisa cargas de trabalho, sem configurar contas.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon GuardDuty", false],
+            ["AWS Control Tower", true],
+            ["AWS Security Hub", false],
+            ["AWS Well-Architected Tool", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço de orquestração de contêineres da AWS dispensa o usuário de instalar, operar e escalar a própria infraestrutura de gerenciamento de clusters?",
+        explanation:
+            "O Amazon ECS é um serviço totalmente gerenciado de orquestração de contêineres que dispensa instalar e operar software próprio de gerenciamento de clusters. O ECR é um registro de imagens de contêiner, o Elastic Beanstalk é uma plataforma para implantar aplicações web e o EBS fornece volumes de armazenamento em bloco.",
+        topic: "Computação",
+        options: [
+            ["Amazon Elastic Container Registry (Amazon ECR)", false],
+            ["AWS Elastic Beanstalk", false],
+            ["Amazon Elastic Container Service (Amazon ECS)", true],
+            ["Amazon Elastic Block Store (Amazon EBS)", false],
+        ],
+    },
+    {
+        statement: "Qual é a finalidade de um gateway de internet em uma VPC?",
+        explanation:
+            "O gateway de internet é o componente anexado à VPC que permite a comunicação entre os recursos com IP público e a internet, nos dois sentidos. A conexão VPN usa um gateway privado virtual, o acesso só de saída para sub-redes privadas é papel do gateway NAT e a distribuição de tráfego entre instâncias é do Elastic Load Balancing.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Criar uma conexão VPN entre a VPC e a rede local", false],
+            ["Permitir a comunicação entre a VPC e a internet", true],
+            ["Dar às sub-redes privadas acesso de saída à internet", false],
+            ["Distribuir o tráfego da internet entre instâncias EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço gerenciado da AWS pode ser usado para distribuir o tráfego entre várias instâncias do Amazon EC2?",
+        explanation:
+            "O Elastic Load Balancing distribui automaticamente o tráfego de entrada entre várias instâncias do Amazon EC2 e deixa de enviar requisições às que falham nas verificações de integridade. O gateway NAT dá saída à internet para sub-redes privadas, o gateway privado virtual termina conexões VPN e o AWS PrivateLink dá acesso privado a serviços.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Gateway NAT", false],
+            ["Elastic Load Balancing", true],
+            ["Gateway privado virtual", false],
+            ["AWS PrivateLink", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer automatizar o processo de implantação das suas aplicações. Qual serviço da AWS pode ser usado para isso?",
+        explanation:
+            "O AWS CodePipeline é um serviço de entrega contínua que automatiza as etapas de compilação, teste e implantação a cada mudança no código. O AppSync cria APIs GraphQL, o CodeArtifact armazena pacotes e dependências de software e o DataSync transfere dados entre o armazenamento local e a AWS.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS AppSync", false],
+            ["AWS CodeArtifact", false],
+            ["AWS CodePipeline", true],
+            ["AWS DataSync", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço ou recurso da AWS permite ao usuário gerenciar o tráfego de uma aplicação entre várias Regiões?",
+        explanation:
+            "O Amazon Route 53 oferece políticas de roteamento por latência, geolocalização e failover, com verificações de integridade, que direcionam o tráfego da aplicação entre várias Regiões. O WorkSpaces Applications faz streaming de aplicações, a VPC é uma rede isolada dentro de uma Região e o Elastic Load Balancing distribui tráfego dentro de uma Região.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Amazon WorkSpaces Applications", false],
+            ["Amazon VPC", false],
+            ["Elastic Load Balancing", false],
+            ["Amazon Route 53", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa armazenar dados críticos do negócio no Amazon S3 e manter uma cópia deles, atualizada automaticamente, em outra Região da AWS. Como isso pode ser feito?",
+        explanation:
+            "A replicação entre Regiões (CRR) do Amazon S3 copia automaticamente os objetos gravados no bucket de origem para um bucket em outra Região. O CloudFront mantém cópias temporárias em cache, não backups, o versionamento guarda versões no próprio bucket e o S3 não tem snapshots de bucket como o EBS.",
+        topic: "Armazenamento",
+        options: [
+            ["Usar o Amazon CloudFront para armazenar os dados em cache globalmente", false],
+            ["Configurar a replicação entre Regiões do Amazon S3 para outra Região", true],
+            ["Ativar o versionamento do Amazon S3 no bucket onde os dados são gravados", false],
+            ["Tirar snapshots do bucket do Amazon S3 e copiá-los para outra Região", false],
+        ],
+    },
+    {
+        statement:
+            "Quais componentes são necessários para criar uma conexão AWS Site-to-Site VPN entre uma rede local e uma VPC? (Selecione DUAS opções.)",
+        explanation:
+            "Uma Site-to-Site VPN precisa de um gateway do cliente, que representa o dispositivo VPN da rede local, e de um gateway privado virtual anexado à VPC, as duas pontas do túnel criptografado. O gateway de internet e o gateway NAT dão acesso à internet, e o peering liga duas VPCs entre si.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Gateway de internet", false],
+            ["Gateway NAT", false],
+            ["Gateway do cliente", true],
+            ["Conexão de peering de VPC", false],
+            ["Gateway privado virtual", true],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação em uma instância do Amazon EC2 grava em um sistema de arquivos cujos dados precisam ser mantidos mesmo quando a instância é interrompida. Qual opção oferece esse armazenamento persistente?",
+        explanation:
+            "Os volumes do Amazon EBS são armazenamento em bloco persistente: os dados continuam lá quando a instância é interrompida, então servem de base para sistemas de arquivos. O armazenamento de instância é temporário e se perde ao interromper a instância, o S3 Glacier Deep Archive arquiva objetos com recuperação em horas e o ElastiCache é um cache em memória.",
+        topic: "Armazenamento",
+        options: [
+            ["S3 Glacier Deep Archive", false],
+            ["Armazenamento de instância do Amazon EC2", false],
+            ["Amazon Elastic Block Store (Amazon EBS)", true],
+            ["Amazon ElastiCache", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup quer reduzir o esforço operacional usando apenas serviços em que não precisa provisionar nem gerenciar servidores. Quais serviços da AWS atendem a esse critério? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Lambda executa código sem provisionar servidores e o Amazon DynamoDB é um banco NoSQL sem servidor que escala automaticamente, com cobrança pelo uso. O EC2 e o Lightsail entregam servidores virtuais que o cliente dimensiona e gerencia, e o Elastic Beanstalk automatiza a implantação, mas ainda cria instâncias EC2 na conta.",
+        topic: "Computação",
+        options: [
+            ["AWS Lambda", true],
+            ["Amazon EC2", false],
+            ["AWS Elastic Beanstalk", false],
+            ["Amazon DynamoDB", true],
+            ["Amazon Lightsail", false],
+        ],
+    },
+    {
+        statement:
+            "Quais serviços gerenciados da AWS podem ser usados para estender um data center local até a rede da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "A AWS Site-to-Site VPN cria túneis criptografados pela internet entre a rede local e a AWS, e o AWS Direct Connect oferece uma conexão física privada e dedicada. O gateway NAT dá saída à internet para sub-redes privadas, o Global Accelerator acelera o acesso de usuários da internet às aplicações e o Route 53 é DNS.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Site-to-Site VPN", true],
+            ["Gateway NAT", false],
+            ["AWS Direct Connect", true],
+            ["AWS Global Accelerator", false],
+            ["Amazon Route 53", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são benefícios de usar o Amazon RDS em vez do Amazon EC2 para executar bancos de dados relacionais na AWS? (Selecione DUAS opções.)",
+        explanation:
+            "No Amazon RDS, a AWS cuida dos backups automatizados, com recuperação para um ponto no tempo, e da aplicação de patches no mecanismo do banco, tarefas manuais quando o banco roda no EC2. Esquema e índices continuam com o cliente nos dois casos, pois dependem do modelo de dados, e ETL é tarefa de serviços como o AWS Glue.",
+        topic: "Banco de dados",
+        options: [
+            ["Backups automatizados do banco de dados", true],
+            ["Gerenciamento do esquema do banco", false],
+            ["Criação de índices nas tabelas", false],
+            ["Aplicação de patches no mecanismo do banco", true],
+            ["Gerenciamento de ETL (extração, transformação e carga)", false],
+        ],
+    },
+    {
+        statement: "O que a classe de armazenamento S3 Intelligent-Tiering oferece?",
+        explanation:
+            "O S3 Intelligent-Tiering monitora o acesso aos objetos e os move automaticamente entre níveis de acesso conforme o uso, sem taxa de recuperação, reduzindo o custo de dados com padrão de acesso imprevisível. O S3 não tem reserva de capacidade, a classe não copia dados para o EBS e o menor custo de arquivamento é do S3 Glacier Deep Archive.",
+        topic: "Armazenamento",
+        options: [
+            ["Flexibilidade de pagamento com a reserva de capacidade de armazenamento", false],
+            [
+                "Retenção de longo prazo com cópia dos dados para volumes criptografados do Amazon EBS",
+                false,
+            ],
+            [
+                "Economia automática ao mover objetos entre níveis conforme o padrão de acesso muda",
+                true,
+            ],
+            ["Armazenamento seguro, durável e de menor custo para arquivamento de dados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem várias fontes de dados espalhadas pela organização e quer consolidar esses dados em um único data warehouse. Qual serviço da AWS pode ser usado para atender a esse requisito?",
+        explanation:
+            "O Amazon Redshift é o data warehouse gerenciado da AWS, feito para consolidar dados de várias fontes e executar consultas analíticas em grande escala. O DynamoDB é um banco NoSQL para cargas transacionais, o Athena consulta dados direto no S3 sem consolidá-los em um warehouse e o Quick Sight cria painéis de BI.",
+        topic: "Banco de dados",
+        options: [
+            ["Amazon DynamoDB", false],
+            ["Amazon Redshift", true],
+            ["Amazon Athena", false],
+            ["Amazon Quick Sight", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS pode ser usado para oferecer uma central de atendimento (contact center) sob demanda e baseada na nuvem?",
+        explanation:
+            "O Amazon Connect é uma central de atendimento em nuvem que pode ser configurada em minutos, escala sob demanda e cobra pelo uso. O AWS Direct Connect é um link de rede dedicado, o AWS Support é o suporte técnico que a AWS presta aos próprios clientes e o AWS Managed Services opera a infraestrutura AWS em nome de empresas.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Direct Connect", false],
+            ["Amazon Connect", true],
+            ["AWS Support", false],
+            ["AWS Managed Services", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa um banco de dados MySQL em uma única instância do Amazon EC2 e agora precisa de maior disponibilidade caso ocorra uma interrupção. Qual conjunto de tarefas atende a esse requisito?",
+        explanation:
+            "Com o Amazon RDS Multi-AZ, a AWS mantém uma réplica síncrona em espera em outra Zona de Disponibilidade e faz o failover automaticamente. Um balanceador de carga na frente de uma única instância não cria redundância, a recuperação automática do EC2 mantém a instância na mesma Zona e a proteção contra encerramento só evita exclusões acidentais.",
+        topic: "Banco de dados",
+        options: [
+            ["Colocar um Application Load Balancer na frente da instância EC2", false],
+            [
+                "Usar o EC2 Auto Recovery para mover a instância para outra Zona de Disponibilidade",
+                false,
+            ],
+            ["Migrar o banco para o Amazon RDS e ativar a implantação Multi-AZ", true],
+            ["Ativar a proteção contra encerramento da instância para evitar quedas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando uma aplicação cujos componentes precisam enviar, armazenar e receber mensagens entre si. Outro requisito é processar as mensagens na ordem em que chegaram (primeiro a entrar, primeiro a sair, ou FIFO). Qual serviço da AWS a empresa deve usar?",
+        explanation:
+            "O Amazon SQS guarda as mensagens em filas até que os componentes as consumam, e as filas FIFO garantem a ordem de chegada e o processamento sem duplicidade. O SNS distribui mensagens no modelo pub/sub sem guardá-las para consumo posterior, o EventBridge roteia eventos sem garantia de ordem e o Step Functions orquestra fluxos de trabalho.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Step Functions", false],
+            ["Amazon Simple Notification Service (Amazon SNS)", false],
+            ["Amazon EventBridge", false],
+            ["Amazon Simple Queue Service (Amazon SQS)", true],
+        ],
+    },
+    {
+        statement:
+            "Um usuário conhece pouco os serviços da AWS, mas quer implantar rapidamente na Nuvem AWS uma aplicação Node.js escalável, sem configurar a infraestrutura por conta própria. Qual serviço deve ser usado para implantar a aplicação?",
+        explanation:
+            "O AWS Elastic Beanstalk recebe o código e cuida automaticamente de provisionamento, balanceamento de carga, escalabilidade e monitoramento, ideal para quem conhece pouco a AWS. O CloudFormation exige escrever templates, o EC2 exige configurar servidores, rede e escalabilidade manualmente, e o EKS exige conhecimento de Kubernetes.",
+        topic: "Computação",
+        options: [
+            ["AWS CloudFormation", false],
+            ["AWS Elastic Beanstalk", true],
+            ["Amazon EC2", false],
+            ["Amazon Elastic Kubernetes Service (Amazon EKS)", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço ou recurso da AWS exige um circuito de um provedor de conectividade e uma instalação de colocation para ser implementado?",
+        explanation:
+            "O AWS Direct Connect liga a rede local à AWS por um circuito físico dedicado, conectado em um local do Direct Connect (uma instalação de colocation), normalmente com apoio de um provedor de rede. A Site-to-Site VPN usa a internet já existente, e o Transit Gateway e o gateway de internet são recursos lógicos criados na própria AWS.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Site-to-Site VPN", false],
+            ["AWS Transit Gateway", false],
+            ["AWS Direct Connect", true],
+            ["Gateway de internet", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa escolher onde executar o código de uma nova aplicação. Quais serviços da AWS oferecem capacidade de computação? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon EC2 fornece servidores virtuais com controle total do sistema operacional e o AWS Lambda executa código em resposta a eventos sem gerenciar servidores, então ambos são serviços de computação. O S3 é armazenamento de objetos, o EBS fornece volumes em bloco para instâncias e o Cognito gerencia a autenticação de usuários.",
+        topic: "Computação",
+        options: [
+            ["Amazon EC2", true],
+            ["Amazon S3", false],
+            ["Amazon Elastic Block Store (Amazon EBS)", false],
+            ["Amazon Cognito", false],
+            ["AWS Lambda", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS pode ser usado para armazenar de forma privada o código-fonte e gerenciar suas versões?",
+        explanation:
+            "O AWS CodeCommit é um serviço gerenciado de controle de versão que hospeda repositórios Git privados. O CodeBuild compila o código e executa testes, o CodePipeline automatiza as etapas de lançamento e o X-Ray rastreia requisições para analisar o desempenho de aplicações distribuídas, sem guardar código.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS CodeBuild", false],
+            ["AWS CodeCommit", true],
+            ["AWS CodePipeline", false],
+            ["AWS X-Ray", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço ou recurso da AWS é usado para enviar mensagens de texto (SMS) e e-mails a partir de aplicações distribuídas?",
+        explanation:
+            "O Amazon SNS é um serviço de mensagens pub/sub que entrega notificações por SMS, e-mail e outros canais aos assinantes de um tópico. O Amazon SES envia apenas e-mails, os alarmes do CloudWatch dependem do SNS para notificar e o Amazon SQS enfileira mensagens entre componentes, sem enviá-las a pessoas.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon SNS", true],
+            ["Amazon SES", false],
+            ["Alarmes do Amazon CloudWatch", false],
+            ["Amazon SQS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está criando uma aplicação que precisa entregar imagens e vídeos para usuários do mundo todo com latência mínima. Qual abordagem a empresa pode usar para fazer isso de forma econômica?",
+        explanation:
+            "O Amazon CloudFront armazena imagens e vídeos em cache em centenas de locais de borda e os entrega a partir do ponto mais próximo de cada usuário, com baixa latência e custo menor de transferência. A replicação entre Regiões do S3 copia dados, mas o acesso continua regional, a VPN liga redes e o PrivateLink dá acesso privado a serviços.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Entregar o conteúdo pelo Amazon CloudFront", true],
+            ["Armazenar o conteúdo no Amazon S3 e ativar a replicação entre Regiões", false],
+            ["Implementar uma VPN entre várias Regiões da AWS", false],
+            ["Entregar o conteúdo pelo AWS PrivateLink", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem usuários em várias partes do mundo que enfrentam alta latência ao acessar sua aplicação, hospedada em uma única Região da AWS. A aplicação usa tráfego TCP e UDP, e não apenas HTTP. Qual serviço da AWS melhora o desempenho e a disponibilidade da aplicação encaminhando esse tráfego pela rede global da AWS?",
+        explanation:
+            "O AWS Global Accelerator recebe o tráfego TCP e UDP no local de borda mais próximo do usuário e o conduz pela rede global da AWS até a aplicação, reduzindo latência e instabilidade. O CloudFront é uma CDN voltada a conteúdo HTTP, o Route 53 atua só na resolução DNS e o Elastic Load Balancing distribui tráfego dentro de uma Região.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["AWS Global Accelerator", true],
+            ["Amazon CloudFront", false],
+            ["Amazon Route 53", false],
+            ["Elastic Load Balancing", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS fornece endereços IP estáticos anycast que funcionam como um ponto de entrada fixo para os endpoints de uma aplicação em uma ou mais Regiões da AWS?",
+        explanation:
+            "O AWS Global Accelerator fornece dois endereços IP estáticos anycast que servem de entrada fixa e levam o tráfego pela rede da AWS até o endpoint saudável mais próximo, em uma ou mais Regiões. O Elastic Load Balancing atua dentro de uma Região, o Route 53 resolve nomes DNS e o API Gateway expõe APIs sem oferecer IPs anycast fixos.",
+        topic: "Rede e entrega de conteúdo",
+        options: [
+            ["Elastic Load Balancing", false],
+            ["Amazon Route 53", false],
+            ["AWS Global Accelerator", true],
+            ["Amazon API Gateway", false],
+        ],
+    },
+    {
+        statement:
+            "Por exigências de residência de dados, uma empresa precisa manter suas cargas de trabalho no próprio data center, mas quer usar os mesmos serviços, APIs e ferramentas da AWS. Qual serviço atende a esse requisito?",
+        explanation:
+            "O AWS Outposts instala no data center do cliente racks e servidores gerenciados pela AWS, com as mesmas APIs e ferramentas da nuvem, e os dados permanecem no local. O Wavelength leva recursos à borda das redes 5G, as Local Zones ficam em instalações da AWS perto de grandes cidades e o Direct Connect é só uma conexão de rede dedicada.",
+        topic: "Computação",
+        options: [
+            ["AWS Wavelength", false],
+            ["AWS Local Zones", false],
+            ["AWS Outposts", true],
+            ["AWS Direct Connect", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de mídia precisa executar aplicações sensíveis à latência, como edição de vídeo em tempo real, perto dos usuários de uma área metropolitana onde não há uma Região da AWS próxima, e não quer instalar hardware em instalações próprias. Qual opção de infraestrutura da AWS ela deve considerar?",
+        explanation:
+            "As AWS Local Zones levam computação, armazenamento e banco de dados para perto de grandes centros urbanos sem Região próxima, com latência de milissegundos de um dígito. O Outposts exige instalar hardware no local do cliente, o Wavelength atende aplicações móveis dentro das redes 5G e o CloudFront distribui conteúdo em cache.",
+        topic: "Conceitos e arquitetura",
+        options: [
+            ["AWS Outposts", false],
+            ["AWS Local Zones", true],
+            ["AWS Wavelength", false],
+            ["Amazon CloudFront", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer criar uma arquitetura orientada a eventos na qual vários serviços da AWS e aplicações SaaS de parceiros reagem a eventos em tempo real. Qual serviço da AWS oferece um barramento de eventos sem servidor para essa finalidade?",
+        explanation:
+            "O Amazon EventBridge é um barramento de eventos sem servidor que recebe eventos de serviços da AWS, de aplicações próprias e de parceiros SaaS e os encaminha a destinos por meio de regras de filtragem. O SNS envia notificações pub/sub, o SQS é uma fila de mensagens e o Step Functions orquestra fluxos de trabalho.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon SNS", false],
+            ["Amazon SQS", false],
+            ["Amazon EventBridge", true],
+            ["AWS Step Functions", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer acionar automaticamente uma função do AWS Lambda sempre que uma instância do Amazon EC2 mudar de estado, por exemplo, ao ser interrompida. Qual serviço detecta essas mudanças nos recursos da AWS e encaminha os eventos para destinos como o Lambda, filas do SQS ou tópicos do SNS?",
+        explanation:
+            "O Amazon EventBridge recebe os eventos de mudança de estado emitidos pelos serviços da AWS e, por meio de regras, os envia a destinos como Lambda, SQS e SNS. O Kinesis Data Streams ingere fluxos contínuos de dados, o CloudTrail registra chamadas de API para auditoria e o Amazon MQ é um broker de mensagens gerenciado.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Kinesis Data Streams", false],
+            ["Amazon EventBridge", true],
+            ["AWS CloudTrail", false],
+            ["Amazon MQ", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer montar uma central de atendimento em nuvem, na qual seus agentes atendem ligações e chats de clientes, sem manter infraestrutura de telefonia. Qual serviço da AWS oferece esse recurso?",
+        explanation:
+            "O Amazon Connect é o serviço de central de atendimento em nuvem: configura filas, fluxos de contato e atendimento por voz e chat, com pagamento por uso. O Lex cria chatbots que podem ser integrados a uma central, mas não a opera, o AWS Support Center gerencia casos de suporte com a AWS e o WorkSpaces fornece desktops virtuais.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Lex", false],
+            ["Amazon Connect", true],
+            ["AWS Support Center", false],
+            ["Amazon WorkSpaces", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer construir, treinar e implantar modelos de machine learning em escala. Qual serviço da AWS oferece um ambiente totalmente gerenciado para todo esse ciclo?",
+        explanation:
+            "O Amazon SageMaker AI (antigo Amazon SageMaker) reúne ferramentas gerenciadas para preparar dados e construir, treinar e implantar modelos de ML em escala. O Rekognition e o Comprehend são serviços de IA prontos para imagem e texto, e as Deep Learning AMIs são imagens de EC2 que o próprio cliente precisa gerenciar.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Rekognition", false],
+            ["Amazon SageMaker AI", true],
+            ["Amazon Comprehend", false],
+            ["AWS Deep Learning AMIs", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS detecta automaticamente objetos, pessoas, textos e atividades em imagens e vídeos?",
+        explanation:
+            "O Amazon Rekognition usa deep learning para identificar objetos, pessoas, textos, cenas e atividades em imagens e vídeos, sem exigir experiência em ML. O Textract extrai texto e dados de documentos, o Transcribe converte fala em texto e o Kinesis Video Streams apenas ingere e armazena fluxos de vídeo.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Textract", false],
+            ["Amazon Transcribe", false],
+            ["Amazon Rekognition", true],
+            ["Amazon Kinesis Video Streams", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa analisar avaliações escritas por clientes para identificar o sentimento e extrair frases-chave. Qual serviço da AWS usa processamento de linguagem natural (PLN) para essa finalidade?",
+        explanation:
+            "O Amazon Comprehend aplica processamento de linguagem natural a textos para detectar sentimento, entidades, frases-chave e idioma. O Translate traduz textos entre idiomas, o Transcribe converte áudio em texto e o Lex cria interfaces conversacionais, como chatbots, sem analisar avaliações.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Translate", false],
+            ["Amazon Comprehend", true],
+            ["Amazon Transcribe", false],
+            ["Amazon Lex", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS permite que desenvolvedores criem interfaces conversacionais, como chatbots, que entendem voz e texto?",
+        explanation:
+            "O Amazon Lex oferece reconhecimento de fala e compreensão de linguagem natural para criar chatbots e assistentes de voz e texto, com a mesma tecnologia da Alexa. O Polly converte texto em fala, o Transcribe converte fala em texto e o Comprehend analisa textos, mas nenhum deles conduz um diálogo.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Polly", false],
+            ["Amazon Lex", true],
+            ["Amazon Transcribe", false],
+            ["Amazon Comprehend", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS converte texto em fala com som natural, permitindo criar aplicações que falam?",
+        explanation:
+            "O Amazon Polly usa deep learning para transformar texto em fala realista, com dezenas de idiomas e vozes. O Transcribe faz o caminho inverso, convertendo fala em texto, o Translate traduz textos entre idiomas e o Lex cria chatbots de voz e texto, mas não é o serviço que sintetiza a fala.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Transcribe", false],
+            ["Amazon Translate", false],
+            ["Amazon Polly", true],
+            ["Amazon Lex", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa converter automaticamente em texto as gravações de áudio das ligações de clientes. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O Amazon Transcribe é um serviço de reconhecimento automático de fala que converte áudio em texto, ideal para transcrever gravações de ligações. O Polly faz o inverso (texto em fala), o Comprehend analisa textos já escritos e o Lex cria chatbots que interagem com usuários, sem transcrever gravações.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Polly", false],
+            ["Amazon Comprehend", false],
+            ["Amazon Transcribe", true],
+            ["Amazon Lex", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS usa tradução automática neural para converter textos entre idiomas diferentes?",
+        explanation:
+            "O Amazon Translate usa tradução automática neural para traduzir textos entre idiomas com rapidez e qualidade. O Comprehend extrai sentimento, entidades e frases-chave de textos, o Transcribe converte fala em texto e o Lex cria interfaces conversacionais, e nenhum deles faz tradução.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Comprehend", false],
+            ["Amazon Transcribe", false],
+            ["Amazon Lex", false],
+            ["Amazon Translate", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer executar aplicações web de longa duração em contêineres Docker, agendados em um cluster de instâncias do Amazon EC2 pelo orquestrador próprio da AWS, sem adotar o Kubernetes. Qual serviço de orquestração de contêineres totalmente gerenciado atende a esse requisito?",
+        explanation:
+            "O Amazon ECS é o orquestrador de contêineres nativo da AWS: agenda e mantém contêineres Docker em clusters de EC2 ou no Fargate, sem usar Kubernetes. O EKS é o serviço gerenciado de Kubernetes, o Lambda executa funções orientadas a eventos e o AWS Batch processa trabalhos em lote, e não serviços contínuos.",
+        topic: "Computação",
+        options: [
+            ["Amazon Elastic Kubernetes Service (Amazon EKS)", false],
+            ["AWS Lambda", false],
+            ["Amazon Elastic Container Service (Amazon ECS)", true],
+            ["AWS Batch", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa mover grandes volumes de dados de seus servidores de arquivos NFS e SMB locais para o Amazon S3, com transferências agendadas, validação de integridade e uso otimizado da rede. Qual serviço da AWS automatiza e acelera essa transferência?",
+        explanation:
+            "O AWS DataSync usa um agente local para copiar dados de compartilhamentos NFS e SMB para o S3, o EFS ou o FSx, com agendamento, criptografia e verificação de integridade. O Storage Gateway dá acesso híbrido contínuo ao armazenamento na nuvem, o Transfer Family expõe endpoints SFTP e FTP e o AWS Backup centraliza backups.",
+        topic: "Migração",
+        options: [
+            ["AWS Storage Gateway", false],
+            ["AWS DataSync", true],
+            ["AWS Transfer Family", false],
+            ["AWS Backup", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa de um serviço de business intelligence (BI) nativo da nuvem para criar dashboards interativos e visualizações a partir de várias fontes de dados. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O Amazon Quick Sight (antigo Amazon QuickSight) é o serviço de BI sem servidor da AWS para criar dashboards e visualizações interativas conectando fontes como S3, RDS, Redshift e Athena. O Athena consulta dados no S3 com SQL, o Redshift é um data warehouse e o Lake Formation cria e governa data lakes.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Athena", false],
+            ["Amazon Quick Sight", true],
+            ["Amazon Redshift", false],
+            ["AWS Lake Formation", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa de um serviço de extração, transformação e carga (ETL) totalmente gerenciado e sem servidor para preparar e transformar dados para análise. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O AWS Glue é o serviço de integração de dados sem servidor da AWS: descobre fontes, prepara e transforma dados em jobs de ETL e os carrega para análise. O Kinesis ingere dados de streaming em tempo real, o EMR executa frameworks de big data como Spark e Hadoop e o Athena consulta dados no S3 com SQL.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Kinesis", false],
+            ["AWS Glue", true],
+            ["Amazon EMR", false],
+            ["Amazon Athena", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS usa crawlers para descobrir automaticamente e catalogar os metadados de várias fontes de dados, além de gerar scripts de ETL para transformar esses dados?",
+        explanation:
+            "O AWS Glue usa crawlers que examinam as fontes de dados e registram esquemas e tabelas no AWS Glue Data Catalog, e também gera scripts de ETL. O Athena consulta dados no S3 usando esse catálogo, o Redshift Spectrum consulta o S3 a partir do Redshift e o EMR processa big data com Spark e Hadoop.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Athena", false],
+            ["AWS Glue", true],
+            ["Amazon Redshift Spectrum", false],
+            ["Amazon EMR", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS captura e processa continuamente, em tempo real, grandes volumes de dados de streaming vindos de fontes como cliques em sites, transações financeiras e feeds de redes sociais?",
+        explanation:
+            "O Amazon Kinesis Data Streams captura e armazena fluxos de dados em tempo real, com escala para grandes volumes vindos de cliques, transações e redes sociais. O SQS é uma fila para desacoplar componentes, o Redshift é um data warehouse para consultas analíticas e o AWS Batch processa trabalhos em lote, e não em tempo real.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Kinesis Data Streams", true],
+            ["Amazon Simple Queue Service (Amazon SQS)", false],
+            ["Amazon Redshift", false],
+            ["AWS Batch", false],
+        ],
+    },
+    {
+        statement:
+            "Para fins de recuperação de desastres, uma empresa quer manter um banco de dados no Amazon RDS sincronizado continuamente com seu banco de dados on-premises, replicando cada alteração quase em tempo real. Qual serviço da AWS oferece essa replicação contínua?",
+        explanation:
+            "O AWS DMS faz replicação contínua com captura de dados de alteração (CDC), aplicando no banco de destino as mudanças feitas na origem quase em tempo real. O AWS Backup cria cópias pontuais, o Multi-AZ replica apenas dentro da AWS e o Application Migration Service replica servidores inteiros para instâncias EC2, e não para o RDS.",
+        topic: "Migração",
+        options: [
+            ["AWS Backup", false],
+            ["AWS Database Migration Service (AWS DMS)", true],
+            ["Implantação Multi-AZ do Amazon RDS", false],
+            ["AWS Application Migration Service (AWS MGN)", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor precisa criar um fluxo sem servidor de processamento de pedidos que chama várias funções do AWS Lambda em sequência, trata erros em cada etapa, repete automaticamente as etapas que falharem e segue caminhos diferentes conforme o tipo de pedido. Qual serviço da AWS foi projetado para isso?",
+        explanation:
+            "O AWS Step Functions orquestra serviços em fluxos de trabalho visuais com estado, com etapas em sequência ou em paralelo, tratamento de erros, novas tentativas automáticas e ramificações condicionais. O SQS enfileira mensagens, o EventBridge roteia eventos por regras e o SNS distribui notificações, mas nenhum deles controla o estado do fluxo.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon SQS", false],
+            ["Amazon EventBridge", false],
+            ["AWS Step Functions", true],
+            ["Amazon SNS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer conectar com segurança milhões de sensores industriais à AWS, para que os dados sejam processados em tempo real e armazenados no Amazon S3. Qual serviço da AWS gerencia a conexão dos dispositivos, a autenticação e o roteamento das mensagens?",
+        explanation:
+            "O AWS IoT Core conecta dispositivos à nuvem em grande escala, autentica cada um com certificados e usa regras para rotear as mensagens a serviços como Kinesis e S3. O IoT Greengrass leva o processamento para a borda, perto dos dispositivos, o Kinesis processa os fluxos depois de recebidos e o Direct Connect é um link de rede dedicado.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS IoT Greengrass", false],
+            ["Amazon Kinesis", false],
+            ["AWS IoT Core", true],
+            ["AWS Direct Connect", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de software quer entregar seu aplicativo de desktop aos clientes pelo navegador, sem que eles precisem baixar ou instalar nada. O aplicativo deve rodar na infraestrutura da AWS e transmitir sua interface para o navegador. Qual serviço da AWS a empresa deve usar?",
+        explanation:
+            "O Amazon WorkSpaces Applications (antigo Amazon AppStream 2.0) executa aplicativos de desktop na AWS e transmite a interface para o navegador do usuário. O WorkSpaces entrega desktops virtuais completos por usuário, o WorkSpaces Secure Browser dá acesso seguro a sites e SaaS e o Amplify cria e hospeda aplicações web e móveis.",
+        topic: "Computação",
+        options: [
+            ["Amazon WorkSpaces", false],
+            ["Amazon WorkSpaces Secure Browser", false],
+            ["Amazon WorkSpaces Applications", true],
+            ["AWS Amplify", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer substituir os computadores físicos por desktops virtuais hospedados na nuvem, acessíveis de qualquer dispositivo, com cada funcionário tendo seu próprio desktop persistente e personalizado. Qual serviço da AWS oferece esse recurso?",
+        explanation:
+            "O Amazon WorkSpaces é o serviço gerenciado de desktops virtuais: na modalidade WorkSpaces Personal, cada usuário recebe um desktop persistente, acessível de vários dispositivos. O WorkSpaces Applications transmite aplicativos específicos, o Secure Browser só dá acesso a sites e SaaS e o EC2 exigiria montar e gerenciar a solução de desktops.",
+        topic: "Computação",
+        options: [
+            ["Amazon WorkSpaces Applications", false],
+            ["Amazon WorkSpaces", true],
+            ["Amazon WorkSpaces Secure Browser", false],
+            ["Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer que os funcionários usem dispositivos pessoais, não gerenciados, para acessar pelo navegador aplicações web internas e ferramentas SaaS aprovadas, com o menor custo e sem que dados corporativos possam ser baixados ou copiados para esses dispositivos. Qual serviço da AWS foi criado para esse caso de uso?",
+        explanation:
+            "O Amazon WorkSpaces Secure Browser (antigo WorkSpaces Web) exibe as páginas a partir de um navegador isolado na AWS, sem que os dados cheguem ao dispositivo, e pode bloquear download, impressão e cópia. O WorkSpaces entrega desktops completos, o Client VPN dá acesso de rede ao dispositivo e o Session Manager serve para administrar instâncias.",
+        topic: "Computação",
+        options: [
+            ["Amazon WorkSpaces", false],
+            ["AWS Client VPN", false],
+            ["AWS Systems Manager Session Manager", false],
+            ["Amazon WorkSpaces Secure Browser", true],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor front-end quer criar e implantar na AWS uma aplicação web full-stack com autenticação de usuários, API de dados e hospedagem, sem configurar nem gerenciar a infraestrutura de nuvem por trás. Qual serviço da AWS oferece uma plataforma integrada de desenvolvimento e implantação para esse caso?",
+        explanation:
+            "O AWS Amplify reúne bibliotecas, ferramentas e hospedagem com implantação contínua para que desenvolvedores front-end criem aplicações web e móveis full-stack com autenticação, dados e armazenamento. O Elastic Beanstalk implanta aplicações de back-end em servidores, o Lightsail oferece servidores virtuais simples e o AppSync é só a camada de API GraphQL.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Elastic Beanstalk", false],
+            ["AWS Amplify", true],
+            ["Amazon Lightsail", false],
+            ["AWS AppSync", false],
+        ],
+    },
+    {
+        statement:
+            "A aplicação de e-commerce de uma empresa precisa enviar automaticamente, em grande volume e direto do código, e-mails de confirmação de pedido, avisos de envio e redefinição de senha para os clientes. Qual serviço da AWS foi projetado para esse caso de uso?",
+        explanation:
+            "O Amazon SES é o serviço de envio de e-mail em escala para mensagens transacionais e de marketing, com gestão de reputação, tratamento de devoluções e métricas de entrega. O SNS entrega notificações pub/sub a assinantes, o Connect é uma central de atendimento e o AWS End User Messaging envia SMS, voz e push, mas não e-mail.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Simple Notification Service (Amazon SNS)", false],
+            ["Amazon Simple Email Service (Amazon SES)", true],
+            ["Amazon Connect", false],
+            ["AWS End User Messaging", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa recebe milhares de formulários em papel digitalizados por dia e precisa extrair automaticamente textos, tabelas e valores de campos específicos desses documentos, sem precisar treinar modelos de machine learning próprios. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O Amazon Textract extrai texto impresso, escrita à mão, tabelas e pares de campo e valor de documentos digitalizados, entendendo a estrutura dos formulários. O Comprehend analisa textos já extraídos, o Rekognition detecta objetos e textos soltos em imagens, sem entender formulários, e o Transcribe converte áudio em texto.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon Comprehend", false],
+            ["Amazon Rekognition", false],
+            ["Amazon Transcribe", false],
+            ["Amazon Textract", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está criando um aplicativo móvel colaborativo no qual vários usuários precisam ver em tempo real as alterações em dados compartilhados. A equipe quer usar GraphQL e que o back-end envie automaticamente as mudanças a todos os clientes conectados. Qual serviço da AWS oferece APIs GraphQL gerenciadas com sincronização de dados em tempo real?",
+        explanation:
+            "O AWS AppSync é o serviço gerenciado de APIs GraphQL da AWS e, por meio de assinaturas (subscriptions), envia as alterações de dados em tempo real a todos os clientes conectados. O API Gateway cria APIs REST, HTTP e WebSocket sem GraphQL nativo, o Kinesis processa streaming de dados e o Amplify é o conjunto de ferramentas que consome essas APIs.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon API Gateway", false],
+            ["Amazon Kinesis", false],
+            ["AWS AppSync", true],
+            ["AWS Amplify", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS oferece sistemas de arquivos de terceiros totalmente gerenciados, otimizados para cargas de trabalho como computação de alto desempenho (HPC), machine learning e aplicações baseadas em Windows?",
+        explanation:
+            "O Amazon FSx oferece sistemas de arquivos gerenciados baseados em tecnologias de terceiros: FSx for Lustre para HPC e ML, FSx for Windows File Server, FSx for NetApp ONTAP e FSx for OpenZFS. O EBS é armazenamento em bloco para instâncias EC2, o S3 guarda objetos acessados por API e o EFS é um sistema de arquivos NFS nativo da AWS.",
+        topic: "Armazenamento",
+        options: [
+            ["Amazon EBS", false],
+            ["Amazon S3", false],
+            ["Amazon FSx", true],
+            ["Amazon EFS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa acompanhar e gerenciar suas licenças de software da Microsoft e da Oracle enquanto migra cargas de trabalho para a AWS, evitando usar mais licenças do que contratou. Qual serviço da AWS ajuda a manter a conformidade com essas licenças?",
+        explanation:
+            "O AWS License Manager centraliza o controle de licenças de fornecedores como Microsoft, Oracle e SAP na AWS e on-premises, com regras que acompanham o uso e impedem exceder o contratado. O Systems Manager cuida de tarefas operacionais como patches, o Config avalia configurações de recursos e o Service Catalog controla quais produtos podem ser implantados.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Systems Manager", false],
+            ["AWS License Manager", true],
+            ["AWS Config", false],
+            ["AWS Service Catalog", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa aplicações em contêineres no Amazon ECS e precisa de um registro totalmente gerenciado para armazenar, gerenciar e implantar imagens de contêineres Docker. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O Amazon Elastic Container Registry (Amazon ECR) é o registro gerenciado de imagens de contêiner da AWS, integrado ao ECS e ao EKS, com varredura de vulnerabilidades e políticas de ciclo de vida. O S3 guarda objetos sem oferecer a API de registro Docker, o CodeCommit hospeda repositórios Git e o CodeArtifact armazena pacotes como npm e Maven.",
+        topic: "Computação",
+        options: [
+            ["Amazon S3", false],
+            ["AWS CodeCommit", false],
+            ["Amazon ECR", true],
+            ["AWS CodeArtifact", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer uma solução de recuperação de desastres de baixo custo que, se o site principal falhar, recupere seus servidores on-premises na AWS em minutos e com perda mínima de dados. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O AWS Elastic Disaster Recovery replica continuamente os servidores de origem para uma área de preparação de baixo custo na AWS e, em caso de desastre, inicia instâncias de recuperação em minutos. O AWS Backup faz cópias pontuais, a replicação entre Regiões copia apenas objetos do S3 e o DataSync só transfere dados.",
+        topic: "Armazenamento",
+        options: [
+            ["AWS Backup", false],
+            ["AWS Elastic Disaster Recovery", true],
+            ["Replicação entre Regiões (CRR) do Amazon S3", false],
+            ["AWS DataSync", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa com várias contas da AWS em uma organização quer compartilhar sub-redes de VPC e gateways do AWS Transit Gateway entre as contas, sem duplicar esses recursos em cada uma. Qual serviço da AWS permite isso?",
+        explanation:
+            "O AWS Resource Access Manager (AWS RAM) compartilha com segurança recursos como sub-redes de VPC, Transit Gateways e regras do Route 53 Resolver com outras contas ou com toda a organização. O Organizations governa as contas, o emparelhamento de VPC só conecta duas VPCs e o Control Tower configura um ambiente multiconta.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Organizations", false],
+            ["Emparelhamento de VPC (VPC peering)", false],
+            ["AWS Resource Access Manager", true],
+            ["AWS Control Tower", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer oferecer aos funcionários um assistente de IA generativa pronto para uso, que responde a perguntas sobre os dados da empresa, gera conteúdo e automatiza tarefas a partir das fontes de conhecimento corporativas, sem que a equipe precise desenvolver a aplicação. Qual serviço da AWS ela deve usar?",
+        explanation:
+            "O Amazon Quick, sucessor do Amazon Q Business, é um assistente de IA pronto para uso que responde com base nos dados da empresa, pesquisa, cria conteúdo e automatiza tarefas com agentes e fluxos. O SageMaker AI serve para criar modelos de ML, o Lex para desenvolver chatbots e o Bedrock para construir aplicações próprias de IA generativa.",
+        topic: "Machine learning",
+        options: [
+            ["Amazon SageMaker AI", false],
+            ["Amazon Quick", true],
+            ["Amazon Lex", false],
+            ["Amazon Bedrock", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d3.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d3.ts
@@ -163,12 +163,12 @@ export const QUESTOES_CLOUDCERTPREP_D3: Questao[] = [
         statement:
             "Qual serviço da AWS permite executar consultas interativas com SQL padrão diretamente sobre dados armazenados no Amazon S3, pagando por consulta?",
         explanation:
-            "O Amazon Athena é um serviço de consultas interativas sem servidor que roda SQL padrão direto sobre os dados no S3, cobrando pelo volume lido em cada consulta. O AWS Glue prepara e transforma dados (ETL), o Amazon EMR executa frameworks de big data como Spark e Hadoop e o Amazon QuickSight cria painéis de BI.",
+            "O Amazon Athena é um serviço de consultas interativas sem servidor que roda SQL padrão direto sobre os dados no S3, cobrando pelo volume lido em cada consulta. O AWS Glue prepara e transforma dados (ETL), o Amazon EMR executa frameworks de big data como Spark e Hadoop e o Amazon Quick Sight cria painéis de BI.",
         topic: "Ferramentas e suporte",
         options: [
             ["AWS Glue", false],
             ["Amazon EMR", false],
-            ["Amazon QuickSight", false],
+            ["Amazon Quick Sight", false],
             ["Amazon Athena", true],
         ],
     },

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d4.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep-d4.ts
@@ -1,0 +1,2067 @@
+// Questões do simulado AWS Certified Cloud Practitioner (CLF-C02), domínio 4 da prova
+// (Billing, Pricing, and Support), traduzidas e adaptadas do banco aberto cloudcertprep:
+// https://github.com/nastaso/cloudcertprep (commit 9367b00).
+//
+// Copyright (c) 2026 Alex Santonastaso. Distribuído sob a licença MIT, cujo texto
+// completo está em LICENSE-cloudcertprep.txt, nesta mesma pasta.
+//
+// A adaptação segue as regras do banco da casa: enunciado e explicação em
+// português, nomes de serviço atualizados, opções equilibradas em tamanho e
+// questões de múltipla resposta com cinco opções.
+import type { Questao } from "./aws-ccp-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP_D4: Questao[] = [
+    {
+        statement:
+            "Uma empresa configurou o faturamento consolidado para várias contas da AWS, e uma dessas contas comprou Instâncias Reservadas por 3 anos. Qual afirmação sobre esse cenário está correta?",
+        explanation:
+            "No faturamento consolidado do AWS Organizations, o desconto das Instâncias Reservadas é compartilhado por padrão entre as contas da organização, e a conta de gerenciamento pode desativar esse compartilhamento. A reserva é um compromisso de cobrança, não muda o desempenho, e o recurso gera economia real.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "O desconto das Instâncias Reservadas só pode ser compartilhado com a conta de gerenciamento",
+                false,
+            ],
+            [
+                "Qualquer conta da organização pode receber o desconto por hora das Instâncias Reservadas",
+                true,
+            ],
+            [
+                "As Instâncias Reservadas compradas terão desempenho melhor que o das instâncias On-Demand",
+                false,
+            ],
+            [
+                "O faturamento consolidado não gera economia, pois serve apenas para fins informativos",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso da AWS permite a um cliente consultar em detalhes o que foi cobrado pelo uso do Amazon EC2 no mês passado?",
+        explanation:
+            "O AWS Cost and Usage Report traz o detalhamento das cobranças reais por serviço, recurso e período, incluindo o Amazon EC2; hoje ele é gerado como CUR 2.0 pelo AWS Data Exports. O Cost Anomaly Detection alerta sobre gastos fora do padrão, o Pricing Calculator estima custos futuros e o Systems Manager cuida da operação.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost Anomaly Detection", false],
+            ["AWS Pricing Calculator", false],
+            ["AWS Systems Manager", false],
+            ["AWS Cost and Usage Report", true],
+        ],
+    },
+    {
+        statement:
+            "Uma startup com orçamento apertado quer ser avisada sempre que a fatura mensal da AWS passar de US$ 2.000. Quais opções atendem a esse requisito? (Selecione DUAS opções.)",
+        explanation:
+            "O alarme de faturamento do Amazon CloudWatch dispara uma notificação do Amazon SNS quando o valor definido é ultrapassado, e o AWS Budgets envia alertas quando o custo real ou previsto passa do orçamento. O SES só envia e-mails, o CloudTrail registra chamadas de API e o Amazon Connect é uma central de atendimento.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Criar um alarme de faturamento no Amazon CloudWatch que envie uma notificação pelo Amazon SNS",
+                true,
+            ],
+            [
+                "Configurar o Amazon SES para enviar diariamente os dados de faturamento para o e-mail da empresa",
+                false,
+            ],
+            [
+                "Configurar um orçamento no AWS Budgets que alerte a empresa quando o limite for ultrapassado",
+                true,
+            ],
+            [
+                "Configurar o AWS CloudTrail para registrar os gastos e avisar quando o limite for ultrapassado",
+                false,
+            ],
+            [
+                "Configurar o Amazon Connect para alertar a empresa quando o limite for ultrapassado",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa executar uma aplicação de questionário durante apenas um dia, sem nenhuma interrupção. Qual opção de compra do Amazon EC2 ela deve usar?",
+        explanation:
+            "As Instâncias On-Demand são cobradas só pelo tempo de uso, sem compromisso, e não são interrompidas pela AWS, o que atende a uma tarefa de um dia. As Reservadas exigem compromisso de 1 ou 3 anos, as Spot podem ser interrompidas e as Dedicadas custam mais sem trazer vantagem nesse caso.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Reservadas", false],
+            ["Instâncias Spot", false],
+            ["Instâncias Dedicadas", false],
+            ["Instâncias On-Demand", true],
+        ],
+    },
+    {
+        statement:
+            "Um projeto vai gerar miniaturas de milhões de imagens. O processamento pode ser interrompido e retomado depois, e não precisa rodar de forma contínua. Qual opção de compra do Amazon EC2 é a MAIS econômica?",
+        explanation:
+            "As Instâncias Spot usam capacidade ociosa da AWS com descontos de até 90% sobre o On-Demand e podem ser interrompidas, o que combina com um processamento em lote que pode ser retomado. As Reservadas exigem compromisso de longo prazo, o On-Demand cobra o preço cheio e os Hosts Dedicados são a opção mais cara.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Reservadas", false],
+            ["Instâncias On-Demand", false],
+            ["Hosts Dedicados", false],
+            ["Instâncias Spot", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa decidiu comprar Instâncias Reservadas do Amazon EC2 por 3 anos para reduzir custos, mas as cargas de trabalho podem mudar nesse período. Qual opção permite trocar a reserva por outra com mais capacidade de computação, se for preciso?",
+        explanation:
+            "As Instâncias Reservadas Conversíveis podem ser trocadas durante o prazo por outras Conversíveis de valor igual ou maior, com outra família, sistema operacional ou locação. As Standard dão desconto maior, mas só permitem ajustar alguns atributos, e On-Demand e Spot não envolvem reserva.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Reservadas Standard", false],
+            ["Instâncias Reservadas Conversíveis", true],
+            ["Instâncias On-Demand sem compromisso", false],
+            ["Instâncias Spot", false],
+        ],
+    },
+    {
+        statement:
+            "Qual combinação de Instância Reservada oferece a MAIOR economia média em relação ao preço On-Demand?",
+        explanation:
+            "O maior desconto vem da soma do prazo mais longo (3 anos), do pagamento adiantado integral e da classe Standard, menos flexível que a Conversível. Prazo de 1 ano, ausência de pagamento adiantado e classe Conversível reduzem o desconto em troca de flexibilidade ou de menor desembolso inicial.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Standard de 1 ano, sem pagamento adiantado", false],
+            ["Conversível de 1 ano, com pagamento adiantado integral", false],
+            ["Standard de 3 anos, com pagamento adiantado integral", true],
+            ["Conversível de 3 anos, sem pagamento adiantado", false],
+        ],
+    },
+    {
+        statement:
+            "Quais opções descrevem MELHOR o modelo de preços da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "A AWS cobra pelo que é consumido, sem contrato obrigatório nem investimento inicial, o que torna o custo variável e proporcional ao uso. Prazo fixo e custo planejado com antecedência descrevem contratos tradicionais, e colocation é alugar espaço em data center de terceiros para servidores próprios.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Contrato de prazo fixo", false],
+            ["Pagamento conforme o uso", true],
+            ["Hospedagem em colocation", false],
+            ["Custo fixo planejado com antecedência", false],
+            ["Modelo de custo variável", true],
+        ],
+    },
+    {
+        statement:
+            "Um cliente usa várias contas da AWS, cada uma com faturamento separado. Como ele pode aproveitar descontos por volume com o menor impacto possível sobre os recursos da AWS?",
+        explanation:
+            "O faturamento consolidado do AWS Organizations soma o uso de todas as contas para alcançar faixas de preço por volume, sem mover recursos. Juntar tudo em uma conta dá muito trabalho e tira o isolamento, Instâncias Reservadas reduzem o custo de cargas previsíveis sem somar o uso entre contas e plano de suporte não dá desconto por volume.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Criar uma única conta global e mover todos os recursos para ela", false],
+            ["Contratar Instâncias Reservadas de 3 anos com pagamento adiantado", false],
+            ["Ativar o faturamento consolidado do AWS Organizations nas contas", true],
+            ["Assinar o plano Enterprise Support para obter descontos por volume", false],
+        ],
+    },
+    {
+        statement:
+            "Quais benefícios estão incluídos no plano AWS Business Support+? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Business Support+ dá acesso 24/7 a engenheiros de suporte por telefone, web e chat e aceita casos ilimitados. TAM designado, resposta em até 15 minutos para casos críticos e revisões estratégicas de negócio são do Enterprise Support; no Business Support+, a meta para casos críticos é de 30 minutos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Acesso 24/7 a engenheiros de suporte por telefone e chat", true],
+            ["Apoio de um Technical Account Manager (TAM) designado", false],
+            ["Quantidade ilimitada de casos de suporte e de contatos", true],
+            ["Resposta em até 15 minutos para casos críticos de negócio", false],
+            ["Revisões estratégicas de negócio com especialistas da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Em quais situações uma empresa deve considerar o uso de Instâncias Spot do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "As Instâncias Spot saem com grande desconto, mas a AWS pode recuperá-las com aviso de dois minutos, então servem para cargas flexíveis e tolerantes a falhas e para ambientes fora da produção. Cargas que mantêm estado, aplicações que não toleram interrupção e bancos de dados sensíveis precisam de capacidade estável.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Aplicações fora do ambiente de produção", true],
+            ["Cargas de trabalho que mantêm estado", false],
+            ["Aplicações que não podem sofrer interrupções", false],
+            ["Aplicações flexíveis e tolerantes a falhas", true],
+            ["Aplicações de banco de dados sensíveis", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço inspeciona o ambiente da AWS para encontrar oportunidades de economizar dinheiro e também de melhorar o desempenho dos sistemas?",
+        explanation:
+            "O AWS Trusted Advisor verifica o ambiente e recomenda melhorias em otimização de custos, desempenho, segurança, tolerância a falhas, cotas de serviço e excelência operacional. O Cost Explorer analisa gastos, o faturamento consolidado une a cobrança de várias contas e o Cost and Usage Report detalha cobranças sem avaliar o ambiente.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Cost Explorer", false],
+            ["AWS Trusted Advisor", true],
+            ["Faturamento consolidado", false],
+            ["AWS Cost and Usage Report", false],
+        ],
+    },
+    {
+        statement:
+            "Um cliente quer projetar e construir uma nova carga de trabalho na Nuvem AWS, mas não tem na equipe conhecimento técnico sobre a AWS. Qual opção do AWS Partner Network (APN) atende a esse objetivo?",
+        explanation:
+            "Os parceiros do caminho de serviços (Services Path) da APN são empresas de consultoria e de serviços profissionais e gerenciados que projetam, constroem e migram cargas na AWS. O caminho de software reúne quem desenvolve software, o de hardware quem cria dispositivos e o de distribuição quem ajuda outros parceiros a revender.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Parceiros do caminho de software da APN", false],
+            ["Parceiros do caminho de serviços da APN", true],
+            ["Parceiros do caminho de hardware da APN", false],
+            ["Parceiros do caminho de distribuição da APN", false],
+        ],
+    },
+    {
+        statement:
+            "Como uma empresa pode reduzir seu custo total de propriedade (TCO) usando a AWS?",
+        explanation:
+            "Na AWS, o investimento inicial em data center e servidores dá lugar a pagamentos pelo uso, o que reduz as despesas de capital e o TCO. As despesas operacionais continuam existindo, as licenças de terceiros seguem por conta do cliente na maioria dos casos e a gestão das aplicações continua sendo do cliente.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Minimizando grandes despesas de capital (CapEx)", true],
+            ["Deixando de pagar os custos de licenças de terceiros", false],
+            ["Eliminando todas as despesas operacionais (OpEx)", false],
+            ["Transferindo à AWS a gestão das próprias aplicações", false],
+        ],
+    },
+    {
+        statement:
+            "Quais opções a AWS oferece a clientes que querem aprender sobre segurança na nuvem em sessões conduzidas ao vivo por especialistas ou instrutores? (Selecione DUAS opções.)",
+        explanation:
+            "As AWS Online Tech Talks são webinars ao vivo com especialistas da AWS e sessões de perguntas e respostas, e o AWS Classroom Training oferece aulas com instrutores, presenciais ou virtuais. Blog, Knowledge Center e whitepapers são conteúdos para ler por conta própria, sem condução ao vivo.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Security Blog", false],
+            ["AWS Online Tech Talks", true],
+            ["AWS Knowledge Center", false],
+            ["Whitepapers de segurança da AWS", false],
+            ["AWS Classroom Training", true],
+        ],
+    },
+    {
+        statement:
+            "Quais são vantagens do faturamento consolidado da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O faturamento consolidado gera uma fatura para as contas da organização e soma o uso delas para alcançar faixas de preço por volume, sem custo extra. As cotas de serviço continuam valendo por conta e Região, não existe desconto fixo e o plano de suporte é contratado por conta, sem se estender às demais.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Uma única fatura para todas as contas da organização", true],
+            ["Aumento automático das cotas de serviço em todas as contas", false],
+            ["Um desconto fixo sobre o valor da fatura mensal", false],
+            ["Possíveis descontos por volume, já que o uso das contas é somado", true],
+            [
+                "Extensão automática do plano de suporte da conta de gerenciamento a todas as contas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual equipe da AWS ajuda os clientes a acelerar a adoção da nuvem por meio de contratos pagos em diversas áreas de especialidade?",
+        explanation:
+            "O AWS Professional Services é a equipe global de especialistas que atua em projetos pagos em áreas como migração, segurança e dados para acelerar a adoção da nuvem. O Enterprise Support é um plano de suporte, os arquitetos de soluções orientam sem contrato de consultoria e os gerentes de conta cuidam da relação comercial.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Enterprise Support", false],
+            ["Arquitetos de soluções da AWS", false],
+            ["AWS Professional Services", true],
+            ["Gerentes de conta da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Como o AWS Trusted Advisor oferece orientação aos usuários da Nuvem AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Trusted Advisor compara o ambiente com boas práticas, recomenda economias com base no uso atual e aponta riscos de segurança, como buckets do S3 ou grupos de segurança com permissões abertas. Ele não corrige nada sozinho; vulnerabilidades de software ficam com o Amazon Inspector e instâncias comprometidas, com o Amazon GuardDuty.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Identifica vulnerabilidades de software em aplicações executadas na AWS", false],
+            ["Lista recomendações de otimização de custos com base no uso atual da conta", true],
+            ["Detecta possíveis falhas de segurança causadas por configurações de permissão", true],
+            [
+                "Corrige automaticamente falhas de segurança causadas por configurações de permissão",
+                false,
+            ],
+            ["Envia alertas proativos sempre que uma instância do EC2 for comprometida", false],
+        ],
+    },
+    {
+        statement: "Qual é o plano MÍNIMO do AWS Support que oferece suporte técnico por telefone?",
+        explanation:
+            "O AWS Business Support+ é o plano pago de entrada e já inclui atendimento técnico 24/7 por telefone, web e chat com engenheiros de suporte. O Basic cobre só questões de conta e faturamento, sem casos técnicos, e o Enterprise Support e o Unified Operations também têm telefone, mas custam mais.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Basic Support", false],
+            ["AWS Business Support+", true],
+            ["AWS Enterprise Support", false],
+            ["AWS Unified Operations", false],
+        ],
+    },
+    {
+        statement:
+            "Qual modelo de preço do Amazon EC2 pode oferecer descontos de até 90% em relação ao On-Demand?",
+        explanation:
+            "As Instâncias Spot usam capacidade ociosa do EC2 e podem sair até 90% mais baratas que o On-Demand, em troca da possibilidade de interrupção. As Instâncias Reservadas e os Savings Plans chegam a até 72% de desconto, o On-Demand é o preço de referência e os Hosts Dedicados custam mais.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Reservadas", false],
+            ["Instâncias On-Demand", false],
+            ["Hosts Dedicados", false],
+            ["Instâncias Spot", true],
+        ],
+    },
+    {
+        statement:
+            "Como um cliente com o plano AWS Basic Support pode obter ajuda da AWS para dúvidas técnicas?",
+        explanation:
+            "O Basic Support não inclui casos técnicos, mas dá acesso à comunidade AWS re:Post, onde usuários e especialistas da AWS respondem dúvidas, além de documentação e atendimento de conta e faturamento. Casos com engenheiros de suporte e a AWS Support API começam no Business Support+, e o TAM vem com o Enterprise Support.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Abrindo casos com engenheiros de suporte da nuvem", false],
+            ["Acionando um Technical Account Manager (TAM)", false],
+            ["Usando a AWS Support API para abrir casos técnicos", false],
+            ["Publicando a dúvida na comunidade AWS re:Post", true],
+        ],
+    },
+    {
+        statement: "Em qual cenário o uso de Instâncias Spot do Amazon EC2 é mais indicado?",
+        explanation:
+            "Instâncias Spot servem para cargas flexíveis que toleram interrupção, já que a AWS pode recuperar a capacidade com aviso de dois minutos; tarefas eventuais que hoje rodam em On-Demand ficam bem mais baratas. Site principal, serviços com SLA de 99,999% e banco de dados muito usado exigem capacidade estável.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Uma empresa quer migrar seu site principal, hoje em um servidor web on-premises, para a AWS",
+                false,
+            ],
+            [
+                "Uma empresa tem serviços de aplicação cujo SLA exige 99,999% de disponibilidade",
+                false,
+            ],
+            ["O banco de dados legado e muito usado de uma empresa roda hoje on-premises", false],
+            [
+                "Uma empresa roda em instâncias On-Demand tarefas eventuais que aceitam interrupção",
+                true,
+            ],
+        ],
+    },
+    {
+        statement: "Qual é um benefício do modelo de preço On-Demand do Amazon EC2?",
+        explanation:
+            "No On-Demand, a cobrança é por segundo ou por hora apenas enquanto a instância está em execução, sem pagamento adiantado nem compromisso. Usar capacidade ociosa com desconto é a ideia das Instâncias Spot, pagar adiantado por uma tarifa menor descreve as Instâncias Reservadas e não existe diária fixa.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Pagar menos usando a capacidade ociosa da AWS", false],
+            ["Pagar uma diária fixa, independentemente do tempo de uso", false],
+            ["Pagar só pelo tempo em que as instâncias estão em execução", true],
+            ["Pagar adiantado pelas instâncias e ter um custo por hora menor", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai migrar para o Amazon EC2 uma aplicação com cargas de trabalho que não podem ser interrompidas e que vão rodar por três anos. Qual modelo de preço é a solução MAIS econômica?",
+        explanation:
+            "Para uma carga estável e sem interrupção por três anos, as Instâncias Reservadas dão grande desconto sobre o On-Demand em troca do compromisso. As Spot são mais baratas, mas podem ser interrompidas, as Dedicadas custam mais por isolarem o hardware e o On-Demand cobra o preço cheio.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Spot, com até 90% de desconto", false],
+            ["Instâncias Dedicadas", false],
+            ["Instâncias On-Demand", false],
+            ["Instâncias Reservadas", true],
+        ],
+    },
+    {
+        statement:
+            "Como uma conta da AWS pode aproveitar as Instâncias Reservadas compradas por outra conta?",
+        explanation:
+            "No faturamento consolidado do AWS Organizations, o desconto de Instâncias Reservadas que sobra na conta compradora é aplicado ao uso compatível de outras contas da organização, e a conta de gerenciamento controla esse compartilhamento. Instâncias Dedicadas tratam de isolamento, e Cost Explorer e Budgets só analisam ou monitoram reservas.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Executando as cargas em Instâncias Dedicadas do Amazon EC2", false],
+            ["Usando o faturamento consolidado do AWS Organizations", true],
+            ["Ativando as recomendações de reserva do AWS Cost Explorer", false],
+            ["Criando um orçamento de reservas no AWS Budgets", false],
+        ],
+    },
+    {
+        statement:
+            "Em comparação com data centers tradicionais e virtualizados, como são os custos na AWS?",
+        explanation:
+            "Pela economia de escala, a AWS oferece custo variável por unidade menor que o de data centers próprios, e o pagamento conforme o uso elimina grandes investimentos iniciais em hardware. Custos iniciais altos são típicos do modelo tradicional, e na AWS o custo acompanha o consumo em vez de ser fixo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Custos variáveis maiores e custos iniciais maiores", false],
+            ["Custos de uso fixos e custos iniciais menores", false],
+            ["Custos variáveis menores e custos iniciais maiores", false],
+            ["Custos variáveis menores e custos iniciais menores", true],
+        ],
+    },
+    {
+        statement: "Qual afirmação sobre as Instâncias On-Demand do Amazon EC2 está INCORRETA?",
+        explanation:
+            "Não existe taxa de ativação no On-Demand: paga-se só pelo tempo de execução, sem compromisso nem pagamento adiantado, dentro do modelo de pagamento conforme o uso. A tarifa é definida por hora, e instâncias Linux são cobradas por segundo, com mínimo de 60 segundos, então as demais afirmações estão corretas.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "É preciso pagar uma taxa de ativação ao iniciar uma instância pela primeira vez",
+                true,
+            ],
+            ["As instâncias On-Demand seguem o modelo de pagamento conforme o uso da AWS", false],
+            [
+                "Não é preciso assumir compromisso de longo prazo nem fazer pagamento adiantado",
+                false,
+            ],
+            [
+                "Em instâncias Linux, a cobrança é por segundo, calculada a partir de uma tarifa por hora",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai lançar um novo produto e espera um pico de tráfego na aplicação web. Como parte do plano AWS Enterprise Support, qual recurso oferece orientação de arquitetura e de escalabilidade para esse evento?",
+        explanation:
+            "O AWS Countdown, que substituiu o Infrastructure Event Management e faz parte do Enterprise Support, apoia eventos críticos como lançamentos com orientação de arquitetura, planejamento de capacidade e acompanhamento durante o evento. O Health Dashboard avisa sobre eventos da AWS, e Knowledge Center e re:Post são conteúdo e comunidade.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Knowledge Center", false],
+            ["AWS Health Dashboard", false],
+            ["AWS Countdown", true],
+            ["AWS re:Post", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer usar licenças de software que já possui e que são vinculadas a soquetes ou núcleos físicos (BYOL). Qual opção de compra do Amazon EC2 atende a quase todos os cenários desse tipo de licenciamento?",
+        explanation:
+            "Os Hosts Dedicados são servidores físicos reservados ao cliente, com visibilidade de soquetes, núcleos e ID do host, o que permite usar licenças vinculadas ao servidor (BYOL) e cumprir exigências de conformidade. As Instâncias Dedicadas isolam o hardware sem dar essa visibilidade, e On-Demand e Spot, na locação padrão, usam hardware compartilhado.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Dedicadas", false],
+            ["Hosts Dedicados", true],
+            ["Instâncias On-Demand", false],
+            ["Instâncias Spot", false],
+        ],
+    },
+    {
+        statement: "Qual atividade pode ajudar a reduzir os custos mensais da AWS?",
+        explanation:
+            "O Amazon EC2 Auto Scaling adiciona instâncias nos picos e remove nos períodos de baixa demanda, evitando pagar por capacidade ociosa. O Network Load Balancer só distribui o tráfego, remover tags de alocação de custos tira visibilidade sem baixar a conta e usar várias Zonas de Disponibilidade aumenta a resiliência e, em geral, o custo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Usar o Amazon EC2 Auto Scaling para ajustar a capacidade à demanda", true],
+            ["Usar um Network Load Balancer para distribuir as requisições HTTP recebidas", false],
+            ["Remover todas as tags de alocação de custos dos recursos", false],
+            ["Implantar os recursos da AWS em várias Zonas de Disponibilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de consultoria presta serviços que ajudam clientes da AWS a melhorar suas arquiteturas na nuvem. Qual programa da AWS pode apoiar essa empresa?",
+        explanation:
+            "O AWS Partner Network (APN) apoia empresas que trabalham com a AWS; consultorias e prestadoras de serviços profissionais e gerenciados entram pelo caminho de serviços (Services Path). O caminho de software é para quem desenvolve produtos, o AWS Professional Services é a equipe da própria AWS e o TAM atende clientes do Enterprise Support.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Caminho de serviços do AWS Partner Network", true],
+            ["Caminho de software do AWS Partner Network", false],
+            ["AWS Professional Services", false],
+            ["Technical Account Manager (TAM) da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Qual princípio de preços da AWS descreve a opção de assumir um compromisso de uso do Amazon EC2 por 1 ou 3 anos para reduzir o custo total de computação?",
+        explanation:
+            "O princípio Save when you commit (antes chamado Save when you reserve) reúne as opções em que um compromisso de 1 ou 3 anos, como Savings Plans e Instâncias Reservadas, reduz o preço. Pay as you go é pagar pelo uso sem compromisso, Pay less by using more são descontos por volume e Pay less as AWS grows são reduções trazidas pela escala.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Pague menos à medida que a AWS cresce (Pay less as AWS grows)", false],
+            ["Pagamento conforme o uso (Pay as you go)", false],
+            ["Pague menos usando mais (Pay less by using more)", false],
+            ["Economize ao se comprometer (Save when you commit)", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está migrando seu banco de dados on-premises para o Amazon RDS. O que ela deve fazer para manter os custos do Amazon RDS no mínimo?",
+        explanation:
+            "Dimensionar corretamente é escolher classe e tamanho de instância conforme o uso real, antes da migração e de novo depois, com base nas métricas, para não pagar por capacidade ociosa. Arquiteturas em várias Regiões, ativas ou passivas, duplicam recursos, e provisionar com folga para picos futuros encarece o banco.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Dimensionar corretamente as instâncias antes e depois da migração", true],
+            ["Usar uma arquitetura ativa-passiva em várias Regiões", false],
+            ["Provisionar instâncias com folga para o pico previsto dos próximos anos", false],
+            ["Usar uma arquitetura ativa-ativa em várias Regiões", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa manter um banco de dados no Amazon RDS por pelo menos três anos. Qual opção é a MAIS econômica?",
+        explanation:
+            "Para pelo menos três anos, Instâncias Reservadas de 3 anos com pagamento adiantado parcial dão desconto bem maior que o On-Demand. No RDS, a opção sem pagamento adiantado só existe com prazo de 1 ano e desconta menos, o On-Demand cobra o preço cheio e o RDS não oferece Instâncias Spot.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Reservadas sem nenhum pagamento adiantado", false],
+            ["Instâncias Reservadas com pagamento adiantado parcial", true],
+            ["Instâncias On-Demand com cobrança por hora de uso", false],
+            ["Instâncias Spot com grande desconto sobre o preço On-Demand", false],
+        ],
+    },
+    {
+        statement:
+            "Os Savings Plans podem ser aplicados ao uso de quais destes serviços da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Os Compute Savings Plans dão desconto no uso do Amazon EC2, do AWS Lambda e do AWS Fargate em troca de um compromisso de 1 ou 3 anos. O Lightsail tem preço mensal em pacote, a capacidade do Outposts é contratada por um prazo próprio de 3 anos e o Amazon S3 não tem Savings Plans.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Amazon EC2", true],
+            ["AWS Outposts", false],
+            ["Amazon Lightsail", false],
+            ["AWS Lambda", true],
+            ["Amazon S3", false],
+        ],
+    },
+    {
+        statement:
+            "Quais afirmações sobre as cotas de serviço (limites de serviço) da AWS estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "As cotas valem para a conta, em geral por Região, e muitas podem ser aumentadas pelo Service Quotas ou por um caso no AWS Support; o Trusted Advisor tem verificações de limites de serviço em todos os planos. Não há cotas por usuário do IAM, toda conta tem cotas e o Amazon SES é um serviço de envio de e-mails.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["É possível pedir ao AWS Support o aumento de uma cota da conta", true],
+            ["Cada usuário do IAM tem cotas próprias, separadas das da conta", false],
+            ["A AWS não impõe nenhuma cota de serviço às contas dos clientes", false],
+            ["O AWS Trusted Advisor ajuda a acompanhar o uso das cotas de serviço", true],
+            ["O Amazon SES monitora as cotas e avisa quando o uso chega perto do limite", false],
+        ],
+    },
+    {
+        statement: "Como a AWS cobra o uso de instâncias do Amazon EC2 com Amazon Linux?",
+        explanation:
+            "Instâncias do EC2 com Amazon Linux (e também Windows, RHEL e Ubuntu Pro) são cobradas por segundo, com mínimo de 60 segundos, então cargas curtas não pagam a hora cheia. A cobrança por hora foi o modelo antigo e ainda vale para exceções como o SUSE Linux Enterprise Server; cobrança por dia ou por mês não existe no EC2.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Por segundo, com cobrança mínima de 60 segundos", true],
+            ["Por hora, com cobrança mínima de 24 horas", false],
+            ["Por minuto, com cobrança mínima de uma hora cheia", false],
+            ["Por dia, com cobrança mínima de um mês", false],
+        ],
+    },
+    {
+        statement:
+            "Quais fatores influenciam o preço pago por uma instância do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "O preço do EC2 depende do tipo de instância (família e tamanho) e da Região, já que cada Região tem sua própria tabela de preços. O balanceador de carga é cobrado à parte sem alterar o preço da instância, buckets do S3 não entram na conta do EC2 e endereços IP privados não têm custo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["O tipo de instância, como m5.large ou t3.micro", true],
+            ["A Região da AWS onde a instância é provisionada", true],
+            ["O uso de um balanceador de carga na frente da instância", false],
+            ["A quantidade de buckets do Amazon S3 na conta", false],
+            ["O número de endereços IP privados da instância", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa usa o AWS Organizations para gerenciar todas as suas contas AWS. Qual recurso permite definir, de forma centralizada, quais serviços e ações ficam disponíveis em cada conta-membro?",
+        explanation:
+            "As políticas de controle de serviço (SCPs) do AWS Organizations definem o máximo de permissões disponíveis nas contas-membro, inclusive para o usuário raiz delas. Entidades principais e políticas do IAM atuam dentro de uma única conta e não impõem limites centralizados, e as políticas de tags só padronizam o uso de tags.",
+        topic: "Segurança e identidade",
+        options: [
+            ["Entidades principais do IAM em cada conta", false],
+            ["Políticas de controle de serviço (SCPs)", true],
+            ["Políticas do IAM anexadas aos usuários", false],
+            ["Políticas de tags do AWS Organizations", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS fornece recomendações de otimização de custos para os recursos da conta?",
+        explanation:
+            "O AWS Trusted Advisor analisa o ambiente e aponta economias, como instâncias do EC2 subutilizadas e volumes do EBS sem uso (o conjunto completo de verificações exige Business Support+ ou superior). O Pricing Calculator estima custos antes de provisionar, o CloudTrail registra chamadas de API e o X-Ray rastreia requisições de aplicações.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Trusted Advisor", true],
+            ["AWS Pricing Calculator", false],
+            ["AWS CloudTrail", false],
+            ["AWS X-Ray", false],
+        ],
+    },
+    {
+        statement:
+            "Quais opções indicam uma vantagem e uma desvantagem de comprar Instâncias Reservadas do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "A vantagem das Instâncias Reservadas é o desconto significativo sobre o On-Demand, e a desvantagem é o compromisso de 1 ou 3 anos. Interrupção pela AWS é característica das Instâncias Spot, a reserva não pode ser cancelada sem custo e o desconto compensa em cargas estáveis, não em uso esporádico.",
+        topic: "Preços e faturamento",
+        options: [
+            ["A AWS pode encerrar as instâncias a qualquer momento, sem aviso", false],
+            ["Exigem compromisso de uso por um prazo de 1 ou 3 anos", true],
+            ["Podem ser canceladas a qualquer momento, sem nenhum custo", false],
+            ["Oferecem desconto significativo em relação ao On-Demand", true],
+            ["São mais indicadas para cargas de trabalho esporádicas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa executar um conjunto de instâncias do Amazon EC2 que devem ficar disponíveis o tempo todo durante dois meses. Qual opção de compra tem o melhor custo-benefício?",
+        explanation:
+            "Para um uso de apenas dois meses sem interrupção, o On-Demand é o mais econômico: paga-se só pelo período usado, sem compromisso. As Spot podem ser interrompidas quando a AWS precisa da capacidade, e as Reservadas, com ou sem pagamento adiantado, exigem prazo mínimo de 1 ano, o que custaria mais que os dois meses.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias On-Demand", true],
+            ["Instâncias Spot", false],
+            ["Instâncias Reservadas com pagamento adiantado integral", false],
+            ["Instâncias Reservadas sem pagamento adiantado", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é o plano do AWS Support de MENOR custo que inclui o concierge de faturamento, um atendimento personalizado para questões de conta e faturamento?",
+        explanation:
+            "O concierge de faturamento (white-glove) aparece a partir do Enterprise Support. O Unified Operations também tem atendimento dedicado de faturamento, com especialista designado, mas custa mais; o Business Support+ oferece suporte de faturamento 24/7 sem concierge, e o Basic Support dá acesso ao atendimento ao cliente.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Basic Support", false],
+            ["AWS Business Support+", false],
+            ["AWS Enterprise Support", true],
+            ["AWS Unified Operations", false],
+        ],
+    },
+    {
+        statement:
+            "Como um cliente da AWS pode acompanhar a utilização das suas Instâncias Reservadas e evitar gastos com reservas subutilizadas?",
+        explanation:
+            "O AWS Budgets permite criar orçamentos de reserva que acompanham a utilização das Instâncias Reservadas e enviam alertas quando ela fica abaixo do limite definido. Desligar o compartilhamento de reservas só reduz o aproveitamento delas, o CloudWatch não mede a utilização de reservas e o CloudTrail registra chamadas de API.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Reunir as contas no AWS Organizations, ativar o faturamento consolidado e desligar o compartilhamento de reservas",
+                false,
+            ],
+            [
+                "Usar métricas do Amazon CloudWatch para achar reservas subutilizadas e vendê-las no Reserved Instance Marketplace",
+                false,
+            ],
+            [
+                "Criar no AWS Budgets um orçamento de utilização das reservas, com alerta quando ela cair abaixo do limite definido",
+                true,
+            ],
+            [
+                "Usar o AWS CloudTrail para verificar automaticamente reservas sem uso e receber recomendações para reduzir a fatura",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais são benefícios de adotar uma estratégia de tags para os recursos da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Tags são pares de chave e valor que permitem agrupar recursos, por exemplo por projeto, e, ativadas como tags de alocação de custos, acompanhar os gastos de cada grupo. Encontrar soluções de software é papel do AWS Marketplace, registrar chamadas de API é função do AWS CloudTrail e as tags somem junto com o recurso excluído.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Identificar rapidamente os recursos de um projeto específico", true],
+            ["Encontrar rapidamente soluções de software prontas para a AWS", false],
+            ["Registrar as chamadas de API feitas na conta AWS", false],
+            ["Recuperar os metadados de recursos que já foram excluídos", false],
+            ["Acompanhar os gastos da AWS distribuídos por vários recursos", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa que ainda não usa a AWS planeja migrar todo o seu data center on-premises. Qual serviço ela pode usar para montar uma análise de custo-benefício, comparando o custo atual on-premises com o custo projetado na AWS?",
+        explanation:
+            "O Migration Evaluator coleta dados do ambiente on-premises e gera um business case que compara o custo atual com o custo projetado na AWS. O Pricing Calculator estima só o custo na AWS, sem comparar com o on-premises, e o Cost Explorer e o Cost and Usage Report analisam gastos de quem já usa a AWS.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost Explorer", false],
+            ["AWS Migration Evaluator", true],
+            ["AWS Cost and Usage Report", false],
+            ["AWS Pricing Calculator", false],
+        ],
+    },
+    {
+        statement:
+            "A AWS recomenda algumas práticas para evitar cobranças inesperadas na fatura. Qual destas ações NÃO está entre essas práticas?",
+        explanation:
+            "Modelos de execução não têm custo, então excluí-los não reduz a fatura. Volumes do EBS são cobrados pelo espaço provisionado mesmo sem instância, balanceadores de carga cobram por hora mesmo sem tráfego e endereços IPv4 públicos, incluindo os IPs elásticos, são cobrados por hora, estejam em uso ou não.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Excluir volumes do EBS sem uso depois de encerrar uma instância do EC2", false],
+            ["Excluir modelos de execução (launch templates) do EC2 que não são usados", true],
+            ["Excluir balanceadores de carga do Elastic Load Balancing que estão sem uso", false],
+            ["Liberar endereços IP elásticos sem uso depois de encerrar uma instância", false],
+        ],
+    },
+    {
+        statement:
+            "Qual característica de cobrança oferecida pela AWS reduz o custo de executar instâncias do Amazon EC2?",
+        explanation:
+            "O EC2 cobra por segundo, com mínimo de 60 segundos, nas instâncias com Amazon Linux, Windows, RHEL e Ubuntu Pro, então o cliente paga só pelo tempo usado. A manutenção da infraestrutura física já está incluída no preço, as tags não têm custo e o EC2 não cobra taxa de inicialização.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Taxa mensal reduzida de manutenção das instâncias", false],
+            ["Tags de instância com custo reduzido", false],
+            ["Cobrança das instâncias por segundo de uso", true],
+            ["Taxa de inicialização reduzida para novas instâncias", false],
+        ],
+    },
+    {
+        statement:
+            "Qual equipe da AWS trabalha com os clientes para ajudá-los a alcançar os resultados de negócio desejados com a nuvem?",
+        explanation:
+            "O AWS Professional Services é uma equipe de especialistas que atua junto ao cliente, muitas vezes ao lado de parceiros, para alcançar resultados de negócio na nuvem, como migrações e modernização. A equipe de segurança cuida da segurança da própria AWS, a Trust & Safety trata denúncias de abuso e o concierge atende questões de conta e faturamento.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Equipe de segurança da AWS", false],
+            ["AWS Professional Services", true],
+            ["Equipe de Trust & Safety da AWS", false],
+            ["Equipe de concierge do AWS Support", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai comprar uma Instância Reservada com prazo de um ano. Qual opção de pagamento oferece o MAIOR desconto total?",
+        explanation:
+            "Nas Instâncias Reservadas, quanto mais se paga adiantado, maior o desconto: o pagamento adiantado integral dá a maior economia, o parcial fica no meio e a opção sem pagamento adiantado tem o menor desconto das três. Por isso as opções não oferecem o mesmo nível de desconto.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Pagamento adiantado integral", true],
+            ["Todas as opções têm o mesmo nível de desconto", false],
+            ["Pagamento adiantado parcial", false],
+            ["Nenhum pagamento adiantado", false],
+        ],
+    },
+    {
+        statement:
+            "Um cliente usou uma instância do Amazon EC2 com Amazon Linux por 2 horas, 5 minutos e 9 segundos e outra com SUSE Linux Enterprise Server por 4 horas, 23 minutos e 7 segundos. Por quanto tempo ele será cobrado?",
+        explanation:
+            "Instâncias com Amazon Linux são cobradas por segundo, com mínimo de 60 segundos, então o tempo cobrado é exatamente 2 h 5 min 9 s. Já as instâncias com SUSE Linux Enterprise Server são cobradas por hora cheia, e 4 h 23 min 7 s viram 5 horas. As demais opções arredondam o Amazon Linux ou cobram o SUSE por segundo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["3 horas pela instância Amazon Linux e 5 horas pela SUSE", false],
+            ["2 h 5 min 9 s pela instância Amazon Linux e 4 h 23 min 7 s pela SUSE", false],
+            ["2 h 5 min 9 s pela instância Amazon Linux e 5 horas pela SUSE", true],
+            ["3 horas pela instância Amazon Linux e 4 h 23 min 7 s pela SUSE", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso do AWS Support permite que os clientes gerenciem casos de suporte de forma programática?",
+        explanation:
+            "A AWS Support API permite criar, atualizar e resolver casos de suporte por código, integrando o suporte a sistemas internos de chamados; ela está nos planos Business Support+, Enterprise e Unified Operations. O Trusted Advisor dá recomendações, e o Health Dashboard e a Health API informam eventos que afetam serviços e recursos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Trusted Advisor", false],
+            ["AWS Health API", false],
+            ["AWS Support API", true],
+            ["AWS Health Dashboard", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS oferece descontos por volume, com preço por GB menor à medida que o uso aumenta?",
+        explanation:
+            "O Amazon S3 usa preços em faixas: no S3 Standard, o preço por GB armazenado cai quando o volume mensal passa de 50 TB e de 500 TB. O Lightsail cobra planos mensais fixos, a VPC em si não tem custo e recursos como o NAT Gateway têm preço fixo por hora e por GB, e o Cost Explorer é uma ferramenta de análise de custos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Amazon VPC", false],
+            ["Amazon S3", true],
+            ["Amazon Lightsail", false],
+            ["AWS Cost Explorer", false],
+        ],
+    },
+    {
+        statement:
+            "A diferença de custo total de propriedade (TCO) entre a infraestrutura da AWS e a infraestrutura tradicional aumentou nos últimos anos. Qual pode ser o motivo?",
+        explanation:
+            "A AWS reduz preços com frequência graças à economia de escala e repassa essa economia aos clientes, o que amplia a vantagem de TCO sobre o on-premises. A nuvem troca CapEx por OpEx, os clientes ainda precisam de equipe para operar suas cargas e a segurança dos dados continua sendo responsabilidade do cliente.",
+        topic: "Preços e faturamento",
+        options: [
+            ["A AWS ajuda os clientes a investir mais em despesas de capital (CapEx)", false],
+            [
+                "A AWS automatiza toda a operação da infraestrutura e elimina custos com equipe",
+                false,
+            ],
+            ["A AWS continua reduzindo o custo da computação em nuvem para os clientes", true],
+            ["A AWS assume toda a segurança dos dados dos clientes sem cobrança adicional", false],
+        ],
+    },
+    {
+        statement:
+            "Quais itens NÃO são fatores a considerar ao estimar os custos do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "Grupos de segurança não têm custo e zonas hospedadas são cobradas pelo Amazon Route 53, fora da estimativa do EC2. Já o tempo de execução e a quantidade de instâncias definem o custo de computação, e os IPs elásticos, como todo endereço IPv4 público, são cobrados por hora, então entram na estimativa.",
+        topic: "Preços e faturamento",
+        options: [
+            ["O tempo em que as instâncias ficarão em execução", false],
+            ["A quantidade de grupos de segurança", true],
+            ["Os endereços IP elásticos alocados", false],
+            ["A quantidade de zonas hospedadas do Route 53", true],
+            ["A quantidade de instâncias", false],
+        ],
+    },
+    {
+        statement:
+            "Um usuário abriu um caso no AWS Support com a severidade sistema de produção fora do ar (production system down). Qual é o tempo de resposta esperado para esse tipo de caso?",
+        explanation:
+            "Nos planos Business Support+, Enterprise e Unified Operations, a meta de resposta para sistema de produção fora do ar é de menos de 1 hora. Menos de 12 horas vale para sistema prejudicado, menos de 24 horas para orientação geral, e 15 minutos é a meta do Enterprise para sistema crítico para o negócio fora do ar.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Menos de 12 horas", false],
+            ["Menos de 15 minutos", false],
+            ["Menos de 24 horas", false],
+            ["Menos de uma hora", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está migrando uma aplicação web para a AWS. A capacidade de computação da aplicação é usada continuamente ao longo de todo o ano. Qual opção oferece o melhor custo-benefício?",
+        explanation:
+            "Para uso contínuo e previsível ao longo do ano, as Instâncias Reservadas dão desconto significativo sobre o On-Demand em troca de compromisso de 1 ou 3 anos. O On-Demand cobra o preço cheio, os Hosts Dedicados custam mais por reservar um servidor físico inteiro e as Spot podem ser interrompidas, o que não serve a uma aplicação que precisa ficar no ar.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias On-Demand", false],
+            ["Instâncias em Hosts Dedicados", false],
+            ["Instâncias Spot", false],
+            ["Instâncias Reservadas", true],
+        ],
+    },
+    {
+        statement:
+            "Qual destas ações ajuda os clientes a economizar ao migrar suas cargas de trabalho para a AWS?",
+        explanation:
+            "No modelo traga sua própria licença (BYOL), o cliente reaproveita na AWS licenças que já pagou, sem comprar novas. Gerenciar servidores por conta própria aumenta o custo operacional, locais de borda servem para cache e entrega de conteúdo e não para hospedar cargas de produção, e o Outposts é para cargas que precisam ficar on-premises.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Gerenciar servidores em vez de usar serviços gerenciados", false],
+            ["Reaproveitar na AWS as licenças de software de terceiros que já possuem", true],
+            ["Levar as cargas de produção para locais de borda em vez de Regiões", false],
+            ["Usar o AWS Outposts para executar todas as cargas em um ambiente otimizado", false],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos estão disponíveis para os clientes do plano AWS Business Support+? (Selecione DUAS opções.)",
+        explanation:
+            "O Business Support+ inclui suporte de conta e faturamento 24/7 e permite contratar o AWS Countdown Premium, sucessor do Infrastructure Event Management, por uma taxa adicional. O suporte técnico nele é 24/7 por telefone, chat e e-mail, o TAM designado começa no Enterprise e o plano tem o conjunto completo de verificações do Trusted Advisor.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Atendimento de conta e faturamento 24 horas por dia, 7 dias por semana", true],
+            ["Acesso a engenheiros de suporte apenas por e-mail e só em horário comercial", false],
+            ["AWS Countdown Premium para eventos planejados, mediante taxa adicional", true],
+            ["Technical Account Manager designado, disponível 24 horas por dia", false],
+            ["Acesso apenas às verificações principais (core) do AWS Trusted Advisor", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa executa periodicamente grandes trabalhos de processamento de imagens e vídeos na AWS. O tempo de processamento não é crítico, e o fator mais importante é minimizar o custo. Qual opção de instâncias do Amazon EC2 é a mais adequada?",
+        explanation:
+            "As Instâncias Spot usam a capacidade ociosa da AWS com desconto de até 90% sobre o On-Demand e servem para trabalhos flexíveis que toleram interrupções, como processamento de mídia em lote. O On-Demand cobra o preço cheio, os Hosts Dedicados custam mais por reservar um servidor inteiro e a reserva exige compromisso de 1 ou 3 anos, inadequado para uso periódico.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias On-Demand", false],
+            ["Hosts Dedicados", false],
+            ["Instâncias Spot", true],
+            ["Instâncias Reservadas com pagamento adiantado integral", false],
+        ],
+    },
+    {
+        statement: "O que o AWS Cost Explorer oferece para ajudar a gerenciar os gastos na AWS?",
+        explanation:
+            "O Cost Explorer mostra gastos e uso passados e gera previsões de até 18 meses com base no histórico. Comparar a AWS com o on-premises é papel do Migration Evaluator, estimar serviços novos a partir do uso esperado cabe ao Pricing Calculator e o faturamento consolidado é um recurso do AWS Organizations.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Comparações de custo entre a Nuvem AWS e o ambiente on-premises atual", false],
+            ["Estimativas de custo de serviços novos com base no uso esperado", false],
+            ["Faturamento consolidado das várias contas de uma organização", false],
+            ["Previsões de custo de até 18 meses com base no histórico de uso", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe usa várias instâncias On-Demand do Amazon EC2 como ambiente de desenvolvimento. Qual é a melhor forma de reduzir as cobranças quando essas instâncias não estão em uso?",
+        explanation:
+            "Interromper as instâncias suspende a cobrança de computação e preserva a configuração e os volumes do EBS, que seguem cobrados pelo armazenamento, para retomar o ambiente depois. Excluir os volumes destrói os dados, encerrar remove as instâncias de vez e obriga a recriar o ambiente, e é possível sim reduzir a cobrança do On-Demand.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Excluir todos os volumes do EBS anexados às instâncias", false],
+            ["Não há como reduzir cobranças de instâncias On-Demand", false],
+            ["Encerrar as instâncias (terminate)", false],
+            ["Interromper as instâncias (stop)", true],
+        ],
+    },
+    {
+        statement:
+            "Quais fatores devem ser considerados no preço do Amazon EBS? (Selecione DUAS opções.)",
+        explanation:
+            "O Amazon EBS cobra pelo espaço provisionado em GB por mês, mesmo com a instância parada, e pelos dados guardados em snapshots, além de IOPS e throughput extras em alguns tipos de volume. Capacidade e tempo de computação entram no preço do EC2, e grupos de segurança não têm custo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["O tamanho dos volumes provisionados, em GB por mês", true],
+            ["A capacidade de computação consumida pelas instâncias do EC2", false],
+            ["A quantidade de dados armazenados nos snapshots", true],
+            ["O tempo de computação consumido pelas instâncias", false],
+            ["O número de grupos de segurança das instâncias", false],
+        ],
+    },
+    {
+        statement:
+            "Quais itens costumam ter o MAIOR impacto no custo da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "Computação, armazenamento e transferência de dados de saída são os principais fatores de custo na AWS. A transferência de dados de entrada vinda da internet não é cobrada, funções do IAM não têm custo e o número de serviços não define o custo, que depende de quanto cada um é usado.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Cobranças pelo uso de computação", true],
+            ["A quantidade de serviços usados", false],
+            ["Cobranças de transferência de dados de entrada", false],
+            ["Cobranças de transferência de dados de saída", true],
+            ["A quantidade de funções do IAM criadas", false],
+        ],
+    },
+    {
+        statement:
+            "Considerando o mesmo prazo de reserva, qual destes clientes obtém o MAIOR desconto?",
+        explanation:
+            "Com o mesmo prazo, as Instâncias Reservadas Standard dão desconto maior que as Conversíveis, que trocam parte do desconto pela flexibilidade de mudar atributos, e o pagamento adiantado integral rende mais desconto que o parcial ou que nenhum pagamento adiantado. Por isso Standard com pagamento adiantado integral é a combinação de maior desconto.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Quem compra Instâncias Reservadas Conversíveis com pagamento adiantado parcial",
+                false,
+            ],
+            [
+                "Quem compra Instâncias Reservadas Conversíveis com pagamento adiantado integral",
+                false,
+            ],
+            ["Quem compra Instâncias Reservadas Standard sem pagamento adiantado", false],
+            ["Quem compra Instâncias Reservadas Standard com pagamento adiantado integral", true],
+        ],
+    },
+    {
+        statement: "Qual destas opções está disponível na compra de instâncias do Amazon EC2?",
+        explanation:
+            "Nas Instâncias Reservadas e nos Savings Plans, pagar adiantado reduz o custo por hora. Lances eram o antigo modelo das Spot, que desde 2017 cobram o preço Spot vigente sem leilão; não existe registro de instâncias para desconto por volume; e Instâncias Dedicadas custam mais, sendo o desconto de até 90% o das Spot.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Dar lances para conseguir o menor preço possível", false],
+            ["Registrar instâncias para ganhar desconto por volume em cada hora de uso", false],
+            ["Comprar Instâncias Dedicadas com até 90% de desconto", false],
+            ["Pagar adiantado para ter um custo por hora menor", true],
+        ],
+    },
+    {
+        statement:
+            "O CTO pediu que você use o chat do AWS Support para tirar uma dúvida técnica sobre o Amazon EBS. A conta está no plano Basic Support, e o AWS Support Center não mostra a opção de chat. O que você deve fazer?",
+        explanation:
+            "Suporte técnico por chat, telefone e e-mail 24/7 fica nos planos pagos, a partir do Business Support+; o Basic Support dá acesso ao atendimento de conta e faturamento, à documentação e ao AWS re:Post. O chat existe, não é vendido como complemento avulso, e casos de conta e faturamento não cobrem dúvidas técnicas.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Nada, porque o AWS Support não oferece atendimento por chat", false],
+            [
+                "Pedir o chat como complemento pago, que pode ser contratado em qualquer plano",
+                false,
+            ],
+            ["Mudar o plano de suporte da conta para, no mínimo, o AWS Business Support+", true],
+            ["Abrir um caso de conta e faturamento, que também atende dúvidas técnicas", false],
+        ],
+    },
+    {
+        statement:
+            "Quais fatores afetam quanto você paga para armazenar objetos no Amazon S3? (Selecione DUAS opções.)",
+        explanation:
+            "O armazenamento no S3 é cobrado pelo volume de dados em GB por mês, com preço diferente para cada classe de armazenamento. A criptografia padrão com SSE-S3 não tem custo, criar e excluir buckets é gratuito (paga-se pelos dados e pelas requisições) e volumes do EBS são cobrados à parte, sem relação com o S3.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Manter a criptografia padrão SSE-S3 ativa nos buckets", false],
+            ["A quantidade de volumes do EBS anexados às instâncias", false],
+            ["A classe de armazenamento usada para os objetos", true],
+            ["Criar e excluir buckets do S3", false],
+            ["O tamanho total, em GB, dos objetos armazenados", true],
+        ],
+    },
+    {
+        statement:
+            "Quais são tipos válidos de Instâncias Reservadas do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "As Instâncias Reservadas podem ser Standard, com o maior desconto e menos flexibilidade, ou Conversíveis, que permitem trocar atributos como família e sistema operacional em troca de um desconto menor. Expressa é uma opção de recuperação do S3 Glacier, e Spot e sob demanda (On-Demand) são outras opções de compra do EC2, não tipos de reserva.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Conversível", true],
+            ["Expressa", false],
+            ["Sob demanda", false],
+            ["Spot", false],
+            ["Standard", true],
+        ],
+    },
+    {
+        statement:
+            "No modelo de pagamento conforme o uso, quais fatores afetam o custo do Amazon CloudFront? (Selecione DUAS opções.)",
+        explanation:
+            "No pagamento conforme o uso, o CloudFront cobra pela transferência de dados para a internet, com preço que varia por região geográfica, e pelas requisições HTTP e HTTPS. Volumes do EBS, tipo de instância do EC2 e classe de armazenamento do S3 são custos da origem, cobrados por esses serviços, e não entram no preço do CloudFront.",
+        topic: "Preços e faturamento",
+        options: [
+            ["O número de requisições HTTP e HTTPS atendidas", true],
+            ["A distribuição geográfica do tráfego entregue", true],
+            ["O número de volumes do EBS na origem", false],
+            ["O tipo de instância do EC2 usado na origem", false],
+            ["A classe de armazenamento do S3 usada na origem", false],
+        ],
+    },
+    {
+        statement:
+            "Qual afirmação sobre o acesso às verificações do AWS Trusted Advisor nos planos atuais do AWS Support está correta?",
+        explanation:
+            "O Basic Support dá acesso a todas as verificações de limites de serviço e a algumas de segurança e tolerância a falhas. O conjunto completo, com otimização de custos, desempenho e excelência operacional, está nos planos Business Support+, Enterprise e Unified Operations, e não só no Unified Operations.",
+        topic: "Ferramentas e suporte",
+        options: [
+            [
+                "No Basic Support, só parte delas, como as de limites de serviço e algumas de segurança",
+                true,
+            ],
+            [
+                "No Basic Support, o conjunto completo de verificações fica disponível sem nenhum custo extra",
+                false,
+            ],
+            ["Somente o Unified Operations dá acesso ao conjunto completo de verificações", false],
+            [
+                "No Business Support+, só as verificações de segurança e de limites de serviço",
+                false,
+            ],
+        ],
+    },
+    {
+        statement: "Quais são benefícios do AWS Organizations? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Organizations gerencia várias contas de forma central, limitando os serviços e ações disponíveis com políticas de controle de serviço (SCPs) e juntando a cobrança no faturamento consolidado. Traçar o caminho de adoção é papel do AWS CAF, estimar custos cabe ao Pricing Calculator e resultados de negócio são o foco do AWS Professional Services.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Controlar centralmente o acesso aos serviços da AWS nas contas", true],
+            ["Traçar um caminho acelerado para uma adoção de nuvem bem-sucedida", false],
+            ["Estimar o custo de novas cargas de trabalho antes de implantá-las", false],
+            ["Contar com especialistas da AWS para atingir metas de negócio", false],
+            ["Consolidar o faturamento de várias contas em uma só fatura", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem várias contas AWS independentes e quer reduzir a cobrança mensal total. O que ela deve fazer?",
+        explanation:
+            "No faturamento consolidado do AWS Organizations, o uso de todas as contas é somado, o que ajuda a atingir faixas de desconto por volume e permite compartilhar descontos de reservas e Savings Plans. Remover contas não gera desconto por volume, acompanhar cobranças não reduz o valor sozinho e os preços em faixas são aplicados automaticamente.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Tentar remover as contas AWS que não são mais necessárias", false],
+            ["Reunir as contas no AWS Organizations com faturamento consolidado", true],
+            ["Acompanhar de perto as cobranças geradas por cada conta", false],
+            ["Ativar os preços em faixas da AWS antes de provisionar os recursos", false],
+        ],
+    },
+    {
+        statement: "O que o plano AWS Business Support+ oferece? (Selecione DUAS opções.)",
+        explanation:
+            "O Business Support+ inclui o conjunto completo de verificações do Trusted Advisor e a AWS Support API, que permite criar e gerenciar casos por código. Concierge de faturamento, TAM designado e resposta em menos de 15 minutos para sistema crítico fora do ar começam no Enterprise; no Business Support+ essa meta é de menos de 30 minutos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Conjunto completo de verificações do AWS Trusted Advisor", true],
+            ["Concierge de faturamento com atendimento personalizado", false],
+            ["Resposta em menos de 15 minutos quando um sistema crítico cai", false],
+            ["Acesso à AWS Support API para gerenciar casos por código", true],
+            ["Technical Account Manager designado com orientação proativa", false],
+        ],
+    },
+    {
+        statement: "Quais ações podem reduzir os custos do Amazon EBS? (Selecione DUAS opções.)",
+        explanation:
+            "Snapshots desnecessários geram cobrança de armazenamento, e trocar o tipo de volume, como de gp2 para gp3, reduz o preço por GB. Buckets são do Amazon S3, o EBS não tem reservas de capacidade com desconto e espalhar os dados por mais volumes aumenta o espaço provisionado e, com ele, o custo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Excluir buckets do S3 que não são usados", false],
+            ["Comprar reservas de capacidade para os volumes", false],
+            ["Excluir snapshots que não são mais necessários", true],
+            ["Mudar o tipo de volume, como de gp2 para gp3", true],
+            ["Distribuir as requisições de leitura entre mais volumes", false],
+        ],
+    },
+    {
+        statement:
+            "O que torna mais fácil categorizar, gerenciar e filtrar os recursos de uma conta da AWS?",
+        explanation:
+            "Tags são pares de chave e valor anexados aos recursos, usados para agrupar, buscar e filtrar por projeto, ambiente ou responsável. O CloudWatch monitora métricas e logs, o Service Catalog publica catálogos de produtos aprovados e o Directory Service oferece Active Directory gerenciado.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon CloudWatch", false],
+            ["AWS Service Catalog", false],
+            ["AWS Directory Service", false],
+            ["Tags de recursos", true],
+        ],
+    },
+    {
+        statement: "Quais são benefícios do AWS Marketplace? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Marketplace é um catálogo com curadoria de software de fornecedores independentes, pronto para implantar na AWS, com preços flexíveis (avaliação gratuita, por hora, anual, BYOL). Cobrança por segundo é recurso do EC2, o Marketplace não dá desconto em On-Demand e os patches do software cabem ao cliente ou ao vendedor.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Opções de preço flexíveis, como cobrança por hora, contrato anual e BYOL", true],
+            ["Cobrança por segundo em todos os produtos de software do catálogo", false],
+            ["Descontos exclusivos sobre o preço das Instâncias On-Demand do Amazon EC2", false],
+            ["Catálogo com curadoria de software de terceiros pronto para usar na AWS", true],
+            ["Aplicação de patches no software de terceiros feita pela própria AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai lançar uma campanha publicitária no próximo fim de semana para promover um novo produto digital. A expectativa é de grandes picos de carga durante a campanha, e não pode haver indisponibilidade. Será preciso capacidade de computação extra só nesse período. Qual opção de compra do Amazon EC2 tem o MELHOR custo-benefício para esse caso?",
+        explanation:
+            "Para uma carga curta e imprevisível que não pode ser interrompida, as Instâncias On-Demand atendem sem compromisso de prazo. Savings Plans e Instâncias Reservadas exigem compromisso de 1 ou 3 anos, e as Instâncias Spot podem ser interrompidas pela AWS a qualquer momento.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Savings Plans", false],
+            ["Instâncias Spot", false],
+            ["Instâncias Reservadas", false],
+            ["Instâncias On-Demand", true],
+        ],
+    },
+    {
+        statement:
+            "Quais são benefícios das Instâncias On-Demand do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "Com On-Demand você paga pela capacidade usada, sem compromisso, e pode escalar para cima ou para baixo a qualquer momento, sem manter capacidade ociosa para picos. Capacidade gratuita não faz parte do modelo On-Demand, Spot e Reservadas costumam sair mais baratas e as instâncias ficam prontas em minutos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Dispensam comprar capacidade de reserva para picos periódicos de tráfego", true],
+            ["Oferecem capacidade gratuita para testar novas aplicações antes da produção", false],
+            ["Custam menos que qualquer outra opção de compra de instâncias do Amazon EC2", false],
+            ["Exigem de um a dois dias de preparação e configuração antes do primeiro uso", false],
+            ["Permitem aumentar ou reduzir a capacidade de computação conforme a demanda", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS é usado para pagar as faturas da AWS, acompanhar o uso e controlar os custos em relação ao orçamento?",
+        explanation:
+            "O AWS Billing and Cost Management concentra o pagamento das faturas, o acompanhamento do uso e o controle de orçamentos, com ferramentas como Cost Explorer e Budgets. O faturamento consolidado só junta contas numa fatura, o CloudWatch monitora métricas e o Trusted Advisor recomenda boas práticas.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Billing and Cost Management", true],
+            ["Faturamento consolidado do AWS Organizations", false],
+            ["Amazon CloudWatch", false],
+            ["AWS Trusted Advisor", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso da AWS permite que uma empresa aproveite as faixas de preço por volume dos serviços somando o uso de várias contas-membro?",
+        explanation:
+            "O faturamento consolidado do AWS Organizations trata as contas como uma só no cálculo de preços, então o uso somado atinge antes as faixas de desconto por volume. SCPs limitam permissões, Reservadas com pagamento adiantado dão desconto por compromisso e o Cost Explorer só analisa gastos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Políticas de controle de serviço (SCPs)", false],
+            ["Faturamento consolidado", true],
+            ["Instâncias Reservadas com pagamento adiantado integral", false],
+            ["AWS Cost Explorer", false],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir são categorias de verificações do AWS Trusted Advisor? (Selecione DUAS opções.)",
+        explanation:
+            "O Trusted Advisor agrupa as verificações em seis categorias: otimização de custos, desempenho, segurança, tolerância a falhas, limites de serviço e excelência operacional. Uso de instâncias, conformidade e capacidade de armazenamento não são categorias do serviço.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Tolerância a falhas", true],
+            ["Uso de instâncias", false],
+            ["Conformidade", false],
+            ["Desempenho", true],
+            ["Capacidade de armazenamento", false],
+        ],
+    },
+    {
+        statement: "Em qual situação é vantajoso para uma empresa usar Instâncias Spot?",
+        explanation:
+            "As Instâncias Spot usam capacidade ociosa do EC2 com grande desconto, mas a AWS pode recuperá-las com aviso de dois minutos, então servem para cargas flexíveis quanto ao horário. Missão crítica e instâncias que não podem parar pedem On-Demand ou Reservadas, e capacidade dedicada pede Hosts ou Instâncias Dedicadas.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Quando há flexibilidade no horário em que a aplicação precisa rodar", true],
+            ["Quando as cargas de trabalho são de missão crítica para o negócio", false],
+            ["Quando a empresa precisa de capacidade física dedicada só para ela", false],
+            ["Quando a instância não pode ser parada nem interrompida em nenhum momento", false],
+        ],
+    },
+    {
+        statement:
+            "Qual opção permite compartilhar entre várias contas da AWS o benefício de custo das Instâncias Reservadas?",
+        explanation:
+            "Com o faturamento consolidado do AWS Organizations, o desconto de uma Instância Reservada que sobra numa conta é aplicado ao uso compatível de outra conta-membro. Relatórios de utilização, recomendações de compra e orçamentos de Reservadas só mostram dados ou alertam, sem compartilhar o benefício.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Relatório de utilização de Instâncias Reservadas no AWS Cost Explorer", false],
+            ["Contas-membro no faturamento consolidado do AWS Organizations", true],
+            ["Orçamento de utilização de Instâncias Reservadas no AWS Budgets", false],
+            ["Recomendações de compra de Reservadas no AWS Cost Explorer", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem várias contas da AWS e quer simplificar e consolidar o processo de faturamento. Qual serviço da AWS atende a esse objetivo?",
+        explanation:
+            "O AWS Organizations oferece faturamento consolidado: as contas-membro ficam sob a conta de gerenciamento, que recebe uma única fatura com o uso de todas. O Cost and Usage Report detalha os gastos, o Cost Explorer analisa e prevê custos e o AWS Budgets dispara alertas de limite.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost and Usage Report", false],
+            ["AWS Organizations", true],
+            ["AWS Cost Explorer", false],
+            ["AWS Budgets", false],
+        ],
+    },
+    {
+        statement:
+            "Quais métodos podem ser usados para identificar os custos da AWS de cada departamento de uma empresa? (Selecione DUAS opções.)",
+        explanation:
+            "Contas separadas isolam naturalmente os gastos de cada departamento, e tags de alocação de custos permitem filtrar os custos por departamento no Cost Explorer e nos relatórios de faturamento. MFA protege o acesso, Reservadas reduzem o custo total e ordens de compra são só uma forma de pagamento.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Ativar a autenticação multifator (MFA) no usuário raiz da conta", false],
+            ["Criar uma conta da AWS separada para cada departamento", true],
+            ["Comprar Instâncias Reservadas sempre que for possível", false],
+            ["Aplicar tags que associem cada recurso a um departamento", true],
+            ["Pagar as faturas da AWS por meio de ordens de compra", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS é usado para gerenciar de forma centralizada várias contas da AWS e o acesso aos serviços em cada uma delas?",
+        explanation:
+            "O AWS Organizations gerencia várias contas de forma centralizada e, com as políticas de controle de serviço (SCPs), limita os serviços e as ações disponíveis em cada conta. O Service Catalog publica produtos aprovados, o AWS Config registra configurações e o Trusted Advisor recomenda boas práticas.",
+        topic: "Segurança e identidade",
+        options: [
+            ["AWS Service Catalog", false],
+            ["AWS Config", false],
+            ["AWS Trusted Advisor", false],
+            ["AWS Organizations", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa avalia migrar suas aplicações para a AWS. Ela já conhece o custo de manter a carga de trabalho on-premises e quer estimar quanto a carga equivalente custaria na AWS, para comparar os dois valores. Qual ferramenta faz essa estimativa?",
+        explanation:
+            "O AWS Pricing Calculator estima quanto a carga equivalente custaria na AWS antes de qualquer recurso existir, e essa estimativa é comparada ao custo on-premises. Cost and Usage Report e Cost Explorer trabalham com gastos que já ocorreram, e o AWS Budgets define limites e alertas sobre o gasto.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost and Usage Report", false],
+            ["AWS Pricing Calculator", true],
+            ["AWS Budgets", false],
+            ["AWS Cost Explorer", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso está incluído no plano AWS Enterprise Support, mas NÃO está disponível no plano AWS Business Support+?",
+        explanation:
+            "O Enterprise Support inclui um TAM designado, que dá orientação proativa e coordena recursos da AWS para o cliente. O Business Support+ já oferece acesso 24/7 a engenheiros por telefone, chat, e-mail e web, todas as verificações do Trusted Advisor e a AWS Support API, mas não tem TAM designado.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Acesso 24/7 a engenheiros de suporte por telefone e chat", false],
+            ["Technical Account Manager (TAM) designado para a empresa", true],
+            ["Conjunto completo de verificações do Trusted Advisor", false],
+            ["Acesso à AWS Support API para gerenciar casos", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são vantagens das Instâncias Reservadas do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "As Instâncias Reservadas dão até 72% de desconto sobre o On-Demand em troca de compromisso de 1 ou 3 anos, e as zonais reservam capacidade numa Zona de Disponibilidade. Os tipos de instância e a rede são os mesmos do On-Demand, e o desconto só existe porque há compromisso de prazo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Oferecem desconto em relação ao preço das Instâncias On-Demand", true],
+            ["Dão acesso a tipos de instância que não existem no modelo On-Demand", false],
+            ["Oferecem capacidade de rede adicional em relação ao On-Demand", false],
+            ["Dispensam qualquer compromisso de prazo com a AWS", false],
+            ["Permitem reservar capacidade numa Zona de Disponibilidade", true],
+        ],
+    },
+    {
+        statement:
+            "Um cliente executa uma instância On-Demand do Amazon EC2 com Amazon Linux por 3 horas, 5 minutos e 6 segundos. Por quanto tempo esse cliente será cobrado?",
+        explanation:
+            "Instâncias On-Demand com Amazon Linux são cobradas por segundo, com mínimo de 60 segundos, então o cliente paga exatamente 3 horas, 5 minutos e 6 segundos. Descartar os segundos ou arredondar o minuto não segue essa regra, e a cobrança por hora cheia é o modelo antigo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["3 horas e 5 minutos (ignora os segundos)", false],
+            ["3 horas, 5 minutos e 6 segundos (exato)", true],
+            ["3 horas e 6 minutos (arredonda o minuto)", false],
+            ["4 horas (arredonda para a hora cheia)", false],
+        ],
+    },
+    {
+        statement:
+            "Quais vantagens uma empresa tem ao usar software de terceiros do AWS Marketplace, em vez de instalar esse software por conta própria no Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "No AWS Marketplace o software é cobrado conforme a licença (por hora, mês ou ano, na própria fatura da AWS) e já vem configurado para implantar em poucos cliques. A criptografia dos dados continua sendo do cliente, as atualizações de versão continuam necessárias e testar antes de usar segue sendo boa prática.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Pagar pelo software por hora ou por mês, conforme a licença", true],
+            ["Implantar a aplicação já configurada no EC2 com poucos cliques", true],
+            ["Ter a criptografia dos dados gerenciada pelo fornecedor do software", false],
+            ["Deixar de precisar atualizar o software para versões mais novas", false],
+            ["Implantar o software de terceiros sem precisar testá-lo antes", false],
+        ],
+    },
+    {
+        statement: "O que é o AWS Trusted Advisor?",
+        explanation:
+            "O Trusted Advisor é uma ferramenta automatizada que inspeciona o ambiente e recomenda melhorias em otimização de custos, desempenho, segurança, tolerância a falhas, limites de serviço e excelência operacional. Não é uma pessoa, não é a AWS Partner Network e não se confunde com os TAMs, profissionais do plano Enterprise.",
+        topic: "Ferramentas e suporte",
+        options: [
+            [
+                "Um especialista da AWS que analisa a conta e recomenda boas práticas de custo e segurança",
+                false,
+            ],
+            ["Uma rede de parceiros da AWS que recomenda boas práticas de uso", false],
+            ["Uma ferramenta on-line que faz verificações automáticas e recomenda melhorias", true],
+            [
+                "Outro nome dado aos Technical Account Managers que recomendam melhorias de custo e segurança",
+                false,
+            ],
+        ],
+    },
+    {
+        statement: "Qual é um efeito do modelo de pagamento conforme o uso dos serviços da AWS?",
+        explanation:
+            "No pagamento conforme o uso, a empresa não precisa investir antes em servidores e data centers, o que reduz as despesas de capital e transforma o gasto em despesa variável. Não há pagamento adiantado obrigatório, o modelo vale para quase todos os serviços e a troca é de CapEx por OpEx, não o contrário.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Reduz as despesas de capital (CapEx), pois dispensa comprar hardware", true],
+            ["Exige pagamento adiantado pelos serviços antes de começar a usá-los", false],
+            ["Vale apenas para os serviços Amazon EC2, Amazon S3 e Amazon RDS", false],
+            ["Converte despesas operacionais (OpEx) em despesas de capital (CapEx)", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de escolher uma reserva de Host Dedicado do Amazon EC2, qual forma de pagamento oferece o MAIOR desconto?",
+        explanation:
+            "Na reserva de Host Dedicado, o pagamento adiantado integral quita toda a reserva de uma vez e dá o maior desconto. O adiantado parcial combina uma entrada com taxa horária reduzida, o sem adiantamento tem o menor desconto entre as reservas e o On-Demand por hora não tem desconto nenhum.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Sem pagamento adiantado (No Upfront)", false],
+            ["Pagamento por hora no modelo On-Demand", false],
+            ["Pagamento adiantado parcial (Partial Upfront)", false],
+            ["Pagamento adiantado integral (All Upfront)", true],
+        ],
+    },
+    {
+        statement:
+            "Como uma empresa pode isolar os custos das cargas de trabalho de produção e de não produção na AWS?",
+        explanation:
+            "Contas separadas criam uma fronteira de faturamento: cada ambiente tem seus próprios custos, fáceis de acompanhar e revisar. Funções do IAM controlam permissões, dividir por serviço não separa ambientes e o CloudWatch monitora o uso, mas nenhum deles isola os custos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Criar funções do IAM separadas para as cargas de produção e de não produção", false],
+            ["Usar contas da AWS diferentes para os ambientes de produção e de não produção", true],
+            [
+                "Usar Amazon EC2 para não produção e outros serviços para as cargas de produção",
+                false,
+            ],
+            ["Usar o Amazon CloudWatch para monitorar o uso dos serviços em cada ambiente", false],
+        ],
+    },
+    {
+        statement:
+            "O que o AWS Marketplace permite que os usuários façam? (Selecione DUAS opções.)",
+        explanation:
+            "No AWS Marketplace, fornecedores vendem suas soluções para clientes da AWS e compradores contratam software de terceiros que roda na AWS, pago na própria fatura. Instâncias Spot não podem ser revendidas, relatórios de conformidade ficam no AWS Artifact e aumento de cotas é pedido no Service Quotas.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Vender Instâncias Spot do Amazon EC2 que não estão sendo usadas", false],
+            ["Vender suas próprias soluções para outros clientes da AWS", true],
+            ["Comprar software de terceiros que roda na AWS", true],
+            ["Adquirir documentos de segurança e conformidade da AWS", false],
+            ["Solicitar aumento das cotas de serviço da conta", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS oferece uma forma rápida e automatizada de criar e gerenciar contas da AWS?",
+        explanation:
+            "O AWS Organizations permite criar contas-membro pelo console ou por API e gerenciá-las de forma centralizada, com unidades organizacionais, SCPs e faturamento consolidado. O Cognito e o Directory Service cuidam de usuários de aplicações e de diretórios, e o Lightsail oferece servidores virtuais simplificados.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Cognito", false],
+            ["Amazon Lightsail", false],
+            ["AWS Organizations", true],
+            ["AWS Directory Service", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está migrando seus data centers on-premises para a Nuvem AWS e quer ajuda prática de especialistas na execução do projeto. Como a empresa pode obter esse apoio? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Professional Services e os parceiros da AWS Partner Network oferecem ajuda prática em migrações, com especialistas que planejam e executam o trabalho junto com a empresa. O time do Marketplace não executa migrações, o AWS Support resolve problemas técnicos por casos e o Amazon Connect é uma central de contato.",
+        topic: "Ferramentas e suporte",
+        options: [
+            [
+                "Pedir ao time do AWS Marketplace um orçamento para executar a migração na conta da empresa",
+                false,
+            ],
+            [
+                "Abrir um caso no AWS Support pedindo que a equipe de suporte execute a migração",
+                false,
+            ],
+            [
+                "Contratar o AWS Professional Services para orientar a migração e montar a landing zone",
+                true,
+            ],
+            ["Contratar um parceiro da AWS Partner Network (APN) especializado em migração", true],
+            [
+                "Usar o Amazon Connect para criar uma solicitação de proposta (RFP) de ajuda especializada",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Como o serviço de concierge incluído no AWS Enterprise Support ajuda os clientes?",
+        explanation:
+            "O Enterprise Support inclui um serviço de concierge com especialistas em faturamento e conta, que atendem dúvidas de cobrança e ajudam a aplicar boas práticas de faturamento. Arquitetura fica com o TAM e os Solutions Architects, casos técnicos com os engenheiros de suporte e desenvolvimento com Professional Services ou parceiros.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Apoiando o desenvolvimento das aplicações do cliente", false],
+            ["Oferecendo orientação sobre arquitetura na AWS", false],
+            ["Respondendo a dúvidas de faturamento e de conta", true],
+            ["Respondendo a perguntas sobre casos de suporte técnico", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem várias contas no AWS Organizations e quer que o desconto das Instâncias Reservadas do Amazon EC2 compradas para uma conta-membro específica valha somente para essa conta. O que deve ser feito?",
+        explanation:
+            "O desconto de uma Reservada vale primeiro para a conta que a comprou e só é compartilhado com contas que tenham o compartilhamento ativo. Comprar na conta-membro e desativar o compartilhamento dela, pela conta de gerenciamento, restringe o benefício a essa conta. Comprar na conta de gerenciamento beneficiaria outra conta, e ativar o compartilhamento faria o oposto.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Comprar as Reservadas na conta de gerenciamento e desativar o compartilhamento dela",
+                false,
+            ],
+            [
+                "Ativar os alertas de faturamento no console do AWS Billing and Cost Management",
+                false,
+            ],
+            [
+                "Comprar as Reservadas na conta-membro e desativar o compartilhamento dela na conta de gerenciamento",
+                true,
+            ],
+            [
+                "Ativar o compartilhamento de Reservadas para todas as contas no console do AWS Billing and Cost Management",
+                false,
+            ],
+        ],
+    },
+    {
+        statement: "Para que o AWS Budgets pode ser usado?",
+        explanation:
+            "O AWS Budgets cria orçamentos de custo, uso, utilização e cobertura de Reservadas e Savings Plans, com alertas quando o valor passa do limite ou fica abaixo da meta. Recomendar tipos de instância é papel do Compute Optimizer, registrar chamadas de API é do CloudTrail e formas de pagamento ficam nas preferências de faturamento.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Alertar quando a utilização das Reservadas cair abaixo da meta definida", true],
+            [
+                "Recomendar tipos de instância mais baratos com base no histórico de uso de CPU",
+                false,
+            ],
+            ["Registrar as chamadas de API que criaram cada recurso cobrado na fatura", false],
+            ["Dividir o valor de uma fatura da AWS entre várias formas de pagamento", false],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos ou serviços podem ser usados para monitorar os custos e as despesas de uma conta da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O Cost and Usage Report (hoje entregue pelo AWS Data Exports como CUR 2.0) traz os custos detalhados da conta, e os alarmes de faturamento do CloudWatch avisam quando o gasto estimado passa de um limite. Páginas de produto e a Price List API mostram preços de tabela, e o Trusted Advisor recomenda economias sem acompanhar os gastos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost and Usage Report", true],
+            ["Páginas de produto com os preços dos serviços da AWS", false],
+            ["AWS Trusted Advisor", false],
+            ["Alarmes de faturamento no Amazon CloudWatch", true],
+            ["AWS Price List API", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer testar uma solução de e-commerce de terceiros antes de decidir usá-la a longo prazo. Qual serviço ou ferramenta da AWS apoia esse objetivo?",
+        explanation:
+            "O AWS Marketplace tem produtos de terceiros com avaliação gratuita e cobrança conforme o uso, então a empresa pode testar a solução antes de assumir um contrato. A APN é o programa de parceiros, o Service Catalog organiza produtos aprovados para uso interno e o Amplify serve para criar aplicações web e móveis.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Marketplace", true],
+            ["AWS Partner Network (APN)", false],
+            ["AWS Amplify", false],
+            ["AWS Service Catalog", false],
+        ],
+    },
+    {
+        statement:
+            "Cada departamento de uma empresa tem sua própria conta da AWS, independente e com forma de pagamento própria. A nova liderança quer centralizar a governança dos departamentos e consolidar os pagamentos. Como fazer isso com serviços ou recursos da AWS?",
+        explanation:
+            "Com uma nova conta como conta de gerenciamento do AWS Organizations, basta convidar as contas dos departamentos: a empresa ganha governança central com SCPs e faturamento consolidado numa única forma de pagamento. Não dá para criar uma organização em cada conta e depois juntá-las, e faturas encaminhadas, funções do IAM ou o Cost Explorer não consolidam pagamentos.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Encaminhar as faturas mensais de cada conta e depois criar funções do IAM para acesso entre contas",
+                false,
+            ],
+            [
+                "Criar uma nova conta da AWS, configurar o AWS Organizations e convidar todas as contas existentes",
+                true,
+            ],
+            [
+                "Configurar o AWS Organizations em cada uma das contas existentes e depois vincular todas elas",
+                false,
+            ],
+            [
+                "Usar o Cost Explorer para somar os custos das contas e depois replicar as políticas do IAM",
+                false,
+            ],
+        ],
+    },
+    {
+        statement: "O que o AWS Pricing Calculator faz?",
+        explanation:
+            "O AWS Pricing Calculator é uma ferramenta gratuita que estima custos mensais, anuais e iniciais a partir da configuração e do uso previsto dos serviços da AWS. Ele não compara colocation, não mede consumo de energia de data centers e não acompanha CPU de instâncias em execução, papel do Amazon CloudWatch.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Compara custos on-premises com os de ambientes de colocation", false],
+            ["Estima a fatura mensal com base no uso projetado dos serviços da AWS", true],
+            ["Estima o consumo de energia elétrica dos data centers existentes da empresa", false],
+            ["Estima a utilização de CPU das instâncias que estão em execução", false],
+        ],
+    },
+    {
+        statement:
+            "Um usuário precisa de ajuda com o faturamento e quer reativar uma conta suspensa. Para onde ele deve enviar uma solicitação de conta e faturamento?",
+        explanation:
+            "Casos de conta e faturamento podem ser abertos no AWS Support Center por qualquer cliente, inclusive no plano Basic, e é por eles que se trata cobrança e reativação de conta. O re:Post é uma comunidade de perguntas, a equipe Trust & Safety recebe denúncias de abuso e um Solutions Architect orienta arquitetura.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Comunidade do AWS re:Post", false],
+            ["Equipe AWS Trust & Safety", false],
+            ["Um Solutions Architect da AWS", false],
+            ["Atendimento do AWS Support", true],
+        ],
+    },
+    {
+        statement:
+            "Quais funcionalidades as ferramentas do AWS Billing and Cost Management oferecem aos usuários? (Selecione DUAS opções.)",
+        explanation:
+            "O AWS Cost Explorer detalha os custos por dia, por serviço e por conta vinculada, e o AWS Budgets cria orçamentos com alertas para uso real ou previsto. Essas ferramentas não encerram todos os recursos nem trocam o modelo de compra sozinhas, e mover dados para classes mais baratas é função do ciclo de vida do Amazon S3.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Encerrar automaticamente todos os recursos da AWS quando um orçamento é ultrapassado",
+                false,
+            ],
+            [
+                "Detalhar os custos da AWS por dia, por serviço e por conta vinculada da organização",
+                true,
+            ],
+            [
+                "Criar orçamentos e receber notificações quando o uso real ou previsto os ultrapassar",
+                true,
+            ],
+            [
+                "Trocar sozinhas para Instâncias Reservadas ou Spot, conforme o que sair mais barato",
+                false,
+            ],
+            ["Mover os dados do Amazon S3 para uma classe de armazenamento mais barata", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer reaproveitar licenças de software que são cobradas por núcleo físico de processador. Qual opção de compra do Amazon EC2 permite cumprir essa exigência de licenciamento?",
+        explanation:
+            "Os Hosts Dedicados reservam um servidor físico inteiro e mostram seus soquetes e núcleos, o que permite usar licenças cobradas por núcleo ou por soquete (BYOL). On-Demand, Spot e Reservadas são formas de pagamento que, por padrão, rodam em hardware compartilhado e não expõem essa topologia física.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Hosts Dedicados", true],
+            ["Instâncias On-Demand", false],
+            ["Instâncias Spot", false],
+            ["Instâncias Reservadas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem várias contas da AWS que até agora eram cobradas de forma independente. Qual recurso é o mais adequado para reunir a cobrança dessas contas?",
+        explanation:
+            "O faturamento consolidado do AWS Organizations reúne contas antes independentes sob a conta de gerenciamento, que recebe uma única fatura e soma o uso para descontos por volume. O Cost Explorer analisa gastos, o Data Exports exporta dados de custo e as tags de alocação classificam custos, sem unificar a cobrança.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost Explorer", false],
+            ["Faturamento consolidado", true],
+            ["AWS Data Exports", false],
+            ["Tags de alocação de custos", false],
+        ],
+    },
+    {
+        statement: "Para que serve o AWS Pricing Calculator?",
+        explanation:
+            "O AWS Pricing Calculator é uma ferramenta web gratuita para modelar uma solução e estimar seus custos antes de criá-la. Relatórios de custos já cobrados vêm do AWS Data Exports, a comparação com o orçado e os alertas são do AWS Budgets, e gastos fora do padrão são detectados pelo AWS Cost Anomaly Detection.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Receber relatórios que detalham os custos já cobrados por duração, recurso ou tag",
+                false,
+            ],
+            ["Montar estimativas do custo de uma solução na AWS antes de construí-la", true],
+            ["Comparar os custos reais com os valores orçados e enviar alertas por e-mail", false],
+            ["Detectar gastos fora do padrão com machine learning e avisar a equipe", false],
+        ],
+    },
+    {
+        statement: "Qual é o plano MÍNIMO do AWS Support que dá acesso à AWS Support API?",
+        explanation:
+            "A AWS Support API, que permite abrir e gerenciar casos e consultar o AWS Trusted Advisor por código, exige o AWS Business Support+, o AWS Enterprise Support ou o AWS Unified Operations. O Basic não dá acesso à API, e Enterprise e Unified Operations também dão, mas não são o plano mínimo.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Basic Support", false],
+            ["AWS Business Support+", true],
+            ["AWS Enterprise Support", false],
+            ["AWS Unified Operations", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é o plano do AWS Support de MENOR custo que inclui, sem custo adicional, o AWS Security Incident Response, para receber orientação na resposta a incidentes como sequestro de conta e ransomware?",
+        explanation:
+            "Pela documentação atual, o Enterprise Support inclui o AWS Security Incident Response sem custo adicional, além de TAM designado e resposta em até 15 minutos para casos críticos. No Business Support+ o serviço é cobrado à parte, o Basic só abre casos de conta e faturamento, e o Unified Operations também o inclui, mas custa bem mais.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Basic Support", false],
+            ["AWS Business Support+", false],
+            ["AWS Enterprise Support", true],
+            ["AWS Unified Operations", false],
+        ],
+    },
+    {
+        statement:
+            "Qual ferramenta pode ser usada para monitorar o uso das cotas de serviço (limites de serviço) da AWS?",
+        explanation:
+            "O AWS Trusted Advisor tem a categoria de verificações de limites de serviço, que avisa quando o uso se aproxima da cota e está disponível em todos os planos. O Pricing Calculator estima custos, o Health Dashboard informa eventos da AWS que afetam suas contas e o Data Exports exporta dados de custo e uso.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Pricing Calculator", false],
+            ["AWS Trusted Advisor", true],
+            ["AWS Health Dashboard", false],
+            ["AWS Data Exports", false],
+        ],
+    },
+    {
+        statement:
+            "A aplicação de uma empresa tem horários de início e de término flexíveis. Qual modelo de preço do Amazon EC2 é o MAIS econômico para essa aplicação?",
+        explanation:
+            "As Instâncias Spot usam capacidade ociosa do EC2 com descontos de até 90% e combinam com aplicações de início e término flexíveis, que aceitam ser interrompidas e retomadas. On-Demand cobra o preço cheio, Reservadas exigem compromisso de 1 ou 3 anos e Hosts Dedicados custam mais pelo servidor exclusivo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias On-Demand", false],
+            ["Instâncias Spot", true],
+            ["Instâncias Reservadas", false],
+            ["Hosts Dedicados", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de nuvem tem uma carga de análise de dados que roda poucas vezes e pode ser interrompida sem prejuízo. Para otimizar o custo, qual opção de compra do Amazon EC2 ele deve usar?",
+        explanation:
+            "Cargas esporádicas que toleram interrupção são o caso típico das Instâncias Spot, que oferecem os maiores descontos em troca de a AWS poder recuperar a capacidade. On-Demand não tem desconto, Reservadas pagariam por capacidade ociosa num compromisso de 1 ou 3 anos e Hosts Dedicados custam mais.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias On-Demand", false],
+            ["Instâncias Reservadas", false],
+            ["Instâncias Spot", true],
+            ["Hosts Dedicados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa com o plano AWS Business Support+ criou um banco de dados no Amazon RDS, e o desenvolvedor responsável não consegue se conectar a ele. Quem ele deve procurar para resolver o problema?",
+        explanation:
+            "O Business Support+ inclui casos de suporte técnico ilimitados, com atendimento 24 horas, então o caminho é abrir um caso no AWS Support. Um TAM designado só existe a partir do Enterprise, e o AWS Professional Services e os parceiros da AWS Partner Network atuam em projetos contratados, não no suporte do plano.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["O AWS Support, abrindo um caso técnico pelo console", true],
+            ["O AWS Professional Services, com um projeto de consultoria", false],
+            ["O Technical Account Manager (TAM) designado da conta", false],
+            ["Um parceiro de consultoria da AWS Partner Network", false],
+        ],
+    },
+    {
+        statement:
+            "Em quais categorias o AWS Trusted Advisor oferece recomendações? (Selecione DUAS opções.)",
+        explanation:
+            "O Trusted Advisor organiza suas verificações em seis categorias: otimização de custos, desempenho, segurança, tolerância a falhas, limites de serviço e excelência operacional. Auditoria de atividades é papel do AWS CloudTrail e do AWS Config, e arquitetura sem servidor e escalabilidade não são categorias do serviço.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Otimização de custos", true],
+            ["Auditoria", false],
+            ["Arquitetura sem servidor", false],
+            ["Desempenho", true],
+            ["Escalabilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa que opera na Nuvem AWS precisa de faturas separadas para cada ambiente, como desenvolvimento, testes e produção. Como ela pode conseguir isso?",
+        explanation:
+            "A cobrança da AWS é organizada por conta. Com uma conta para cada ambiente, os custos de desenvolvimento, testes e produção ficam separados e podem gerar faturas próprias. Tags e o Cost Explorer só classificam e filtram custos dentro da mesma cobrança, e VPCs isolam a rede sem separar a fatura.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Usar uma conta da AWS para cada ambiente", true],
+            ["Aplicar tags de ambiente aos recursos", false],
+            ["Criar uma VPC separada para cada ambiente", false],
+            ["Filtrar os custos por ambiente no AWS Cost Explorer", false],
+        ],
+    },
+    {
+        statement:
+            "O que pode ser usado para reduzir o custo de execução de instâncias do Amazon EC2? (Selecione DUAS opções.)",
+        explanation:
+            "Instâncias Spot dão grandes descontos para cargas sem estado e flexíveis, que toleram interrupção, e Instâncias Reservadas reduzem o custo de cargas contínuas com compromisso de 1 ou 3 anos. On-Demand é o preço cheio, a família de instância deve seguir o perfil da carga e o AWS Budgets alerta sobre gastos, mas não reduz o preço.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Spot para cargas sem estado e com horário flexível", true],
+            ["Instâncias otimizadas para memória em cargas que exigem muita CPU", false],
+            ["Instâncias On-Demand para cargas de alto custo e uso contínuo", false],
+            ["Instâncias Reservadas para cargas de trabalho de uso contínuo", true],
+            ["Limites de gasto definidos no AWS Budgets para barrar cobranças", false],
+        ],
+    },
+    {
+        statement:
+            "Qual requisito precisa ser atendido para que uma conta-membro seja removida de uma organização no AWS Organizations?",
+        explanation:
+            "Ao sair da organização, a conta passa a pagar a própria fatura, por isso precisa ter as informações de uma conta independente: plano de suporte, contato verificado e forma de pagamento. A remoção pode partir da conta de gerenciamento ou da própria conta-membro, sem caso no AWS Support, e certificação SOC não é requisito.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "A conta-membro precisa ter certificação SOC (System and Organization Controls) ativa",
+                false,
+            ],
+            [
+                "A conta de gerenciamento e a conta-membro precisam abrir casos no AWS Support",
+                false,
+            ],
+            ["A conta-membro precisa ter as informações exigidas de uma conta independente", true],
+            [
+                "A remoção só pode ser feita a partir da conta de gerenciamento da organização",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Quais práticas ajudam a identificar os custos da AWS de cada departamento de uma empresa? (Selecione DUAS opções.)",
+        explanation:
+            "Tags de alocação de custos permitem filtrar os gastos por departamento nos relatórios, e contas separadas por departamento criam divisões claras na cobrança. Um gerente de contas não atribui custos, o Trusted Advisor recomenda boas práticas e o faturamento consolidado junta as contas em uma fatura, sem identificar departamentos.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Aplicar tags com o nome do departamento a cada recurso", true],
+            ["Usar uma conta da AWS separada por departamento", true],
+            ["Contratar um gerente de contas da AWS para a empresa", false],
+            ["Executar as verificações do AWS Trusted Advisor", false],
+            ["Receber uma única fatura com o faturamento consolidado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai testar por um mês, em projeto piloto, uma nova aplicação voltada aos clientes no Amazon Elastic Compute Cloud (Amazon EC2). Qual modelo de preço é o mais adequado?",
+        explanation:
+            "Um piloto de um mês pede On-Demand: não há compromisso de longo prazo e a capacidade não é interrompida, algo essencial para uma aplicação usada por clientes. Reservadas exigem pelo menos 1 ano, Spot pode ser recuperada pela AWS a qualquer momento e Hosts Dedicados custam mais sem necessidade.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Reservadas", false],
+            ["Instâncias Spot", false],
+            ["Instâncias On-Demand", true],
+            ["Hosts Dedicados", false],
+        ],
+    },
+    {
+        statement:
+            "Por meio de qual serviço é possível configurar uma conta de gerenciamento que paga e visualiza a cobrança consolidada de várias contas da AWS?",
+        explanation:
+            "No AWS Organizations, a conta de gerenciamento paga as cobranças de todas as contas-membro e vê o faturamento consolidado. O AWS Budgets cria orçamentos e alertas, o AWS Cost Explorer analisa gastos já existentes e o Amazon Quick Sight monta painéis de BI, mas nenhum deles cria a estrutura de conta pagadora.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Budgets", false],
+            ["AWS Cost Explorer", false],
+            ["Amazon Quick Sight", false],
+            ["AWS Organizations", true],
+        ],
+    },
+    {
+        statement:
+            "Qual é uma característica das Instâncias Reservadas Conversíveis do Amazon EC2?",
+        explanation:
+            "Conversíveis podem ser trocadas por outras Conversíveis com família, sistema operacional ou locação diferentes, desde que o novo valor seja igual ou maior. A Região fica fixa durante todo o prazo, só Reservadas Standard podem ser vendidas no Reserved Instance Marketplace e combinar reservas não encurta o prazo.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "Podem ser trocadas por outras Conversíveis de outra família de instância, com valor igual ou maior",
+                true,
+            ],
+            [
+                "Podem ser trocadas por outras Conversíveis em uma Região diferente da AWS, com valor igual ou maior",
+                false,
+            ],
+            [
+                "Podem ser vendidas a outros clientes no Reserved Instance Marketplace a qualquer momento",
+                false,
+            ],
+            [
+                "Podem ter o prazo encurtado quando combinadas com outras Conversíveis da mesma conta",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um profissional de nuvem precisa de uma instância do Amazon EC2 que seja iniciada e rode por 7 horas, sem interrupções. Qual é a opção mais adequada e econômica para essa tarefa?",
+        explanation:
+            "Para uma tarefa única de 7 horas que não pode parar, On-Demand é o ideal: paga-se só pelo tempo de uso, sem compromisso e sem risco de interrupção. Reservadas exigem compromisso de 1 ou 3 anos, Hosts Dedicados custam mais pelo servidor exclusivo e Spot pode ser interrompida pela AWS.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias On-Demand", true],
+            ["Instâncias Reservadas", false],
+            ["Hosts Dedicados", false],
+            ["Instâncias Spot", false],
+        ],
+    },
+    {
+        statement:
+            "Que vantagens o AWS Trusted Advisor traz para uma conta da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O Trusted Advisor verifica a conta e aponta recursos subutilizados, como instâncias ociosas, e riscos de segurança, como portas abertas ou falta de MFA no usuário raiz. Orquestrar contêineres é papel do Amazon ECS e do Amazon EKS, chaves de criptografia ficam no AWS KMS e impor tags é feito com políticas do AWS Organizations.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Orquestrar contêineres com alto desempenho em clusters gerenciados", false],
+            ["Criar e rotacionar chaves de criptografia para proteger dados", false],
+            ["Detectar recursos subutilizados ou ociosos para reduzir custos", true],
+            ["Melhorar a segurança com monitoramento proativo do ambiente", true],
+            ["Impor o uso obrigatório de tags em todos os recursos da conta", false],
+        ],
+    },
+    {
+        statement:
+            "Qual ferramenta permite que pessoas sem conta na AWS estimem o custo de praticamente todos os serviços da AWS?",
+        explanation:
+            "O AWS Pricing Calculator é uma ferramenta web gratuita e pública, usada sem conta na AWS, para montar estimativas de quase todos os serviços. Cost Explorer, Budgets e o console do Billing and Cost Management trabalham com dados de uma conta existente, então não servem para quem ainda não tem conta.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost Explorer", false],
+            ["AWS Billing and Cost Management", false],
+            ["AWS Budgets", false],
+            ["AWS Pricing Calculator", true],
+        ],
+    },
+    {
+        statement:
+            "Um servidor de banco de dados no Amazon EC2 precisa ficar ligado sem interrupção durante um ano. Entre as opções abaixo, qual modelo de preço gera a MAIOR economia?",
+        explanation:
+            "Para um banco que precisa ficar ligado o ano todo, a Reservada de 1 ano é a escolha, e com pagamento adiantado parcial o desconto é maior que sem adiantamento. Spot pode ser interrompida, o que não serve para um banco de dados, e On-Demand cobra o preço cheio, sem desconto por compromisso.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Spot, com preço variável conforme a capacidade", false],
+            ["Instâncias On-Demand, com cobrança por segundo sem compromisso", false],
+            ["Instâncias Reservadas com pagamento adiantado parcial", true],
+            ["Instâncias Reservadas sem nenhum pagamento adiantado", false],
+        ],
+    },
+    {
+        statement:
+            "A AnyCompany comprou a Example Corp. As duas empresas usam a AWS, e a AnyCompany quer receber uma única fatura com a cobrança das duas. O que permite isso?",
+        explanation:
+            "A conta de gerenciamento da organização da AnyCompany envia um convite à conta da Example Corp.; ao aceitar, ela vira conta-membro e entra no faturamento consolidado, com uma única fatura. Não é preciso acionar TAM, arquiteto ou caso de suporte, e migrar todos os recursos seria trabalhoso e desnecessário.",
+        topic: "Preços e faturamento",
+        options: [
+            [
+                "A Example Corp. pedir a um arquiteto de soluções ou TAM da AWS que una as contas",
+                false,
+            ],
+            ["A AnyCompany abrir um caso no AWS Support pedindo a junção das duas faturas", false],
+            [
+                "Convidar a conta da Example Corp. para a organização da AnyCompany no AWS Organizations",
+                true,
+            ],
+            [
+                "Migrar as VPCs, instâncias EC2 e demais recursos da Example Corp. para a conta da AnyCompany",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual conjunto de verificações do AWS Trusted Advisor está disponível para todos os clientes da AWS, inclusive no plano Basic Support?",
+        explanation:
+            "Todo cliente, inclusive no Basic, tem as verificações principais do Trusted Advisor: toda a categoria de limites de serviço e algumas de segurança, como MFA no usuário raiz e permissões de buckets do S3. O conjunto completo, com otimização de custos e desempenho, exige Business Support+, Enterprise ou Unified Operations.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Verificações principais (core checks)", true],
+            ["Todas as verificações de todas as categorias", false],
+            ["Verificações de otimização de custos", false],
+            ["Verificações de desempenho", false],
+        ],
+    },
+    {
+        statement:
+            "Uma carga de trabalho vai rodar por tempo indeterminado na AWS, sempre com a mesma quantidade de instâncias do Amazon EC2. Qual modelo de preço minimiza o custo sem que as instâncias corram risco de interrupção?",
+        explanation:
+            "Uso estável e contínuo é o caso das Instâncias Reservadas, que dão até 72% de desconto sobre o On-Demand em troca de compromisso de 1 ou 3 anos. On-Demand cobra o preço cheio, Spot é mais barata mas pode ser interrompida pela AWS e Hosts Dedicados custam mais pelo servidor físico exclusivo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Hosts Dedicados do Amazon EC2", false],
+            ["Instâncias On-Demand", false],
+            ["Instâncias Spot", false],
+            ["Instâncias Reservadas", true],
+        ],
+    },
+    {
+        statement:
+            "Qual opção do Amazon EC2 permite comprar capacidade computacional ociosa da AWS, geralmente com grande desconto?",
+        explanation:
+            "As Instâncias Spot vendem a capacidade ociosa do EC2 com descontos de até 90% sobre o On-Demand, e a AWS pode recuperá-la com aviso de dois minutos. Reservadas dão desconto por compromisso de 1 ou 3 anos, On-Demand é o preço padrão sem desconto e Hosts Dedicados custam mais pelo servidor exclusivo.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Reservadas", false],
+            ["Instâncias On-Demand", false],
+            ["Hosts Dedicados", false],
+            ["Instâncias Spot", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa roda, diretamente no Amazon EC2, um banco de dados Oracle autogerenciado que tem uso estável e não pode sofrer interrupções. Ela quer reduzir o custo de computação. Qual opção gera a MAIOR economia em um prazo de 3 anos?",
+        explanation:
+            "Um banco com uso estável por 3 anos é o caso clássico das Instâncias Reservadas, com até 72% de desconto sobre o On-Demand. Instâncias Dedicadas custam mais pelo hardware exclusivo, Spot pode ser interrompida mesmo com hibernação, o que não serve para um banco de produção, e On-Demand cobra o preço cheio.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias Dedicadas", false],
+            ["Instâncias Spot com hibernação", false],
+            ["Instâncias Reservadas", true],
+            ["Instâncias On-Demand", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são benefícios do faturamento consolidado para os serviços da Nuvem AWS? (Selecione DUAS opções.)",
+        explanation:
+            "O faturamento consolidado do AWS Organizations soma o uso de todas as contas para alcançar faixas de desconto por volume e entrega uma única fatura. O recurso não tem custo extra nem opção de parcelamento, e orçamentos personalizados de custo e uso são criados no AWS Budgets.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Descontos por volume com a soma do uso das contas", true],
+            ["Uma pequena taxa adicional cobrada pelo uso do recurso", false],
+            ["Uma única fatura para todas as contas da organização", true],
+            ["Opção de parcelar o pagamento das faturas mensais", false],
+            ["Criação de orçamentos personalizados de custo e uso", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa espera um pico de tráfego de curta duração em sua aplicação, que não pode ser interrompida durante esse período. A empresa também quer minimizar o custo e ter o máximo de flexibilidade. Qual opção de compra do Amazon EC2 ela deve usar?",
+        explanation:
+            "Para um pico curto que não pode sofrer interrupção, On-Demand oferece flexibilidade total, sem compromisso, pagando só pelo período de uso. Spot é mais barata mas pode ser interrompida, Reservadas exigem compromisso de 1 ou 3 anos, desproporcional para um pico passageiro, e Hosts Dedicados custam mais.",
+        topic: "Preços e faturamento",
+        options: [
+            ["Instâncias On-Demand", true],
+            ["Instâncias Spot", false],
+            ["Instâncias Reservadas", false],
+            ["Hosts Dedicados", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS usa machine learning para analisar a configuração e as métricas de utilização de instâncias do Amazon EC2 e recomendar os tipos de instância ideais?",
+        explanation:
+            "O AWS Compute Optimizer aplica machine learning ao histórico de métricas de utilização, como CPU e rede, para recomendar o tipo e o tamanho ideais das instâncias. O Amazon Inspector procura vulnerabilidades, o AWS Config registra a configuração dos recursos para conformidade e o Systems Manager Inventory coleta metadados das instâncias.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Amazon Inspector", false],
+            ["AWS Compute Optimizer", true],
+            ["AWS Config", false],
+            ["AWS Systems Manager Inventory", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS usa modelos de machine learning para identificar mudanças inesperadas nos gastos da AWS, sem que o usuário precise definir limites de gasto?",
+        explanation:
+            "O AWS Cost Anomaly Detection aprende o padrão de gastos com machine learning e avisa quando surge um custo fora do esperado, sem exigir um limite fixo. O AWS Budgets só alerta ao passar de um valor definido, mesmo nos alertas de previsão, o Trusted Advisor recomenda boas práticas e o GuardDuty detecta ameaças de segurança.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Budgets com alertas de previsão", false],
+            ["AWS Cost Anomaly Detection", true],
+            ["AWS Trusted Advisor", false],
+            ["Amazon GuardDuty", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa com várias unidades de negócio quer repassar os custos da AWS a cada departamento (chargeback), criando regras que agrupam os gastos por conta, tag ou serviço em grupos com nomes próprios. Qual recurso da AWS permite isso?",
+        explanation:
+            "O AWS Cost Categories cria regras que mapeiam custos por conta, tag, serviço e outras dimensões para grupos com nomes próprios, como departamentos, usados em relatórios de chargeback. O Cost Explorer só analisa e filtra gastos, as tags de alocação rotulam recursos um a um e o Budgets cria orçamentos com alertas.",
+        topic: "Preços e faturamento",
+        options: [
+            ["AWS Cost Explorer", false],
+            ["AWS Cost Categories", true],
+            ["Tags de alocação de custos", false],
+            ["AWS Budgets", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa com o plano AWS Business Support+ abre um caso de suporte porque sua carga de trabalho de produção está com o desempenho degradado, mas não parou totalmente. Qual é o tempo de resposta inicial previsto para esse caso?",
+        explanation:
+            "Sistema de produção prejudicado, com funções importantes degradadas, tem primeira resposta em até 4 horas no Business Support+. 24 horas vale para orientação geral, 12 horas para sistema prejudicado sem impacto crítico e 1 hora para sistema de produção fora do ar; sistema crítico para o negócio fora do ar tem menos de 30 minutos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["Menos de 24 horas", false],
+            ["Menos de 12 horas", false],
+            ["Menos de 4 horas", true],
+            ["Menos de 1 hora", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é uma diferença importante entre o plano AWS Basic Support e o plano AWS Business Support+?",
+        explanation:
+            "O Business Support+ inclui suporte técnico 24 horas por telefone, chat e e-mail, enquanto o Basic não abre casos técnicos e fica com atendimento ao cliente, documentação e AWS re:Post. Nenhum dos dois tem TAM, que começa no Enterprise, o conjunto completo do Trusted Advisor é do Business Support+ e o plano não exige ser parceiro da AWS.",
+        topic: "Ferramentas e suporte",
+        options: [
+            [
+                "O Basic inclui um Technical Account Manager (TAM); o Business Support+ não inclui",
+                false,
+            ],
+            [
+                "O Business Support+ dá acesso 24 horas a engenheiros por telefone, chat e e-mail; o Basic não",
+                true,
+            ],
+            [
+                "O Basic dá acesso a todas as verificações do Trusted Advisor; o Business Support+ só às principais",
+                false,
+            ],
+            [
+                "O Business Support+ só pode ser contratado por membros da AWS Partner Network",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS oferece um local central para consultar e gerenciar as cotas padrão dos recursos de uma conta e solicitar aumentos quando necessário?",
+        explanation:
+            "O Service Quotas centraliza os valores das cotas de cada serviço, mostra o uso em relação a elas e permite pedir aumento direto no console. O Trusted Advisor só alerta sobre parte dos limites e não envia pedidos de aumento, o AWS Organizations governa várias contas e o AWS Config avalia a configuração dos recursos.",
+        topic: "Ferramentas e suporte",
+        options: [
+            ["AWS Trusted Advisor", false],
+            ["AWS Organizations", false],
+            ["Service Quotas", true],
+            ["AWS Config", false],
+        ],
+    },
+];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
@@ -1,5 +1,6 @@
 // Lotes importados do banco aberto cloudcertprep para o simulado CLF-C02, um
 // arquivo por domínio da prova. Licença MIT: ver LICENSE-cloudcertprep.txt.
 import type { Questao } from "./aws-ccp-questoes.ts";
+import { QUESTOES_CLOUDCERTPREP_D1 } from "./aws-ccp-questoes-cloudcertprep-d1.ts";
 
-export const QUESTOES_CLOUDCERTPREP: Questao[] = [];
+export const QUESTOES_CLOUDCERTPREP: Questao[] = [...QUESTOES_CLOUDCERTPREP_D1];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
@@ -4,9 +4,11 @@ import type { Questao } from "./aws-ccp-questoes.ts";
 import { QUESTOES_CLOUDCERTPREP_D1 } from "./aws-ccp-questoes-cloudcertprep-d1.ts";
 import { QUESTOES_CLOUDCERTPREP_D2 } from "./aws-ccp-questoes-cloudcertprep-d2.ts";
 import { QUESTOES_CLOUDCERTPREP_D3 } from "./aws-ccp-questoes-cloudcertprep-d3.ts";
+import { QUESTOES_CLOUDCERTPREP_D4 } from "./aws-ccp-questoes-cloudcertprep-d4.ts";
 
 export const QUESTOES_CLOUDCERTPREP: Questao[] = [
     ...QUESTOES_CLOUDCERTPREP_D1,
     ...QUESTOES_CLOUDCERTPREP_D2,
     ...QUESTOES_CLOUDCERTPREP_D3,
+    ...QUESTOES_CLOUDCERTPREP_D4,
 ];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
@@ -3,8 +3,10 @@
 import type { Questao } from "./aws-ccp-questoes.ts";
 import { QUESTOES_CLOUDCERTPREP_D1 } from "./aws-ccp-questoes-cloudcertprep-d1.ts";
 import { QUESTOES_CLOUDCERTPREP_D2 } from "./aws-ccp-questoes-cloudcertprep-d2.ts";
+import { QUESTOES_CLOUDCERTPREP_D3 } from "./aws-ccp-questoes-cloudcertprep-d3.ts";
 
 export const QUESTOES_CLOUDCERTPREP: Questao[] = [
     ...QUESTOES_CLOUDCERTPREP_D1,
     ...QUESTOES_CLOUDCERTPREP_D2,
+    ...QUESTOES_CLOUDCERTPREP_D3,
 ];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
@@ -2,5 +2,9 @@
 // arquivo por domínio da prova. Licença MIT: ver LICENSE-cloudcertprep.txt.
 import type { Questao } from "./aws-ccp-questoes.ts";
 import { QUESTOES_CLOUDCERTPREP_D1 } from "./aws-ccp-questoes-cloudcertprep-d1.ts";
+import { QUESTOES_CLOUDCERTPREP_D2 } from "./aws-ccp-questoes-cloudcertprep-d2.ts";
 
-export const QUESTOES_CLOUDCERTPREP: Questao[] = [...QUESTOES_CLOUDCERTPREP_D1];
+export const QUESTOES_CLOUDCERTPREP: Questao[] = [
+    ...QUESTOES_CLOUDCERTPREP_D1,
+    ...QUESTOES_CLOUDCERTPREP_D2,
+];

--- a/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
+++ b/backend/scripts/data/aws-ccp-questoes-cloudcertprep.ts
@@ -1,0 +1,5 @@
+// Lotes importados do banco aberto cloudcertprep para o simulado CLF-C02, um
+// arquivo por domínio da prova. Licença MIT: ver LICENSE-cloudcertprep.txt.
+import type { Questao } from "./aws-ccp-questoes.ts";
+
+export const QUESTOES_CLOUDCERTPREP: Questao[] = [];

--- a/backend/scripts/data/aws-ccp-questoes.ts
+++ b/backend/scripts/data/aws-ccp-questoes.ts
@@ -4,6 +4,10 @@
 // categoria da resposta e a correta não pode ser a única opção mais longa,
 // nem a única mais curta por folga visível. Questões de múltipla escolha
 // terminam com "(Selecione DUAS opções.)".
+//
+// As questões autorais vêm primeiro; os lotes importados do cloudcertprep entram
+// depois, pelo índice aws-ccp-questoes-cloudcertprep.ts.
+import { QUESTOES_CLOUDCERTPREP } from "./aws-ccp-questoes-cloudcertprep.ts";
 
 export type Questao = {
     statement: string;
@@ -12,7 +16,7 @@ export type Questao = {
     options: [string, boolean][];
 };
 
-export const QUESTOES: Questao[] = [
+const AUTORAIS: Questao[] = [
     {
         statement: "Quais tarefas são responsabilidades da AWS? (Selecione DUAS opções.)",
         explanation:
@@ -3148,3 +3152,5 @@ export const QUESTOES: Questao[] = [
         ],
     },
 ];
+
+export const QUESTOES: Questao[] = [...AUTORAIS, ...QUESTOES_CLOUDCERTPREP];

--- a/backend/scripts/data/aws-ccp-questoes.ts
+++ b/backend/scripts/data/aws-ccp-questoes.ts
@@ -123,25 +123,13 @@ const AUTORAIS: Questao[] = [
         statement:
             "Qual ferramenta realiza ações de automação para serviços e aplicações da AWS por meio de scripts?",
         explanation:
-            "A AWS CLI automatiza e gerencia serviços via linha de comando/scripts. QLDB é banco ledger, Redshift é data warehouse e Snowball é transferência física de dados.",
+            "A AWS CLI automatiza e gerencia serviços via linha de comando/scripts. DynamoDB é banco NoSQL, Redshift é data warehouse e Storage Gateway conecta o armazenamento local à AWS.",
         topic: "Ferramentas e suporte",
         options: [
-            ["Amazon QLDB", false],
+            ["Amazon DynamoDB", false],
             ["Amazon Redshift Serverless", false],
             ["AWS Command Line Interface", true],
-            ["AWS Snowball", false],
-        ],
-    },
-    {
-        statement: "Qual serviço é usado para transferência até 100 PB de dados para a AWS?",
-        explanation:
-            "O Snowmobile move até ~100 PB por unidade (escala de exabytes). O Snowball move dezenas de TB. Neptune é banco de grafos, DeepRacer é ML e CloudFront é CDN.",
-        topic: "Armazenamento",
-        options: [
-            ["Amazon Neptune", false],
-            ["AWS Snowmobile", true],
-            ["AWS DeepRacer", false],
-            ["Amazon CloudFront", false],
+            ["AWS Storage Gateway", false],
         ],
     },
     {
@@ -259,10 +247,10 @@ const AUTORAIS: Questao[] = [
     {
         statement: "Qual serviço permite implantar e dimensionar rapidamente aplicações na AWS?",
         explanation:
-            "O Beanstalk (PaaS) faz deploy e escala automático (provisiona EC2, Load Balancer, Auto Scaling). Snowball é transferência de dados, Outposts é on-premises e CloudFront é CDN.",
+            "O Beanstalk (PaaS) faz deploy e escala automático (provisiona EC2, Load Balancer, Auto Scaling). DMS migra bancos de dados, Outposts é on-premises e CloudFront é CDN.",
         topic: "Computação",
         options: [
-            ["AWS Snowball", false],
+            ["AWS Database Migration Service", false],
             ["AWS Outposts", false],
             ["AWS Elastic Beanstalk", true],
             ["Amazon CloudFront (CDN)", false],
@@ -271,26 +259,13 @@ const AUTORAIS: Questao[] = [
     {
         statement: "Qual serviço executa aplicações em contêineres na AWS?",
         explanation:
-            "O EKS roda contêineres com Kubernetes. Aurora é banco, SageMaker é ML e Redshift é data warehouse.",
+            "O EKS roda contêineres com Kubernetes. Aurora é banco, SageMaker AI é ML e Redshift é data warehouse.",
         topic: "Computação",
         options: [
             ["Amazon EKS", true],
             ["Amazon Aurora", false],
-            ["Amazon SageMaker", false],
+            ["Amazon SageMaker AI", false],
             ["Amazon Redshift", false],
-        ],
-    },
-    {
-        statement:
-            "Qual serviço permite criar fluxos de trabalho necessários para a revisão humana das previsões de machine learning?",
-        explanation:
-            "O Amazon A2I (Augmented AI) é o serviço de human-in-the-loop. Aurora é banco, Lex faz chatbots e Textract extrai texto de documentos.",
-        topic: "Machine learning",
-        options: [
-            ["Amazon Augmented AI", true],
-            ["Amazon Aurora", false],
-            ["Amazon Lex", false],
-            ["Amazon Textract (OCR)", false],
         ],
     },
     {
@@ -371,26 +346,12 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Na storage class S3 Intelligent-Tiering, o Amazon S3 move objetos entre um nível de acesso frequente e um nível de acesso pouco frequente. Quais classes de armazenamento são usadas? (Selecione DUAS opções.)",
-        explanation:
-            "O Intelligent-Tiering move objetos entre o tier de acesso frequente (S3 Standard) e o de acesso infrequente (S3 Standard-IA). As demais são classes de arquivamento separadas.",
-        topic: "Armazenamento",
-        options: [
-            ["S3 One Zone - IA", false],
-            ["S3 Glacier Flexible Retrieval", false],
-            ["S3 Standard-IA", true],
-            ["S3 Standard", true],
-            ["S3 Glacier Deep Archive", false],
-        ],
-    },
-    {
-        statement:
             "Um desenvolvedor de aplicação deseja enviar e receber mensagens entre componentes distribuídos de aplicações. Qual serviço deve ser utilizado?",
         explanation:
-            "O SQS é o serviço de filas que desacopla componentes distribuídos. Snowball é transferência, ElastiCache é cache e Route 53 é DNS.",
+            "O SQS é o serviço de filas que desacopla componentes distribuídos. Outposts leva a infraestrutura da AWS para o local do cliente, ElastiCache é cache e Route 53 é DNS.",
         topic: "Computação",
         options: [
-            ["AWS Snowball", false],
+            ["AWS Outposts", false],
             ["Amazon ElastiCache", false],
             ["Amazon Route 53", false],
             ["Amazon SQS", true],
@@ -463,13 +424,13 @@ const AUTORAIS: Questao[] = [
         statement:
             "Uma empresa precisa de acesso ininterrupto por telefone, e-mail e chat. O tempo de resposta deverá ser inferior a uma hora se um sistema de produção tiver uma interrupção de serviço. Qual plano do AWS Support atende a esse requisito pelo MENOR custo?",
         explanation:
-            "Suporte 24/7 por telefone/chat e resposta menor que 1 h para produção inoperante começa no plano Business. Developer não tem telefone nem esse SLA; Enterprise atende mas custa mais.",
+            "Telefone, chat e e-mail 24/7 e resposta em menos de 1 hora para sistema de produção fora do ar começam no Business Support+, o plano pago de entrada. O Basic não tem suporte técnico; Enterprise Support e Unified Operations também atendem, mas custam mais.",
         topic: "Ferramentas e suporte",
         options: [
             ["AWS Basic Support", false],
-            ["AWS Developer Support", false],
-            ["AWS Business Support", true],
+            ["AWS Business Support+", true],
             ["AWS Enterprise Support", false],
+            ["AWS Unified Operations", false],
         ],
     },
     {
@@ -590,24 +551,24 @@ const AUTORAIS: Questao[] = [
         statement:
             "Qual produto da AWS pode criar um alarme que envia uma notificação quando um limite de faturamento é excedido?",
         explanation:
-            "Os billing alarms são criados no CloudWatch (métrica EstimatedCharges + notificação via SNS). CloudTrail apenas audita chamadas de API; Trusted Advisor recomenda; QuickSight é BI.",
+            "Os billing alarms são criados no CloudWatch (métrica EstimatedCharges + notificação via SNS). CloudTrail apenas audita chamadas de API; Trusted Advisor recomenda; Quick Sight é BI.",
         topic: "Preços e faturamento",
         options: [
             ["AWS Trusted Advisor", false],
             ["AWS CloudTrail", false],
             ["Amazon CloudWatch", true],
-            ["Amazon QuickSight", false],
+            ["Amazon Quick Sight", false],
         ],
     },
     {
         statement:
             "Qual produto da AWS fornece uma solução de armazenamento de arquivos compartilhado, simples e escalável para uso com servidores locais e instâncias Amazon EC2?",
         explanation:
-            "Palavra-chave: armazenamento de arquivos compartilhado (NFS, montável em várias instâncias). AMS é operações, Glacier é arquivamento e EBS é bloco anexado a uma única instância.",
+            "Palavra-chave: armazenamento de arquivos compartilhado (NFS, montável em várias instâncias). AMS é operações, S3 Glacier Deep Archive é classe de arquivamento e EBS é bloco anexado a uma única instância.",
         topic: "Armazenamento",
         options: [
             ["AWS Managed Services (AMS)", false],
-            ["Amazon S3 Glacier", false],
+            ["Amazon S3 Glacier Deep Archive", false],
             ["Amazon Elastic Block Store (Amazon EBS)", false],
             ["Amazon Elastic File System (Amazon EFS)", true],
         ],
@@ -703,7 +664,7 @@ const AUTORAIS: Questao[] = [
         statement:
             "Qual recurso da AWS permite testar diversos serviços sem custo, dentro de certos limites?",
         explanation:
-            "O AWS Free Tier oferece uso gratuito limitado (alguns por 12 meses, outros sempre grátis). Budgets, Cost Explorer e Pricing Calculator são ferramentas de custo, não de uso gratuito.",
+            "O AWS Free Tier dá uso gratuito limitado: contas novas recebem créditos e podem ficar no plano Free por até 6 meses, além das ofertas sempre gratuitas. Budgets, Cost Explorer e Pricing Calculator são ferramentas de custo, não de uso gratuito.",
         topic: "Preços e faturamento",
         options: [
             ["AWS Free Tier", true],
@@ -729,13 +690,13 @@ const AUTORAIS: Questao[] = [
         statement:
             "Qual serviço permite provisionar a infraestrutura da AWS como código, a partir de templates?",
         explanation:
-            "O CloudFormation provisiona recursos via templates (infraestrutura como código). CodeDeploy faz deploy de aplicações, Config avalia conformidade e OpsWorks é gestão de configuração com Chef/Puppet.",
+            "O CloudFormation provisiona recursos via templates (infraestrutura como código). CodeDeploy faz deploy de aplicações, Config avalia conformidade e Systems Manager gerencia e automatiza a operação de recursos já existentes.",
         topic: "Ferramentas e suporte",
         options: [
             ["AWS CloudFormation", true],
             ["AWS CodeDeploy", false],
             ["AWS Config", false],
-            ["AWS OpsWorks Stacks", false],
+            ["AWS Systems Manager", false],
         ],
     },
     {
@@ -854,15 +815,16 @@ const AUTORAIS: Questao[] = [
         ],
     },
     {
-        statement: "Qual plano do AWS Support inclui um Technical Account Manager (TAM) dedicado?",
+        statement:
+            "Qual é o plano do AWS Support de MENOR custo que inclui um Technical Account Manager (TAM) designado?",
         explanation:
-            "O TAM dedicado faz parte do plano Enterprise Support. Basic e Developer não têm TAM, e o Business também não tem um TAM dedicado.",
+            "O TAM designado começa no Enterprise Support, o plano de menor custo com esse recurso. O Unified Operations também tem TAM designado, mas custa mais, e o Basic e o Business Support+ não incluem TAM.",
         topic: "Ferramentas e suporte",
         options: [
             ["AWS Basic Support", false],
-            ["AWS Developer Support", false],
-            ["AWS Business Support", false],
+            ["AWS Business Support+", false],
             ["AWS Enterprise Support", true],
+            ["AWS Unified Operations", false],
         ],
     },
     {
@@ -889,19 +851,6 @@ const AUTORAIS: Questao[] = [
             ["Alta disponibilidade", false],
             ["Colocation", false],
             ["Capacidade fixa provisionada", false],
-        ],
-    },
-    {
-        statement:
-            "Uma empresa precisa transferir 80 TB de dados para a AWS sem depender da conexão de internet. Qual serviço usar?",
-        explanation:
-            "O AWS Snowball é um dispositivo físico para mover dezenas de TB offline. Transfer Acceleration e Direct Connect dependem da rede, e o CloudFront é uma CDN.",
-        topic: "Migração",
-        options: [
-            ["AWS Snowball Edge", true],
-            ["Amazon S3 Transfer Acceleration", false],
-            ["AWS Direct Connect", false],
-            ["Amazon CloudFront", false],
         ],
     },
     {
@@ -1727,7 +1676,7 @@ const AUTORAIS: Questao[] = [
         statement:
             "O que uma política de ciclo de vida (lifecycle) de um bucket do Amazon S3 permite automatizar?",
         explanation:
-            "As regras de ciclo de vida movem automaticamente os objetos para classes mais baratas (por exemplo, de Standard para Glacier) e/ou os expiram após um prazo definido, otimizando custos. Criptografia, replicação e cache em edge locations são funções de outros mecanismos (SSE, replicação e CloudFront).",
+            "As regras de ciclo de vida movem automaticamente os objetos para classes mais baratas (por exemplo, de S3 Standard para S3 Glacier Flexible Retrieval) e/ou os expiram após um prazo definido, otimizando custos. Criptografia, replicação e cache em edge locations são funções de outros mecanismos (SSE, replicação e CloudFront).",
         topic: "Armazenamento",
         options: [
             ["A replicação síncrona dos objetos para outra conta AWS", false],
@@ -1741,7 +1690,7 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma empresa tem arquivos de backup acessados apenas algumas vezes por mês, mas que exigem acesso rápido e alta disponibilidade em várias Zonas de Disponibilidade quando solicitados. Qual classe do Amazon S3 equilibra menor custo de armazenamento com esses requisitos?",
+            "Uma empresa tem arquivos de backup acessados apenas cerca de uma vez por mês, mas que exigem acesso rápido e alta disponibilidade em várias Zonas de Disponibilidade quando solicitados. Qual classe do Amazon S3 equilibra menor custo de armazenamento com esses requisitos?",
         explanation:
             "A S3 Standard-IA reduz o custo de armazenamento para dados de acesso pouco frequente, mantendo acesso em milissegundos e redundância em múltiplas AZs. A Standard é para acesso frequente, a One Zone-IA usa uma única AZ e a Glacier é voltada a arquivamento.",
         topic: "Armazenamento",
@@ -1797,13 +1746,13 @@ const AUTORAIS: Questao[] = [
         statement:
             "Várias instâncias EC2 Linux, distribuídas em diferentes Zonas de Disponibilidade, precisam ler e gravar simultaneamente no MESMO sistema de arquivos compartilhado, que deve crescer e diminuir automaticamente conforme os dados. Qual serviço atende a esse requisito?",
         explanation:
-            "O Amazon EFS é um sistema de arquivos elástico (NFS) que escala automaticamente e pode ser montado por muitas instâncias Linux ao mesmo tempo, em várias AZs. Um volume EBS se anexa a uma instância por vez, o instance store é efêmero e local, e o Glacier é para arquivamento de objetos.",
+            "O Amazon EFS é um sistema de arquivos elástico (NFS) que escala automaticamente e pode ser montado por muitas instâncias Linux ao mesmo tempo, em várias AZs. Um volume EBS se anexa a uma instância por vez, o instance store é efêmero e local, e a S3 Glacier Flexible Retrieval é uma classe de arquivamento de objetos.",
         topic: "Armazenamento",
         options: [
             ["Amazon Elastic Block Store (Amazon EBS)", false],
             ["Amazon Elastic File System (Amazon EFS)", true],
             ["Armazenamento de instância (instance store)", false],
-            ["Amazon S3 Glacier", false],
+            ["Amazon S3 Glacier Flexible Retrieval", false],
         ],
     },
     {
@@ -1823,32 +1772,13 @@ const AUTORAIS: Questao[] = [
         statement:
             "Uma empresa quer aposentar sua infraestrutura física de fitas de backup, mas continuar usando o software de backup atual e armazenar os backups na nuvem AWS. Qual solução é a mais adequada?",
         explanation:
-            "O Tape Gateway do AWS Storage Gateway apresenta uma biblioteca de fitas virtuais ao software de backup existente e guarda os dados no Amazon S3/Glacier, substituindo as fitas físicas. Snowmobile é transferência em escala de exabytes, FSx for Lustre é para HPC e o Transfer Acceleration apenas acelera uploads ao S3.",
+            "O Tape Gateway do AWS Storage Gateway apresenta uma biblioteca de fitas virtuais ao software de backup existente e arquiva os dados nas classes S3 Glacier Flexible Retrieval ou Deep Archive, substituindo as fitas físicas. O Elastic Disaster Recovery replica servidores para recuperação, o FSx for Lustre é para HPC e o Transfer Acceleration apenas acelera uploads ao S3.",
         topic: "Armazenamento",
         options: [
-            ["AWS Snowmobile", false],
+            ["AWS Elastic Disaster Recovery (AWS DRS)", false],
             ["AWS Storage Gateway (Tape Gateway)", true],
             ["Amazon FSx for Lustre", false],
             ["Amazon S3 Transfer Acceleration", false],
-        ],
-    },
-    {
-        statement:
-            "Qual afirmação descreve melhor a família de dispositivos AWS Snow (por exemplo, o AWS Snowball Edge)?",
-        explanation:
-            "A família Snow são dispositivos físicos e resistentes enviados ao cliente para transferir grandes volumes de dados de forma offline e executar computação de borda onde a rede é limitada ou inexistente. As demais opções descrevem, respectivamente, o Amazon RDS, o Amazon CloudFront e o Elastic Load Balancing.",
-        topic: "Armazenamento",
-        options: [
-            ["Um serviço totalmente gerenciado de banco de dados relacional", false],
-            [
-                "Dispositivos físicos resistentes para migrar grandes volumes de dados e computação de borda",
-                true,
-            ],
-            ["Uma rede global de entrega de conteúdo (CDN)", false],
-            [
-                "Um serviço de balanceamento de carga para instâncias Amazon EC2 em várias zonas de disponibilidade",
-                false,
-            ],
         ],
     },
     {
@@ -1972,12 +1902,12 @@ const AUTORAIS: Questao[] = [
         statement:
             "Uma empresa quer migrar seus bancos de dados on-premises para a AWS com o mínimo de tempo de inatividade, mantendo o banco de origem em operação durante a migração. Qual serviço da AWS deve ser utilizado?",
         explanation:
-            "O AWS Database Migration Service (DMS) migra bancos de dados para a AWS com mínimo tempo de inatividade, mantendo a origem em operação e suportando migrações homogêneas e heterogêneas. O RDS é um possível destino, o Snowball transfere dados em massa off-line e o CloudWatch faz monitoramento.",
+            "O AWS Database Migration Service (DMS) migra bancos de dados para a AWS com mínimo tempo de inatividade, mantendo a origem em operação e suportando migrações homogêneas e heterogêneas. O RDS é um possível destino, o SCT apenas converte esquemas e código de banco e o CloudWatch faz monitoramento.",
         topic: "Migração",
         options: [
             ["AWS Database Migration Service", true],
             ["Amazon RDS", false],
-            ["AWS Snowball", false],
+            ["AWS Schema Conversion Tool (AWS SCT)", false],
             ["Amazon CloudWatch com alarmes", false],
         ],
     },
@@ -2733,26 +2663,13 @@ const AUTORAIS: Questao[] = [
         statement:
             "Qual serviço oferece acesso sob demanda a relatórios de conformidade e segurança da própria AWS, como os relatórios SOC e as certificações PCI DSS, além de acordos legais como o BAA?",
         explanation:
-            "O AWS Artifact é o portal de autoatendimento para baixar relatórios de conformidade da AWS e revisar acordos legais. O Audit Manager audita o ambiente do cliente, o Config avalia configurações e o Trusted Advisor faz recomendações de boas práticas.",
+            "O AWS Artifact é o portal de autoatendimento para baixar relatórios de conformidade da AWS e revisar acordos legais. O Security Hub avalia a postura de segurança do ambiente do cliente, o Config avalia configurações e o Trusted Advisor faz recomendações de boas práticas.",
         topic: "Segurança e identidade",
         options: [
-            ["AWS Audit Manager", false],
+            ["AWS Security Hub", false],
             ["AWS Config", false],
             ["AWS Artifact", true],
             ["AWS Trusted Advisor", false],
-        ],
-    },
-    {
-        statement:
-            "Qual serviço automatiza a coleta contínua de evidências para simplificar auditorias e avaliar se os controles do ambiente do cliente estão em conformidade com frameworks como PCI DSS e GDPR?",
-        explanation:
-            "O AWS Audit Manager coleta evidências automaticamente e as mapeia para frameworks de conformidade, facilitando auditorias do ambiente do cliente. O Artifact apenas fornece os relatórios de conformidade da AWS, o Config avalia configurações e o CloudTrail registra chamadas de API.",
-        topic: "Segurança e identidade",
-        options: [
-            ["AWS Artifact", false],
-            ["AWS Audit Manager", true],
-            ["AWS Config", false],
-            ["AWS CloudTrail", false],
         ],
     },
     {
@@ -2888,10 +2805,10 @@ const AUTORAIS: Questao[] = [
         statement:
             "O AWS Free Tier (nível gratuito) é composto por diferentes tipos de ofertas gratuitas. Quais das opções a seguir são tipos de oferta do AWS Free Tier? (Selecione DUAS opções.)",
         explanation:
-            "O Free Tier possui três tipos de oferta: gratuito por 12 meses, sempre gratuito (Always Free) e testes gratuitos (free trials). As demais alternativas não existem no modelo do nível gratuito da AWS.",
+            "Hoje o Free Tier combina ofertas sempre gratuitas (Always Free), testes gratuitos de curto prazo em serviços selecionados (no plano pago) e créditos para contas novas; a oferta de 12 meses gratuitos era do modelo anterior, das contas criadas antes de 15/07/2025. As demais alternativas não existem no nível gratuito.",
         topic: "Preços e faturamento",
         options: [
-            ["12 meses gratuitos a partir da criação da conta", true],
+            ["Testes gratuitos de curto prazo (short-term trials)", true],
             ["Sempre gratuito (Always Free)", true],
             ["Gratuito pelos primeiros 5 anos", false],
             ["Uso ilimitado gratuito após o pagamento de uma taxa de ativação", false],
@@ -2919,9 +2836,9 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma equipe financeira precisa do conjunto MAIS detalhado e abrangente de dados de custo e uso da AWS, com itens de linha por serviço e granularidade horária, para carregar em ferramentas como Amazon Athena, Amazon Redshift ou Amazon QuickSight. Qual recurso atende a essa necessidade?",
+            "Uma equipe financeira precisa do conjunto MAIS detalhado e abrangente de dados de custo e uso da AWS, com itens de linha por serviço e granularidade horária, para carregar em ferramentas como Amazon Athena, Amazon Redshift ou Amazon Quick Sight. Qual recurso atende a essa necessidade?",
         explanation:
-            "O Cost and Usage Report (CUR) fornece os dados de faturamento mais granulares e completos, integráveis a Athena, Redshift e QuickSight. O Budgets foca em limites e alertas, o Pricing Calculator estima custos futuros e o painel resumido não oferece esse nível de detalhe.",
+            "O Cost and Usage Report (CUR), hoje na versão CUR 2.0 criada pelo AWS Data Exports, fornece os dados de faturamento mais granulares e completos, integráveis a Athena, Redshift e Quick Sight. O Budgets foca em limites e alertas, o Pricing Calculator estima custos futuros e o painel resumido não oferece esse nível de detalhe.",
         topic: "Preços e faturamento",
         options: [
             ["AWS Cost and Usage Report (CUR)", true],
@@ -2988,13 +2905,10 @@ const AUTORAIS: Questao[] = [
         statement:
             "O plano AWS Basic Support está disponível para todos os clientes da AWS sem custo adicional. Quais recursos estão incluídos no Basic Support? (Selecione DUAS opções.)",
         explanation:
-            "O Basic Support inclui documentação, whitepapers, o Support Center para questões de conta/cobrança, o Personal Health Dashboard e o conjunto core de verificações do Trusted Advisor. Suporte técnico 24/7, TAM e SLAs rápidos exigem planos pagos.",
+            "O Basic Support inclui documentação, whitepapers, o Support Center para questões de conta/cobrança, o AWS Health Dashboard e o conjunto core de verificações do Trusted Advisor. Suporte técnico 24/7, TAM e SLAs rápidos exigem planos pagos.",
         topic: "Ferramentas e suporte",
         options: [
-            [
-                "Acesso ao AWS Personal Health Dashboard (painel personalizado de saúde da conta)",
-                true,
-            ],
+            ["Acesso ao AWS Health Dashboard (visão personalizada da saúde da conta)", true],
             ["Um conjunto básico (core) de verificações do AWS Trusted Advisor", true],
             ["Acesso 24/7 a engenheiros de suporte da nuvem por telefone e chat", false],
             ["Um Technical Account Manager (TAM) designado", false],
@@ -3003,52 +2917,39 @@ const AUTORAIS: Questao[] = [
     },
     {
         statement:
-            "Uma startup está desenvolvendo e testando uma aplicação na AWS e deseja acesso a suporte técnico por e-mail em horário comercial pelo MENOR custo possível acima do Basic. Qual plano do AWS Support é o mais indicado?",
-        explanation:
-            "O plano Developer oferece contato por e-mail com o suporte em horário comercial pelo menor preço entre os planos pagos, ideal para ambientes de desenvolvimento e teste. Business e Enterprise custam mais e agregam telefone/chat 24/7, TAM e outros recursos.",
-        topic: "Ferramentas e suporte",
-        options: [
-            ["Developer", true],
-            ["Business", false],
-            ["Enterprise On-Ramp", false],
-            ["Enterprise", false],
-        ],
-    },
-    {
-        statement:
             "Uma empresa quer acesso ao conjunto COMPLETO de verificações do AWS Trusted Advisor (boas práticas em todas as categorias, incluindo otimização de custos e tolerância a falhas). Qual é o plano de suporte MÍNIMO necessário?",
         explanation:
-            "O conjunto completo de verificações do Trusted Advisor passa a estar disponível a partir do plano Business; Basic e Developer têm acesso apenas às verificações core. O Enterprise também as inclui, mas não é o plano mínimo exigido.",
+            "O conjunto completo de verificações do Trusted Advisor começa no Business Support+; o Basic tem apenas as verificações core. Enterprise Support e Unified Operations também o incluem, com o Trusted Advisor Priority, mas não são o plano mínimo.",
         topic: "Ferramentas e suporte",
         options: [
             ["Basic", false],
-            ["Business", true],
-            ["Developer", false],
-            ["Enterprise", false],
+            ["Business Support+", true],
+            ["Enterprise Support", false],
+            ["Unified Operations", false],
         ],
     },
     {
         statement:
             "Uma grande empresa deseja um contato técnico designado da AWS que atue de forma proativa, conduza revisões de arquitetura e ajude a otimizar continuamente o ambiente, servindo como principal ponto de contato técnico. O que descreve esse papel?",
         explanation:
-            "O Technical Account Manager (TAM), disponível nos planos Enterprise On-Ramp e Enterprise, é um contato técnico designado que oferece orientação proativa e ajuda a otimizar o ambiente. Trusted Advisor, Personal Health Dashboard e Support Center são ferramentas automatizadas, não uma pessoa dedicada.",
+            "O Technical Account Manager (TAM), disponível nos planos Enterprise Support e Unified Operations, é um contato técnico designado que oferece orientação proativa e ajuda a otimizar o ambiente. Trusted Advisor, AWS Health Dashboard e Support Center são ferramentas automatizadas, não uma pessoa dedicada.",
         topic: "Ferramentas e suporte",
         options: [
             ["Technical Account Manager (TAM)", true],
             ["AWS Trusted Advisor", false],
-            ["AWS Personal Health Dashboard", false],
-            ["AWS Support Center", false],
+            ["AWS Health Dashboard", false],
+            ["AWS Support Center (Central de Suporte)", false],
         ],
     },
     {
         statement:
             "Qual serviço oferece uma visão PERSONALIZADA do estado dos serviços da AWS e envia alertas sobre eventos que podem afetar especificamente os SEUS recursos, como uma manutenção programada em uma instância EC2 da sua conta?",
         explanation:
-            "O Personal Health Dashboard mostra uma visão personalizada e alertas relacionados aos recursos e à conta do próprio cliente. O Service Health Dashboard exibe o status geral e público dos serviços; o CloudWatch monitora métricas e o Trusted Advisor avalia boas práticas.",
+            "O AWS Health Dashboard, na página Your account health (antigo Personal Health Dashboard), mostra eventos que afetam os recursos da sua conta e envia alertas. A página Service health (antigo Service Health Dashboard) é pública e mostra o status geral; o CloudWatch monitora métricas e o Trusted Advisor avalia boas práticas.",
         topic: "Ferramentas e suporte",
         options: [
-            ["AWS Personal Health Dashboard (AWS Health Dashboard - sua conta)", true],
-            ["AWS Service Health Dashboard (status geral e público dos serviços)", false],
+            ["AWS Health Dashboard, página Your account health", true],
+            ["AWS Health Dashboard, página pública Service health", false],
             ["Amazon CloudWatch", false],
             ["AWS Trusted Advisor", false],
         ],
@@ -3129,26 +3030,26 @@ const AUTORAIS: Questao[] = [
         statement:
             "Um cliente com um plano de suporte pago precisa abrir e acompanhar um caso técnico com a AWS pelo Console de Gerenciamento. Qual recurso deve utilizar?",
         explanation:
-            "O AWS Support Center (Central de Suporte) é onde se abrem e acompanham casos de suporte técnico e de conta/cobrança no console. O Knowledge Center traz respostas às dúvidas mais frequentes, o Personal Health Dashboard mostra a saúde dos seus recursos e a Well-Architected Tool revisa cargas de trabalho.",
+            "O AWS Support Center (Central de Suporte) é onde se abrem e acompanham casos de suporte técnico e de conta/cobrança no console. O Knowledge Center traz respostas às dúvidas mais frequentes, o AWS Health Dashboard mostra a saúde dos seus recursos e a Well-Architected Tool revisa cargas de trabalho.",
         topic: "Ferramentas e suporte",
         options: [
             ["AWS Knowledge Center", false],
             ["AWS Support Center (Central de Suporte)", true],
-            ["AWS Personal Health Dashboard da conta", false],
+            ["AWS Health Dashboard (Your account health)", false],
             ["AWS Well-Architected Tool", false],
         ],
     },
     {
         statement:
-            "Uma empresa executa cargas de trabalho de produção críticas para o negócio e exige o MENOR tempo de resposta do AWS Support quando um sistema crítico fica indisponível (meta inferior a 15 minutos). Qual plano de suporte atende a esse requisito?",
+            "Uma empresa executa cargas de trabalho de produção críticas para o negócio e exige o MENOR tempo de resposta do AWS Support quando um sistema crítico fica indisponível (meta inferior a 5 minutos). Qual plano de suporte atende a esse requisito?",
         explanation:
-            "O plano Enterprise oferece o menor tempo de resposta, com meta inferior a 15 minutos para casos de sistemas críticos de negócio indisponíveis. O Enterprise On-Ramp tem meta de 30 minutos, o Business de 1 hora para produção indisponível, e o Developer não cobre sistemas de produção com essa urgência.",
+            "O Unified Operations tem o menor tempo de resposta: com sistema crítico para o negócio fora do ar, um Incident Management Engineer responde em menos de 5 minutos. O Enterprise Support tem meta de 15 minutos, o Business Support+ de 30 minutos, e o Basic não inclui suporte técnico.",
         topic: "Ferramentas e suporte",
         options: [
-            ["Enterprise", true],
-            ["Enterprise On-Ramp", false],
-            ["Business", false],
-            ["Developer", false],
+            ["Unified Operations", true],
+            ["Enterprise Support", false],
+            ["Business Support+", false],
+            ["Basic", false],
         ],
     },
 ];


### PR DESCRIPTION
## O que vai para produção

- Simulado AWS Certified Cloud Practitioner (CLF-C02): 665 questões traduzidas e adaptadas do banco aberto [cloudcertprep](https://github.com/nastaso/cloudcertprep), distribuído sob licença MIT, com um PR por domínio da prova (#663, #664, #665 e #667), mais a revisão do banco autoral (#673). O banco passa de 211 para 869 questões.
- Simulado AWS Certified AI Practitioner (AIF-C01): 308 questões importadas do mesmo banco (#666, #668, #669, #670 e #671), mais a revisão do banco autoral (#672). O banco passa de 165 para 464 questões.
- Nos dois simulados, serviço fechado a clientes novos ou encerrado deixou de ser resposta correta e saiu dos distratores. Planos de suporte, nível gratuito e nomes de serviço seguem a oferta atual da AWS.
- O gabarito de todas as questões novas ou alteradas foi conferido às cegas.

Não há mudança de código na aplicação, só nos arquivos de dados dos dois simulados.

## Depois do deploy

As questões só mudam em produção depois de rodar os atualizadores dos dois simulados. Os dois são idempotentes, e a segunda execução deve responder que o banco já está em dia.

- `atualizar-aws-ccp.ts`: 869 questões no banco.
- `atualizar-aif-c01.ts`: 464 questões no banco.

Tentativas antigas mantêm a nota. Nas revisões que não foram congeladas, as questões alteradas ou removidas deixam de aparecer.
